### PR TITLE
Bandcamp - check for various artists by checking if each track has a dash

### DIFF
--- a/connectors/bandcamp.js
+++ b/connectors/bandcamp.js
@@ -33,7 +33,7 @@ $(function() {
 		var lastTrack = null;
 
 		/**
-		 * Bind events to audio
+		 * Bind scrobbling logic to the audio's playing event
 		 */
 		audio.addEventListener('playing', function() {
 
@@ -63,6 +63,8 @@ $(function() {
 
 				console.log('BandCampScrobbler: scrobbling - Artist: ' + artist + '; Album:  ' + album + '; Track: ' + track + '; duration: ' + duration.total);
 
+				lastTrack = track;
+
 				chrome.runtime.sendMessage({
 					type: 'validate',
 					artist: artist,
@@ -84,6 +86,17 @@ $(function() {
 					}
 				});
 			}
+		});
+
+		/**
+		 * Set lastTrack to null to reset playing and enabling re-scrobbling
+		 * of the same song again once audio has finished playing.
+		 */
+		audio.addEventListener('ended', function() {
+
+			console.log('BandCampScrobbler: song finished playing');
+
+			lastTrack = null;
 		});
 
 		/**


### PR DESCRIPTION
I find it annoying when scrobbling compilations from Bandcamp (which don't set the artist to Various or Various Artists) that the track title contains the artist. I've made a modification to the scrobbler to work out artist from the track if either:
- The artist is set to 'Various' or 'Various Artists' and track has a dash 
- This is an album and all the tracks have a dash

**Examples:**
- https://nothingbuthopeandpassion.bandcamp.com/album/nothing-but-nordic-music
- https://section27.bandcamp.com/album/s27-127-sectioned-v40

~~I guess the fact that the Bandcamp scrobbler for every time the duration updates has to work out the artist/track isn't the most effective mechanism and perhaps could be improved in another way.~~

**Done:** Now listens to the `playing` event from the `audio` player. 
