### PR TITLE
Fix bandcamp title parsing.

### DIFF
--- a/bandcamp.js
+++ b/bandcamp.js
@@ -46,7 +46,7 @@ function parseTitle()
 {
 	if (isAlbum())
 	{
-		return $(".track_info .title").text();
+		return $(".track_info .title").first().text();
 	}
 	else //isTrack
 	{


### PR DESCRIPTION
Bandcamp title was parsed as TitleTitle instead of title.
