### PR TITLE
Allow for scrobbling from internal builds of Google Play Music 

### DIFF
--- a/core/connectors.js
+++ b/core/connectors.js
@@ -55,7 +55,7 @@ define(function() {
 
 		{
 			label: 'Google Play Music',
-			matches: ['*://play.google.com/music/*'],
+			matches: ['*://play.google.com/music/*', '*://play-music.sandbox.google.com/music/*'],
 			js: ['connectors/googlemusic.js']
 		},
 


### PR DESCRIPTION
In case you're a Google employee! Just an extra option in the Google Play Music entry in core/connectors.js.

Note that I should have just updated my old pull request rather than creating a new one. I did it this way because I am an idiot who doesn't understand git. Sorry for the trouble!
