### PR TITLE
Updated Amazon Connector to make artist tag language-independent

### DIFF
--- a/connectors/amazon.js
+++ b/connectors/amazon.js
@@ -1,4 +1,3 @@
-
 /*
  * Chrome-Last.fm-Scrobbler amazon.com "new interface" Connector
  *
@@ -31,10 +30,10 @@ function titleAndArtist() {
     }
   } else {
     var currentSongDetails = $(".currentSongDetails .title");
+    var currentSongStatus = $(".currentSongStatus > a");
     return {
       title: currentSongDetails.text(),
-      // substring(3) because format is: 'by Artist'
-      artist: currentSongDetails.next().text().substring(3)
+      artist: currentSongStatus.text()
     }
   }
 }


### PR DESCRIPTION
Previously, the search for the artist was dependent on the fact that it reads as '<Title> by <Artist>' by using substring function. In languages different to English this might result in wrong findings.
This approach uses another HTML tag to find the artist.
