### PR TITLE
Added Sound Session

### DIFF
--- a/connectors/soundsession.js
+++ b/connectors/soundsession.js
@@ -1,0 +1,33 @@
+'use strict';
+
+setupConnector();
+
+function setupConnector() {
+	['#notice-track', '#playlist'].forEach(function(playerSelector, index) {
+		if ($(playerSelector).length) {
+			Connector.playerSelector = playerSelector;
+			if (0 === index) {
+				setupCenterPlayer();
+			} else {
+				setupStationPlayer();
+			}
+		}
+	});
+}
+
+function setupCenterPlayer() {
+	$('audio').bind('playing pause timeupdate', Connector.onStateChanged);
+
+	Connector.isPlaying = () => {
+		const audio = $('audio').get(0);
+		return audio.currentTime && !audio.paused && !audio.ended;
+	};
+
+	Connector.trackSelector = '.notice-track-name';
+
+	Connector.artistSelector = '.notice-track-singer';
+}
+
+function setupStationPlayer() {
+	Connector.artistTrackSelector = '#playlist li:nth-child(1) a';
+}

--- a/core/connectors.js
+++ b/core/connectors.js
@@ -1146,5 +1146,9 @@ define(function() {
 		label: 'Mideast Tunes',
 		matches: ['*://mideastunes.com/*', '*://map.mideastunes.com/*'],
 		js: ['connectors/mideastunes.js']
+	}, {
+		label: 'Sound Session',
+		matches: ['*://*soundsession.com/', '*://soundsession.center/station/*'],
+		js: ['connectors/soundsession.js']
 	}];
 });

--- a/tests/connectors/soundsession.js
+++ b/tests/connectors/soundsession.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = function(driver, connectorSpec) {
+	// center player
+	connectorSpec.shouldBehaveLikeMusicSite(driver, {
+		url: 'http://soundsession.center/station/?station=indie'
+	});
+	// station player
+	connectorSpec.shouldContainPlayerElement(driver, {
+		url: 'http://litesoundsession.com/'
+	});
+};


### PR DESCRIPTION
Closes #1512.

Known issue:
---
Station players in [lite sound session](http://litesoundsession.com/) and [deep sound session](http://deepsoundsession.com/) use a flash player, thus the connector can't detect the playing state.