### PR TITLE
Add an option to prevent notifications autohiding

### DIFF
--- a/options.html
+++ b/options.html
@@ -26,6 +26,10 @@
                         <input type="checkbox" id="use-notifications-scrobbled">
                         <label for="use-notifications-scrobbled">Notify when song has been scrobbled</label>
                      </li>
+                     <li>
+                        <input type="checkbox" id="auto-hide-notifications">
+                        <label for="auto-hide-notifications">Automatically hide notifications</label>
+                     </li>
                   </ul>
                </li>               
                <li>

--- a/options.js
+++ b/options.js
@@ -17,6 +17,10 @@ $(function(){
       localStorage['useNotificationsScrobbled'] = this.checked ? 1 : 0;
    });
 
+   $('#auto-hide-notifications').click(function(){
+      localStorage['autoHideNotifications'] = this.checked ? 1 : 0;
+   });
+
    $('#use-autocorrect').click(function(){
       localStorage['useAutocorrect'] = this.checked ? 1 : 0;
    });
@@ -29,6 +33,7 @@ $(function(){
    $('#use-notifications').attr('checked', (localStorage['useNotifications'] == 1));
    $('#use-notifications-nowplaying').attr('checked', (localStorage['useNotificationsNowPlaying'] == 1));
    $('#use-notifications-scrobbled').attr('checked', (localStorage['useNotificationsScrobbled'] == 1));
+   $('#auto-hide-notifications').attr('checked', (localStorage['autoHideNotifications'] == 1));
    $('#use-autocorrect').attr('checked', (localStorage['useAutocorrect'] == 1));
    $('#use-youtube-inpage').attr('checked', (localStorage['useYTInpage'] == 1));
    
@@ -36,6 +41,7 @@ $(function(){
    function updateDisabled() {
       $('#use-notifications-nowplaying').attr('disabled', (!$('#use-notifications').is(':checked')));
       $('#use-notifications-scrobbled').attr('disabled', (!$('#use-notifications').is(':checked')));
+      $('#auto-hide-notifications').attr('disabled', (!$('#use-notifications').is(':checked')));
    }
    
 });

--- a/scrobbler.js
+++ b/scrobbler.js
@@ -78,6 +78,10 @@ const ACTION_CONN_DISABLED = 7;
    if (localStorage.useNotificationsScrobbled == null)
       localStorage.useNotificationsScrobbled = 1;
 
+   // hide notifications by default
+   if (localStorage.autoHideNotifications == null)
+      localStorage.autoHideNotifications = 1;
+
    // don't use the YT statuses by default
    if (localStorage.useYTInpage == null)
       localStorage.useYTInpage = 0;
@@ -247,7 +251,9 @@ function scrobblerNotification(text, force) {
       body
    );
    notification.show();
-   setTimeout(function() {notification.cancel()}, NOTIFICATION_TIMEOUT);
+
+   if (localStorage.autoHideNotifications == 1)
+      setTimeout(function() {notification.cancel()}, NOTIFICATION_TIMEOUT);
 }
 
 


### PR DESCRIPTION
By disabling this option, notifications will not automatically close themselves after a predefined period has elapsed. By remaining open, notifications will remain in the Notification Center on OS X Mountain Lion, providing a log of play history.
