### PR TITLE
Allow PLEX connector to work via Plex.tv as well

### DIFF
--- a/core/connectors.js
+++ b/core/connectors.js
@@ -364,7 +364,7 @@ define(function() {
 
 		{
 			label: 'PLEX',
-			matches: ['*://*32400/web/*'],
+			matches: ['*://*32400/web/*', '*://plex.tv/web/*'],
 			js: ['connectors/plex.js']
 		},
 


### PR DESCRIPTION
Plex.tv acts as a gateway for running Plex Media Server instances. Haven't looked too deep into the HTML, but I doubt it's very different. This just adds the URL matching pattern.

If the added newline at the end of the file is an issue, let me know and I'll fix that up. GitHub's online editor added that on its own.
