### PR TITLE
Fixes Rdio scrobbling issue

### DIFF
--- a/connectors/rdio.js
+++ b/connectors/rdio.js
@@ -15,44 +15,44 @@ $(function(){
  * Called every time we load a new song
  */
 function updateNowPlaying(){
-    var parsedInfo = parseInfo();
+    parseInfo(function(parsedInfo){
+        if (parsedInfo.artist == '' || parsedInfo.track == '' || parsedInfo.duration == 0) {
+            console.warn('empty artist/track/duration', parsedInfo);
+            return;
+        }
 
-    if (parsedInfo.artist == '' || parsedInfo.track == '' || parsedInfo.duration == 0) {
-	    console.warn('empty artist/track/duration', parsedInfo);
-	    return;
-    }
+        // check if the same track is being played and we have been called again
+        // if the same track is being played we return
+        if (clipTitle == parsedInfo.track) {
+            return;
+        }
+        clipTitle = parsedInfo.track;
 
-    // check if the same track is being played and we have been called again
-    // if the same track is being played we return
-    if (clipTitle == parsedInfo.track) {
-        return;
-    }
-    clipTitle = parsedInfo.track;
+        console.log("Now playing -- artist: " + parsedInfo.artist + ", track: " + parsedInfo.track + ", duration: " + parsedInfo.duration);
 
-	console.log("Now playing -- artist: " + parsedInfo.artist + ", track: " + parsedInfo.track + ", duration: " + parsedInfo.duration);
-
-	chrome.runtime.sendMessage({type: 'validate', artist: parsedInfo.artist, track: parsedInfo.track}, function(response) {
-      if (response != false) {
-          chrome.extension.sendMessage({type: 'nowPlaying', artist: parsedInfo.artist, track: parsedInfo.track, duration: parsedInfo.duration});
-      }
-      // on failure send nowPlaying 'unknown song'
-      else {
-         chrome.runtime.sendMessage({type: 'nowPlaying', duration: parsedInfo.duration});
-      }
+        chrome.runtime.sendMessage({type: 'validate', artist: parsedInfo.artist, track: parsedInfo.track}, function(response) {
+          if (response != false) {
+              chrome.extension.sendMessage({type: 'nowPlaying', artist: parsedInfo.artist, track: parsedInfo.track, duration: parsedInfo.duration});
+          }
+          // on failure send nowPlaying 'unknown song'
+          else {
+             chrome.runtime.sendMessage({type: 'nowPlaying', duration: parsedInfo.duration});
+          }
+        });
     });
 }
 
 
-function parseInfo() {
+function parseInfo(callback) {
     var artistValue = $(".App_PlayerFooter .player_bottom .artist_title").text().trim();
     var trackValue = $(".App_PlayerFooter .song_title").text().trim();
     var durationValue = $(".App_PlayerFooter .bottom .duration").text().trim();
 
-    return {
-	    artist: artistValue,
-	    track: trackValue,
-	    duration: parseDuration(durationValue)
-    };
+    callback({
+        artist: artistValue,
+        track: trackValue,
+        duration: parseDuration(durationValue)
+    });
 }
 
 function parseDuration(duration) {


### PR DESCRIPTION
There's an issue where sometimes Rdio scrobbles a correct songname with an incorrect artist name. This seems to fix it, it looks like a bug to do with line 33 executing before parseInfo is finished, so I put it in a callback to force synchronicity. If there's a better way to do this, or if I've misdiagnosed the issue, I'd be happy to hear :)
