### PR TITLE
YouTube fix

### DIFF
--- a/connectors/youtube.js
+++ b/connectors/youtube.js
@@ -123,7 +123,7 @@ function cleanArtistTrack(artist, track) {
    track = track.replace(/\s+(HD|HQ)\s*$/, ''); // HD (HQ)
    track = track.replace(/\s*video\s*clip/i, ''); // video clip
    track = track.replace(/\s+\(?live\)?$/i, ''); // live
-   track = track.replace(/\(\s*\)/, ''); // Leftovers after e.g. (official video)
+   track = track.replace(/\(+\s*\)+/, ''); // Leftovers after e.g. (official video)
    track = track.replace(/^(|.*\s)"(.*)"(\s.*|)$/, '$2'); // Artist - The new "Track title" featuring someone
    track = track.replace(/^(|.*\s)'(.*)'(\s.*|)$/, '$2'); // 'Track title'
    track = track.replace(/^[\/\s,:;~-\s"]+/, ''); // trim starting white chars and dash


### PR DESCRIPTION
Fix for YouTube when titles have more than one bracket around stripped elements
## Test cases
-  https://www.youtube.com/watch?v=GRVwtSmgKP8 (now works) 
- https://www.youtube.com/watch?v=nXXVMcyy_Ag (existing one that worked)
