### PR TITLE
amazon cloudplayer URL change (fixes #401)

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -127,7 +127,7 @@ var connectors = [
 
     {
         label: 'Amazon',
-        matches: ['*://www.amazon.com/gp/dmusic/mp3/player*', '*://www.amazon.de/gp/dmusic/mp3/player*', '*://www.amazon.es/gp/dmusic/mp3/player*', '*://www.amazon.co.uk/gp/dmusic/mp3/player*'],
+        matches: ['*://www.amazon.com/gp/dmusic/*/player*', '*://www.amazon.de/gp/dmusic/*/player*', '*://www.amazon.es/gp/dmusic/*/player*', '*://www.amazon.co.uk/gp/dmusic/*/player*'],
         js: ['connectors/amazon.js']
     },
 


### PR DESCRIPTION
Adjust matcher for amazon cloudplayer URL change. 

e.g. it looks like 
    www.amazon.com/gp/dmusic/mp3/player
recently changed to
    www.amazon.com/gp/dmusic/cloudplayer/player
