### PR TITLE
amazon.es added to amazon connector

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -114,7 +114,7 @@
       "js": ["jquery-1.6.1.min.js", "soundcloud.js"]
    },
    {
-      "matches": ["*://www.amazon.com/gp/dmusic/mp3/player*"],
+      "matches": ["*://www.amazon.com/gp/dmusic/mp3/player*","*://www.amazon.es/gp/dmusic/mp3/player*"],
       "js": ["jquery-1.6.1.min.js", "jquery.dump.js", "amazon.js"]
    },
    {


### PR DESCRIPTION
Spanish Amazon.com site amazon.es added, via https://github.com/david-sabata/Chrome-Last.fm-Scrobbler/issues/170
