### PR TITLE
Bandcamp incorrect scrobbling (The scrobbler recognizes the album name as a track title)

### DIFF
--- a/bandcamp.js
+++ b/bandcamp.js
@@ -56,7 +56,7 @@ function parseTitle()
 
 function isAlbum()
 {
-	return document.location.toString().indexOf('bandcamp.com/album/') >= 0;
+	return $('.trackView[itemtype="http://schema.org/MusicAlbum"]').length > 0;
 }
 
 function cancel(){


### PR DESCRIPTION
The scrobbler recognizes the album name as a track title for links like http://lysv.bandcamp.com/ or http://lysv.bandcamp.com/.
