### PR TITLE
Change to not scrobble advertisements on Spotify

### DIFF
--- a/connectors/spotify.js
+++ b/connectors/spotify.js
@@ -56,7 +56,7 @@
         }
 
         // beginning of a new song
-        if (data.track.uri != lastTrackUri) {
+        if (data.track.uri != lastTrackUri && !data.track.advertisement) {
             var track = data.track;
             lastTrackUri = track.uri;
 


### PR DESCRIPTION
Noticed that advertisements on Spotify were being scrobbled. I added a check to make sure that `data.track.advertisement` is false.
