### PR TITLE
add placeholder texts to titles

### DIFF
--- a/popups/info.html
+++ b/popups/info.html
@@ -23,9 +23,9 @@
 			<a id="album" class="album metadata" href="#" target="_blank"></a>
 		</div>
 		<div id="edit" data-hide="true">
-			<input type="text" id="track-input" i18n-placeholder="infoTrackPlaceholder" tabindex="1" />
-			<input type="text" id="artist-input" i18n-placeholder="infoArtistPlaceholder" tabindex="2" />
-			<input type="text" id="album-input" i18n-placeholder="infoAlbumPlaceholder" tabindex="3" />
+			<input type="text" id="track-input" i18n-placeholder="infoTrackPlaceholder" i18n-title="infoTrackPlaceholder" tabindex="1" />
+			<input type="text" id="artist-input" i18n-placeholder="infoArtistPlaceholder" i18n-title="infoArtistPlaceholder" tabindex="2" />
+			<input type="text" id="album-input" i18n-placeholder="infoAlbumPlaceholder" i18n-title="infoAlbumPlaceholder" tabindex="3" />
 		</div>
 		<div id="edit-controls">
 			<span id="edit-link" class="control-btn"></span>


### PR DESCRIPTION
Problem: while editing track info it is not possible to tell the title from artist without temporarily deleting one value; fix: duplicating the placeholder text to title could help a little bit.