### PR TITLE
Return early when video not in music category

### DIFF
--- a/connectors/youtube.js
+++ b/connectors/youtube.js
@@ -174,6 +174,13 @@ function updateNowPlaying() {
    // Get clip info from youtube api
    chrome.runtime.sendMessage({type: "xhr", url: googleURL}, function(response) {
       var info = JSON.parse(response.text);
+
+      // Return early if not in music category
+      var category = info.entry.category[1].label;
+      if (category !== 'Music') {
+      	return;
+      }
+
       var parsedInfo = parseInfo(info.entry.title.$t);
       var artist = null;
       var track = null;


### PR DESCRIPTION
Fix for issue raised in #500 

The gdata URL is language independent so I don't believe there will be an issue with localization of Music. 
