### PR TITLE
add jango.com connector

### DIFF
--- a/jango-dom-inject.js
+++ b/jango-dom-inject.js
@@ -1,0 +1,42 @@
+/*
+ * Chrome-Last.fm-Scrobbler jango.com connector
+ * (c) 2012 Stephen Hamer <stephen.hamer@gmail.com>
+ */
+
+// The attach_artist_pic method gets called in the evaluated javascript
+// returned when songs are switched to update the pictures associated with the
+// artist. This method is used as the trigger for scrobbling the song.
+var orig_attach_artist_pic;
+
+function chromeLastFMUpdateNowPlaying(skip_callback){
+  var sm = _jp.soundManager;
+  var duration = sm.sounds[sm.soundIDs[sm.soundIDs.length - 1]].duration / 1000;
+
+  // We can start updating the attached pics before the sound manager has
+  // loaded the track (and knows the duration). If so, poll the sound manager for
+  // duration.
+  if (duration === 0) {
+    setTimeout(function() { chromeLastFMUpdateNowPlaying(true) }, 1000);
+  } else {
+    var songInfo = {'title': _jm.song_info.song, 'artist': _jm.song_info.artist, 'duration': duration};
+    var commDiv = document.getElementById('chromeLastFM');
+    commDiv.innerText = JSON.stringify(songInfo);
+  }
+
+  // Only call the original method once, don't call it each time we poll the
+  // sound manager for the song duration
+  if (!skip_callback) {
+    orig_attach_artist_pic();
+  }
+}
+
+function waitUi() {
+  //console.log("waiting for _jui");
+  if (window["_jui"] === undefined) {
+    setTimeout(waitUi, 1000);
+    return;
+  }
+  orig_attach_artist_pic = _jui.jango_player.attach_artist_pic.bind(_jui.jango_player);
+  _jui.jango_player.attach_artist_pic = chromeLastFMUpdateNowPlaying;
+}
+waitUi();

--- a/jango.js
+++ b/jango.js
@@ -1,0 +1,56 @@
+/*
+ * Chrome-Last.fm-Scrobbler jango.com connector
+ * (c) 2012 Stephen Hamer <stephen.hamer@gmail.com>
+ */
+
+// Used to cache the song title to prevent repeated calls to updateNowPlaying
+var lastSongTitle = '';
+
+function updateNowPlaying(){
+  var commDiv = document.getElementById('chromeLastFM');
+  var songInfo = JSON.parse(commDiv.innerText);
+
+  if (songInfo['title'] == lastSongTitle) {
+    return;
+  }
+  lastSongTitle = songInfo['title'];
+
+  // Update scrobbler
+  //console.log('submitting a now playing request. artist: ' + songInfo['artist'] + ', title: ' + songInfo['title'] + ', duration: ' + songInfo['duration']);
+  chrome.extension.sendRequest({'type': 'validate', 'artist': songInfo['artist'], 'track': songInfo['title']}, function(response) {
+    if (response != false) {
+      chrome.extension.sendRequest({type: 'nowPlaying', 'artist': songInfo['artist'], 'track': songInfo['title'], 'duration': songInfo['duration']});
+    } else {
+      // on validation failure send nowPlaying 'unknown song'
+      chrome.extension.sendRequest({'type': 'nowPlaying', 'duration': songInfo['duration']});
+    }
+  });
+}
+
+// Run at startup, inject hooks into Jango application javascript to catch song changes.
+$(document).ready(function(){
+  console.log('Jango module starting up');
+
+  // XXX(shamer): we can't directly access the page javascript from the
+  // extension. To get code running in the page context we have to add a script tag
+  // to the DOM. The script then is executed in the global context.
+  // To communicate between the injected JS and the extension a DOM node is updated with the text to send.
+
+  var comNode = $('<div id="chromeLastFM" style="display: none"><span id="title"></span><span id="artist"></span><span id="duration"></span></div>');
+  document.body.appendChild(comNode[0]);
+
+  $('body').append('<script type="text/javascript">(function(l) {\n' +
+"    var injectScript = document.createElement('script');\n" +
+"    injectScript.type = 'text/javascript';\n" +
+"    injectScript.src = l;\n" +
+"    document.getElementsByTagName('head')[0].appendChild(injectScript);\n" +
+"  })('" + chrome.extension.getURL('jango-dom-inject.js') + "');</script>");
+
+  // Listen for 'messages' from the injected script
+  $('#chromeLastFM').live('DOMSubtreeModified', updateNowPlaying);
+
+  $(window).unload(function() {
+    chrome.extension.sendRequest({type: 'reset'});
+    return true;
+  });
+});

--- a/manifest.json
+++ b/manifest.json
@@ -71,6 +71,11 @@
       "run_at": "document_idle"
    },
    {
+      "matches": ["*://www.jango.com/*"],
+      "js": ["jquery-1.6.1.min.js", "jquery.dump.js", "jango.js", "jango-dom-inject.js"],
+      "run_at" : "document_start"
+   },
+   {
       "matches": ["*://www.pandora.com/*"],
       "js": ["jquery-1.6.1.min.js", "jquery.dump.js", "pandora.js"],
       "run_at" : "document_start"


### PR DESCRIPTION
I've added a connector for the site jango.com

Because chrome isolates the extension in a separate context I had to use the script-injection trick to be able to access javascript on the page. With access to the page JS I am able to read the song information out of the local "media player" structures.

Communication back with the extension happens through a node in the DOM with the same DOMSubtreeModified method that several of the other connectors use to catch track changes.

Thanks,
Stephen
