### PR TITLE
Fix bug with Plex connector not detecting playback

### DIFF
--- a/connectors/plex.js
+++ b/connectors/plex.js
@@ -12,7 +12,7 @@ var CONTAINER_SELECTOR = 'div#plex.application.show-nav-bar.show-action-bar.show
 
 
 $(function(){
-	$(CONTAINER_SELECTOR).live('DOMSubtreeModified', function(e) {
+	$(CONTAINER_SELECTOR).on('DOMSubtreeModified', function(e) {
 
 		if ($(CONTAINER_SELECTOR).length > 0) {
 			updateNowPlaying();


### PR DESCRIPTION
I noticed that playing music from my Plex server, though the icon in my browser showed
that the site (my PMS instance) is supported for scrobbling, no playback notifications
ever appeared. I did a little digging and discovered that .live() is deprecated in
latest jQuery; we should use .on() instead (or .delegate(), if absolutely necessary).

In fact, testing $('div#plex.application').live(); in the JS console with my Plex server
open and the scrobbler icon active in my location bar returned a TypeError: undefined is
not a function. However, $('dig#plex.application').on(); works fine.

<s>Granted, I don't know enough about building Chrome extensions to actually package this
and test it myself, but having a patch available is still a step toward fixing an issue.</s> I can't read. Test results will follow in a bit, once I've cloned and loaded the unpacked extension into my browser.
