### PR TITLE
correct amazon scrobbling when user navigates away from main pane

### DIFF
--- a/connectors/amazon.js
+++ b/connectors/amazon.js
@@ -223,7 +223,6 @@ chrome.runtime.onMessage.addListener(
  */
 $(function(){
   console.log("Amazon module starting up");
-  window.taa = titleAndArtist;
 
   $(watchedContainer).live('DOMSubtreeModified', function(e) {
     //console.log("Live watcher called");


### PR DESCRIPTION
This corrects amazon scrobbling in the case that the user navigates away from the main pane. In that case, the scrobbling info is gotten from a different part of the DOM. Some time since my last pull request, Amazon slightly tweaked that part of the DOM, resulting in the album name being submitted as the title.
