### PR TITLE
Activate Amazon connector for amazon.co.uk

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -114,7 +114,7 @@ var connectors = [
 
     {
         label: "Amazon",
-        matches: ["*://www.amazon.com/gp/dmusic/mp3/player*", "*://www.amazon.de/gp/dmusic/mp3/player*", "*://www.amazon.es/gp/dmusic/mp3/player*"],
+        matches: ["*://www.amazon.com/gp/dmusic/mp3/player*", "*://www.amazon.de/gp/dmusic/mp3/player*", "*://www.amazon.es/gp/dmusic/mp3/player*", "*://www.amazon.co.uk/gp/dmusic/mp3/player*"],
         js: ["connectors/amazon.js"]
     },
 


### PR DESCRIPTION
I just added the .co.uk extension as one of the amazon connector's injection URL match strings. No further code change necessary, and it works fine on my machine with my amazon account.
