### PR TITLE
VK connector duration fix

### DIFF
--- a/connectors/vk.js
+++ b/connectors/vk.js
@@ -1,34 +1,11 @@
 var lastTrack = null;
 var $r = chrome.runtime.sendMessage;
 
-function parseDurationString(timestr) {
-    if (timestr) {
-        var m = /(\d+):(\d+)/.exec(timestr);
-
-        return parseInt(m[1], 10) * 60 + parseInt(m[2], 10);
-    }
-    return 0;
-}
-
 function scrobble(e) {
-	var timestr	= '';
-	if ($("#ac_duration").length > 0) {
-	   timestr = $("#ac_duration").text();
-	} else if ($("#pd_duration").length > 0) {
-	   timestr = $("#pd_duration").text();
-	}
-	if (timestr != '') {
-		if (timestr[0] == '-') {
-            timestr = timestr.substring(1);
-        }
-        var duration = parseDurationString(timestr);
-	}
-	var artist = $("#gp_performer").text();
+    var artist = $("#gp_performer").text();
     var title = $("#gp_title").text();
 
     if (lastTrack != artist + " " + title) {
-        var total = duration;
-
         lastTrack = artist + " " + title;
 
         $r({type: 'validate', artist: artist, track: title}, function(response) {
@@ -37,10 +14,10 @@ function scrobble(e) {
                     type: 'nowPlaying',
                     artist: response.artist,
                     track: response.track,
-                    duration: total
+                    duration: Math.floor(response.duration / 1000)
                 });
             } else {
-                $r({type: 'nowPlaying', duration: total});
+                $r({type: 'nowPlaying'});
             }
         });
     }


### PR DESCRIPTION
Get track duration info from LFM (using data returned by `validate` function request)
(see issue #182)
