### PR TITLE
Sky.FM support via Digitally Imported connector

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -306,8 +306,8 @@ var connectors = [
     },
 
     {
-        label: "Digitally Imported",
-        matches: ["*://www.di.fm/*"],
+        label: "Digitally Imported and Sky.FM",
+        matches: ["*://www.di.fm/*", "*://www.sky.fm/*"],
         js: ["connectors/difm.js"]
     },
 


### PR DESCRIPTION
Sky.FM is a sister site of Digitally Imported. It uses an identical player interface, so the same connector can be used.
