### PR TITLE
BandCamp support

### DIFF
--- a/bandcamp.js
+++ b/bandcamp.js
@@ -1,0 +1,99 @@
+/*
+ * Chrome-Last.fm-Scrobbler BandCamp.com Connector by George Pollard
+ *                (loosely based on Yasin Okumus's MySpace connector)
+ * v0.1
+ */
+ 
+var prevTrack = null;
+
+$(function(){
+	// bind page unload function to discard current "now listening"
+	cancel();
+});
+
+var durationPart = ".track_info .time";
+var durationRegex = /(\d+):(\d+)/;
+function parseDuration(match){
+	try{
+		var m = durationRegex.exec(match);
+		return parseInt(m[1]*60) + parseInt(m[2]);
+	}catch(err){
+		return 0;
+	}
+}
+
+function parseArtist()
+{
+	var byLine = "";
+	if (isAlbum())
+	{
+		byLine = $("dt.hiddenAccess:contains('band name') ~ dd").text();
+	}
+	else // isTrack
+	{
+		byLine = $(".albumTitle nobr").text();
+	}
+
+	return $.trim($.trim(byLine).substring(2));
+}
+
+
+function parseTitle()
+{
+	if (isAlbum())
+	{
+		return $(".track_info .title").text();
+	}
+	else //isTrack
+	{
+		return $(".trackTitle").first().text();
+	}
+}
+
+function isAlbum()
+{
+	return document.location.toString().indexOf('bandcamp.com/album/') >= 0;
+}
+
+function cancel(){
+	$(window).unload(function() {      
+		// reset the background scrobbler song data
+		chrome.extension.sendRequest({type: 'reset'});
+		return true;      
+	});
+}
+
+console.log('BandCampScrobbler: ' + 'loaded');
+
+$(durationPart).bind('DOMSubtreeModified',function(e){
+	var duration = parseDuration($(durationPart).text());
+	
+	if(duration > 90){
+
+		var artist = parseArtist();
+		var track = parseTitle();
+
+		var dashIndex = track.indexOf('-');
+		if (artist == 'Various Artists' && dashIndex >= 0)
+		{
+			artist = track.substring(0, dashIndex);
+			track = track.substring(dashIndex + 1);
+		}
+
+		artist = $.trim(artist);
+		track = $.trim(track);
+
+		//ensure this is a new scrobble
+		if (track != prevTrack)
+		{
+			prevTrack = track;
+
+			console.log("BandCampScrobbler: scrobbling '" + track + "' by " + artist);
+			chrome.extension.sendRequest({type: 'validate', artist: artist, track: track}, function(response) {
+				if (response != false){
+					chrome.extension.sendRequest({type: 'nowPlaying', artist: artist, track: track, duration: duration});
+				}
+			});
+		}	
+	}
+});

--- a/manifest.json
+++ b/manifest.json
@@ -65,7 +65,11 @@
    {
       "matches": ["*://fizy.com/*"],
       "js": ["jquery-1.6.1.min.js", "jquery.dump.js", "fizy.js"]
+   },
+   {
+      "matches": ["*://*.bandcamp.com/*"],
+      "js": ["jquery-1.6.1.min.js", "jquery.dump.js", "bandcamp.js"],
+      "run_at": "document_idle"
    }
    ]
-
 }

--- a/options.html
+++ b/options.html
@@ -46,6 +46,7 @@
          <li>TTnetMuzik.com.tr</li>
          <li>FFtunes.com</li>
          <li>Fizy.com</li>
+         <li>BandCamp.com</li>
       </ul>
    </p>
    <p>
@@ -76,6 +77,7 @@
          <li><a href="http://www.yasinokumus.com/">Yasin Okumus</a> - Grooveshark, MySpace, FFtunes, Fizy and TTnetMuzik support</li>
          <li><a href="https://github.com/sharjeelaziz">Sharjeel Aziz</a> - Google Music support</li>
          <li><a href="https://github.com/moski">Moski Doski</a> - Thesixtyone.com support</li>         
+         <li><a href="https://github.com/porges">George Pollard</a> - BandCamp support</li>
       </ul>
    </p>
 </div>


### PR DESCRIPTION
Support for BandCamp pages. This will only work on bandcamp.com URLs, not custom domain bandcamp pages.

It supports /track/ and /album/ pages. It also tries to figure out the correct artist/track for Various Artist albums.

I'm not sure if any of the code is 'best practice' - I'm not a JavaScript developer :)
