### PR TITLE
Add duration parsing to Amazon Alexa connector

### DIFF
--- a/connectors/amazon-alexa.js
+++ b/connectors/amazon-alexa.js
@@ -1,7 +1,8 @@
 'use strict';
 
 Connector.playerSelector = '#d-content';
-Connector.remainingTimeSelector  = '.d-np-time-display.remaining-time';
+Connector.albumSelector = '#d-info-text .d-sub-text-2';
+Connector.remainingTimeSelector = '.d-np-time-display.remaining-time';
 Connector.currentTimeSelector = '.d-np-time-display.elapsed-time';
 
 Connector.getDuration = () => {
@@ -26,19 +27,17 @@ Connector.getArtistTrack = () => {
 	return { artist, track };
 };
 
-Connector.albumSelector = '#d-info-text .d-sub-text-2';
-
 Connector.isPlaying = () => {
-	let songProgress = $('.d-np-progress-slider .d-slider-container .d-slider-track').attr('aria-valuenow');
 	let duration = Connector.getDuration();
 
-	// The app doesn't update the progress bar or time remaining straight away (and starts counting down from an hour). This is a workaround to avoid detecting an incorrect duration time.
-	if (duration > 3600 || songProgress == 100) {
+	// The app doesn't update the remaining and elapsed times straight away when changing songs. The remaining time rolls over and starts counting down from an hour.
+	// This is a workaround to avoid detecting an incorrect duration time.
+	if (duration > 3600) {
 		return false;
 	}
-	
+
 	return $('#d-primary-control .play').size() === 0;
-}
+};
 
 function isPlayingLiveRadio() {
 	return $('#d-secondary-control-left .disabled').size() === 1 &&

--- a/connectors/amazon-alexa.js
+++ b/connectors/amazon-alexa.js
@@ -4,6 +4,7 @@ Connector.playerSelector = '#d-content';
 Connector.albumSelector = '#d-info-text .d-sub-text-2';
 Connector.remainingTimeSelector = '.d-np-time-display.remaining-time';
 Connector.currentTimeSelector = '.d-np-time-display.elapsed-time';
+Connector.trackArtSelector = '#d-album-art > #d-image img';
 
 Connector.getDuration = () => {
 	let elapsed = Util.stringToSeconds($(Connector.currentTimeSelector).text());

--- a/connectors/amazon-alexa.js
+++ b/connectors/amazon-alexa.js
@@ -36,10 +36,10 @@ Connector.isPlaying = () => {
 		return false;
 	}
 
-	return $('#d-primary-control .play').size() === 0;
+	return $('#d-primary-control .play').length === 0;
 };
 
 function isPlayingLiveRadio() {
-	return $('#d-secondary-control-left .disabled').size() === 1 &&
-		$('#d-secondary-control-right .disabled').size() === 1;
+	return $('#d-secondary-control-left .disabled').length === 1 &&
+		$('#d-secondary-control-right .disabled').length === 1;
 }

--- a/connectors/amazon-alexa.js
+++ b/connectors/amazon-alexa.js
@@ -1,6 +1,19 @@
 'use strict';
 
 Connector.playerSelector = '#d-content';
+Connector.remainingTimeSelector  = '.d-np-time-display.remaining-time';
+Connector.currentTimeSelector = '.d-np-time-display.elapsed-time';
+
+Connector.getDuration = () => {
+	let elapsed = Util.stringToSeconds($(Connector.currentTimeSelector).text());
+	let remaining = -Util.stringToSeconds($(Connector.remainingTimeSelector).text());
+	return (remaining + elapsed);
+};
+
+Connector.getRemainingTime = () => {
+	let remaining = -Util.stringToSeconds($(Connector.remainingTimeSelector).text());
+	return remaining;
+};
 
 Connector.getArtistTrack = () => {
 	if (isPlayingLiveRadio()) {
@@ -15,7 +28,17 @@ Connector.getArtistTrack = () => {
 
 Connector.albumSelector = '#d-info-text .d-sub-text-2';
 
-Connector.isPlaying = () => $('#d-primary-control .play').size() === 0;
+Connector.isPlaying = () => {
+	let songProgress = $('.d-np-progress-slider .d-slider-container .d-slider-track').attr('aria-valuenow');
+	let duration = Connector.getDuration();
+
+	// The app doesn't update the progress bar or time remaining straight away (and starts counting down from an hour). This is a workaround to avoid detecting an incorrect duration time.
+	if (duration > 3600 || songProgress == 100) {
+		return false;
+	}
+	
+	return $('#d-primary-control .play').size() === 0;
+}
 
 function isPlayingLiveRadio() {
 	return $('#d-secondary-control-left .disabled').size() === 1 &&


### PR DESCRIPTION
The Amazon Alexa SPA app has a Now Playing tab which includes additional metadata about the currently playing song. We can use this to parse the duration time of the song. The user will need to navigate and stay on the Now Playing tab in order for this new functionality to work. This appears to fallback gracefully if the user is not on the Now Playing tab though.

I've had to include a workaround to get around the fact that the UI does not update some of the metadata straight away when changing song which lead to incorrect duration time calculations.

**Note**: This **was** working on the v2.3.x branch but does not appear to work in master, even without my changes. It doesn't detect that a song is playing.