### PR TITLE
Fix BBC Radio Player connector to work with new Playlister/NowPlaying functionality

### DIFF
--- a/connectors/bbcradioplayer.js
+++ b/connectors/bbcradioplayer.js
@@ -15,6 +15,7 @@ var DEFAULT_TIMEOUT = 90;
 var config = {childList: true, subtree: true, attributes: true};
 
 // BBC RadioPlayer stations show a Now Playing box inside the container
+// The box is removed when no track is played, so we need to check for it
 var CONTAINER = '.programme-details-wrapper ';
 var NP_ELEMENT = '#now-playing .playlister ';
 var ARTIST_ELEMENT = NP_ELEMENT+'.track .artist';


### PR DESCRIPTION
BBC Radio Player updated its HTML rendering, so I've amended the selectors and logic to always get the strings.

Tested for 20-30 minutes and it's scrobbled everything thrown at it, which is unsurprising as the HTML is always the same now.
