### PR TITLE
Add SoundCloud set/playlist support

### DIFF
--- a/connectors/soundcloud.js
+++ b/connectors/soundcloud.js
@@ -71,7 +71,11 @@ function cleanArtistTrack(artist, track) {
     var current = {};
 
     var song = function(ptitle) {
-        var title = ptitle.split(/ (by|in) /);
+        var title = ptitle.split(' by '); // Default behaviour: song
+        if (ptitle.indexOf(' by ' ) >= 0) {
+            // Playlist
+            title = ptitle.split(' by ');
+        }
         var parsedInfo = parseInfo(title[0]);
 
         if (parsedInfo.artist === '') {


### PR DESCRIPTION
**Previously:**
Checked the title only for existence of `' by '` in order to match the form `<song name> by <artist name>`

**Problem:**
This did not correctly identify songs in playlists, whose titles have the form `<song name> in <playlist name>`

**Solution:**
Checks for existence of either `' by '` or `' in '`.
Additionally, splits the title at either `by` or `in` in `song()`

Should fix issue #127 ("Scrobbling doesn't work when listening to Soundcloud.com sets"), and also solves the same problem that #158 tried to solve.

**Test Cases:**
[Regular case: playlist with song names of format "<artist name> - <song name>"](https://soundcloud.com/flume/sets/flume-remixes)
-> works great
[Another regular playlist case](https://soundcloud.com/futureclassic/sets/woolfy-city-lights-ep-1)
-> works great
[Default case: individual song](https://soundcloud.com/dariusofficial/hot-hands)
-> works great
[Album, song names of format "<song name>"](https://soundcloud.com/oaklandfalcons/sets/remixxes-vol-3)
-> Doesn't identify artist name because it isn't in song title. User will have to input manually.
-> Possible solution: when this happens, pass the _song title_ as the _song name_ and pass the _username_ as the _artist name_.
