### PR TITLE
Fix Deezer is isPlaying() detection

### DIFF
--- a/connectors/deezer.js
+++ b/connectors/deezer.js
@@ -17,4 +17,4 @@ Connector.trackArtSelector = '.player-cover img';
 
 Connector.filter = MetadataFilter.getRemasteredFilter();
 
-Connector.isPlaying = () => $('.svg-icon-pause').length > 0;
+Connector.isPlaying = () => $('#player .svg-icon-pause').length > 0;


### PR DESCRIPTION
Currently to check if a song is playing and should be scrobbled, the existence of an item with css class "svg-icon-pause" is being checked. This, unfortunately, causes problems as soon as playlists, albums or anything playable is being displayed since every track also has an item with "svg-icon-pause".

This results in the current selected track in the player, no matter what that is, being scrobbled as being played... even though it is not. This is especially bad since Deezer preselect a song of its choice when you open a new session which will then get scrobbled as being played if you browse the your collection or whatnot.

The fix is rather simple: Limit the css selector to the actual player itself (an element with id "player") which is guaranteed to be unique for the whole page.