### PR TITLE
Stop unnecessary scrobbling and notifications when navigating Google Music

### DIFF
--- a/connectors/googlemusic.js
+++ b/connectors/googlemusic.js
@@ -22,9 +22,6 @@ $(function(){
    });
    
    //console.log("Last.fm Scrobbler: starting Google Music connector")
-   
-   // first load
-   updateNowPlaying();
 });
 
 /**


### PR DESCRIPTION
Google Music triggers a tabs.onUpdated changeInfo.status=='complete' event each time you click on the navigation to change the view. This causes the connector to be injected into the page again.

Upon injection, the currently playing track was updated. If a track was playing, this would cause additional scrobbling (and notifications). Stopping the track being updated on anything other than a DOM modification prevents this happening.

This may cause a first track to not be scrobbled. I cannot, however, reach a state where this happens after a bit of clicking around while refreshing and reloading things.
