### PR TITLE
Update track duration element id for slacker

### DIFF
--- a/connectors/slacker2.js
+++ b/connectors/slacker2.js
@@ -34,7 +34,7 @@ function LFM_TRACK_ALBUM() {
 // function that returns duration of current song in seconds
 // called at begining of song
 function LFM_TRACK_DURATION() {
-	durationArr = $('#total-length').text().split(":");
+	durationArr = $('#progress-total').text().split(":");
 	return parseInt(durationArr[0], 10)*60 + parseInt(durationArr[1], 10);
 }
 


### PR DESCRIPTION
The old #total-length element still exists, but it now seems to always be
'0:00', causing songs to never scrobble.
