### PR TITLE
Updated name for iheart.com radio play button class.

### DIFF
--- a/connectors/iheart.js
+++ b/connectors/iheart.js
@@ -13,7 +13,7 @@ $(function () {
         });
         return true;
     });
-    $(".play").click(function () {
+    $(".js-play").click(function () {
         var c = 0;
         //wait for changes in artist name
         $(".js-track-name").bind("DOMSubtreeModified", function (e) {


### PR DESCRIPTION
Connector for iheart.com radio stopped working because class name was changed for a play button. Updated class name is also used for a "Listen Now" button. This shouldn't be a problem because both buttons trigger playback.
