### PR TITLE
Pleer connector: don't scrobble songs with zero duration

### DIFF
--- a/connectors/pleer.js
+++ b/connectors/pleer.js
@@ -19,6 +19,7 @@ function scrobble () {
      * Detect this case and cancel scrobbling.
      */
     if (duration == 0) {
+        chrome.runtime.sendMessage({type: 'reset'});
         return;
     }
 


### PR DESCRIPTION
When pleer.com is unable to play a song, the song is scrobbled immediately. It occurs because of the zero song duration that pleer.com sets. I decided to fix this problem by checking song duration. If the song duration is zero, the connector doesn't send `nowPlaying` request.

But there's a problem. Pleer.com has following behavior:
- it sets the song duration to zero after a while; 
- it does nothing if it fails to play the song (it doesn't switch to next song).

So connector understands that the song duration is zero after sending `nowPlaying` request. In this case the song will be scrobbled if user doesn't select another song. I suppose it could be fixed by sending `reset` request to core:

```
  if (duration == 0) {
      chrome.runtime.sendMessage({type: 'reset'});
      return;
  }
```

but I doubt the correctness of this approach. Maybe there is a another way to fix this problem?
