### PR TITLE
Fixed bandcamp duration regex (ignore spaces/newlines)

### DIFF
--- a/bandcamp.js
+++ b/bandcamp.js
@@ -11,7 +11,7 @@ $(function(){
 });
 
 var durationPart = ".track_info .time";
-var durationRegex = /(\d+):(\d+)\/(\d+):(\d+)/;
+var durationRegex = /[ \n]*(\d+):(\d+)[ \n]*\/[ \n]*(\d+):(\d+)[ \n]*/;
 function parseDuration(match){
 	try{
 		var m = durationRegex.exec(match);


### PR DESCRIPTION
Bandcamp scrobbler stopped working for me, it seems that the text of song's duration/time had some spaces/newlines around slash (/) character.
I corrected the regular expression of duration to take spaces and newlines into account, when matching duration.
