### PR TITLE
Plug.dj support added

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
    "web_accessible_resources": [
       "icon128.png",
       "jango-dom-inject.js",
-      "spotify-dom-inject.js"
+      "spotify-dom-inject.js",
+      "plugdj-dom-inject.js"
    ],
 
    "background": {
@@ -153,6 +154,10 @@
    {
       "matches": ["https://play.spotify.com/*"],
       "js": ["jquery-1.6.1.min.js", "spotify.js"]
+   },
+   {
+      "matches": ["http://plug.dj/*"],
+      "js": ["jquery-1.6.1.min.js", "plugdj.js"]
    }
    ]
 }

--- a/options.html
+++ b/options.html
@@ -65,6 +65,7 @@
                   <li>MySpace (not the new 2013 MySpace)</li>
                   <li><strong>Pandora.com (new interface)</strong></li>
                   <li>Pitchfork.com</li>
+                  <li><strong>Plug.dj</strong></li>
                   <li>SoundCloud.com</li>
                   <li>Spotify.com</li>
                   <li>Thesixtyone.com</li>
@@ -118,8 +119,9 @@
                   <li><a href="https://github.com/plushsteel">Natalia</a> - Weborama.fm, Megalyrics.ru, 22tracks.com support</li>
                   <li><a href="https://github.com/fiv3isaliv3">fiv3isaliv3</a> - iHeart.com support</li>
                   <li><a href="#">Titus Ramczykowski</a> - Indieshuffle.com support</li>
-			<li><a href="https://github.com/pluszak">Michal Rumanek</a> - Tuba.fm support</li>
-			<li><a href="https://github.com/vintitres">vintitres</a> - SoundCloud.com support</li>
+                  <li><a href="https://github.com/pluszak">Michal Rumanek</a> - Tuba.fm support</li>
+                  <li><a href="https://github.com/vintitres">vintitres</a> - SoundCloud.com support</li>
+                  <li><a href="https://github.com/aeon">Anton Stroganov</a> - Plug.dj support</li>
                </ul>
             </p>
          </div>

--- a/plugdj-dom-inject.js
+++ b/plugdj-dom-inject.js
@@ -1,0 +1,55 @@
+/**
+ * Listen to a "play" event and communicate the current song to the extension
+ * via a Json string in a DOM node.
+ *
+ * @author Anton Stroganov <stroganov.a@gmail.com>
+ */
+function chromeLastFMUpdateNowPlaying(mediaObject) {
+    "use strict";
+
+    var commDiv = document.getElementById('chromeLastFM'),
+        message = null;
+
+    if(mediaObject != null) {
+        message = {
+            'track': mediaObject.title,
+            'artist': mediaObject.author,
+            'duration': mediaObject.duration
+        };
+    } else {
+        message = {
+            'pause': true
+        }
+    }
+
+    commDiv.innerText = JSON.stringify(message);
+}
+
+function chromeLastFMinit() {
+    "use strict";
+
+    var plugdjAPI = window.API;
+
+    if (!plugdjAPI) {
+        // Plug.DJ context is not started yet, poll for it.
+        setTimeout(function () {
+            chromeLastFMinit();
+        }, 1000);
+    } else {
+
+        // subscrive to song change event
+        plugdjAPI.addEventListener(plugdjAPI.DJ_ADVANCE, function (plugdj_event) {
+            var mediaObject = plugdj_event == null ? null : plugdj_event.media;
+            chromeLastFMUpdateNowPlaying(mediaObject);
+        });
+
+        // getMedia() will return your next queued media object if nobody is playing
+        // so let's make sure that a DJ is performing, then send currently playing 
+        // song info
+        if(API.getDJs().length > 0) {
+            chromeLastFMUpdateNowPlaying(API.getMedia());
+        }
+    }
+}
+
+chromeLastFMinit();

--- a/plugdj.js
+++ b/plugdj.js
@@ -1,0 +1,107 @@
+/**
+ * Chrome-Last.fm-Scrobbler plug.dj connector
+ * @author Anton Stroganov <stroganov.a@gmail.com>
+ * Heavily inspired by spotify.js by Damien Alexandre <dalexandre@jolicode.com>, 
+ * which was based on jango.js by Stephen Hamer <stephen.hamer@gmail.com>
+ */
+(function ChromeLastFmPlugDjScrobbler($) {
+    "use strict";
+
+    /**
+     * Clean non-informative garbage from title
+     */
+    function cleanArtistTrack(artist, track) {
+
+       // Do some cleanup
+       artist = artist.replace(/^\s+|\s+$/g,'');
+       track = track.replace(/^\s+|\s+$/g,'');
+
+       // Strip crap
+       track = track.replace(/\s*\*+\s?\S+\s?\*+$/, ''); // **NEW**
+       track = track.replace(/\s*\[[^\]]+\]$/, ''); // [whatever]
+       track = track.replace(/\s*\([^\)]*version\)$/i, ''); // (whatever version)
+       track = track.replace(/\s*\.(avi|wmv|mpg|mpeg|flv)$/i, ''); // video extensions
+       track = track.replace(/\s*(of+icial\s*)?(music\s*)?video/i, ''); // (official)? (music)? video
+       track = track.replace(/\s*\(\s*of+icial\s*\)/i, ''); // (official)
+       track = track.replace(/\s*\(\s*[0-9]{4}\s*\)/i, ''); // (1999)
+       track = track.replace(/\s+\(\s*(HD|HQ)\s*\)$/, ''); // HD (HQ)
+       track = track.replace(/\s+(HD|HQ)\s*$/, ''); // HD (HQ)
+       track = track.replace(/\s*video\s*clip/i, ''); // video clip
+       track = track.replace(/\s+\(?live\)?$/i, ''); // live
+       track = track.replace(/\(\s*\)/, ''); // Leftovers after e.g. (official video)
+       track = track.replace(/^(|.*\s)"(.*)"(\s.*|)$/, '$2'); // Artist - The new "Track title" featuring someone
+       track = track.replace(/^(|.*\s)'(.*)'(\s.*|)$/, '$2'); // 'Track title'
+       track = track.replace(/^[\/\s,:;~-]+/, ''); // trim starting white chars and dash
+       track = track.replace(/[\/\s,:;~-]+$/, ''); // trim trailing white chars and dash
+
+       return {artist: artist, track: track};
+    }
+
+    /**
+     * Cache the last song called to avoid multiple calls
+     * @type {String}
+     */
+    var lastSongTitle = '';
+
+    var updateNowPlaying = function() {
+        var commDiv = document.getElementById('chromeLastFM'), songInfo, cleanInfo;
+
+        try {
+            songInfo = JSON.parse(commDiv.innerText);
+        } catch (e) {
+            // Skip malformed communication blobs
+            return;
+        }
+
+        // If this is a "pause" event, just call the "reset"
+        if (songInfo.pause && songInfo.pause === true) {
+            lastSongTitle = '';
+            chrome.extension.sendRequest({type: "reset"});
+            return;
+        }
+
+        // If the title is the same as the previous one, just leave
+        if (songInfo.track === lastSongTitle) {
+            return;
+        }
+        lastSongTitle = songInfo.track;
+
+        // the plug.dj sound sources are youtube and soundcloud, which can have dirty track/artist info.
+        // clean them up before scrobbling.
+        cleanInfo = cleanArtistTrack(songInfo.artist, songInfo.track);
+        cleanInfo.duration = songInfo.duration;
+
+        chrome.extension.sendRequest({'type': 'validate', 'artist': cleanInfo.artist, 'track': cleanInfo.track}, function (response) {
+            if (response !== false) {
+                chrome.extension.sendRequest({type: 'nowPlaying', 'artist': cleanInfo.artist, 'track': cleanInfo.track, 'duration': cleanInfo.duration});
+            } else {
+                // on validation failure send nowPlaying 'unknown song'
+                chrome.extension.sendRequest({'type': 'nowPlaying', 'duration': cleanInfo.duration});
+            }
+        });
+    };
+
+    $(document).ready(function () {
+        // XXX(shamer): we can't directly access the page javascript from the
+        // extension. To get code running in the page context we have to add a script tag
+        // to the DOM. The script then is executed in the global context.
+        // To communicate between the injected JS and the extension a DOM node is updated with the text to send.
+        var comNode = $('<div id="chromeLastFM" style="display: none"></div>');
+        document.body.appendChild(comNode[0]);
+
+        $('body').append('<script type="text/javascript">(function(l) {\n' +
+            "    var injectScript = document.createElement('script');\n" +
+            "    injectScript.type = 'text/javascript';\n" +
+            "    injectScript.src = l;\n" +
+            "    document.getElementsByTagName('head')[0].appendChild(injectScript);\n" +
+            "  })('" + chrome.extension.getURL('plugdj-dom-inject.js') + "');</script>");
+
+        // Listen for 'messages' from the injected script
+        $('#chromeLastFM').bind('DOMSubtreeModified', updateNowPlaying);
+
+        $(window).unload(function () {
+            chrome.extension.sendRequest({type:'reset'});
+            return true;
+        });
+    });
+})(jQuery);


### PR DESCRIPTION
Added support for [plug.dj](http://plug.dj/) collaborative listening site using their [official API](http://blog.plug.dj/api-documentation). Their site uses youtube and soundcloud for music sources. I didn't increment the minor version number though. 

Thanks for the great extension!
