### PR TITLE
Remove genre with 【 】 from YouTube

### DIFF
--- a/src/core/content/util.js
+++ b/src/core/content/util.js
@@ -24,7 +24,7 @@ const Util = {
 		}
 
 		// Remove [genre] or 【genre】 from the beginning of the title
-		let title = videoTitle.replace(/^(\[[^\]]+(\]))|(【[^】]+】)\s*-*\s*/i, '');
+		let title = videoTitle.replace(/^(\[[^\]]+\])|(【[^】]+】)\s*-*\s*/i, '');
 
 		let { artist, track } = this.splitArtistTrack(title);
 		if (artist === null && track === null) {

--- a/src/core/content/util.js
+++ b/src/core/content/util.js
@@ -23,8 +23,8 @@ const Util = {
 			return this.makeEmptyArtistTrack();
 		}
 
-		// Remove [genre] from the beginning of the title
-		let title = videoTitle.replace(/^\[[^\]]+\]\s*-*\s*/i, '');
+		// Remove [genre] or 【genre】 from the beginning of the title
+		let title = videoTitle.replace(/^(\[[^\]]+(\]))|(【[^】]+】)\s*-*\s*/i, '');
 
 		let { artist, track } = this.splitArtistTrack(title);
 		if (artist === null && track === null) {

--- a/src/core/content/util.js
+++ b/src/core/content/util.js
@@ -24,7 +24,7 @@ const Util = {
 		}
 
 		// Remove [genre] or 【genre】 from the beginning of the title
-		let title = videoTitle.replace(/^(\[[^\]]+\])|(【[^】]+】)\s*-*\s*/i, '');
+		let title = videoTitle.replace(/^((\[[^\]]+\])|(【[^】]+】))\s*-*\s*/i, '');
 
 		let { artist, track } = this.splitArtistTrack(title);
 		if (artist === null && track === null) {

--- a/tests/core/util.js
+++ b/tests/core/util.js
@@ -163,6 +163,10 @@ const PROCESS_YOUTUBE_TITLE_DATA = [{
 	description: 'should remove [genre] from the beginning of the title',
 	source: '[Genre] Artist - Track',
 	expected: { artist: 'Artist', track: 'Track' },
+},{
+	description: 'should remove 【genre】 from the beginning of the title',
+	source: '【Genre】 Artist - Track',
+	expected: { artist: 'Artist', track: 'Track' },
 }, {
 	description: 'should process text string w/o separators',
 	source: 'Artist "Track"',

--- a/tests/core/util.js
+++ b/tests/core/util.js
@@ -163,7 +163,7 @@ const PROCESS_YOUTUBE_TITLE_DATA = [{
 	description: 'should remove [genre] from the beginning of the title',
 	source: '[Genre] Artist - Track',
 	expected: { artist: 'Artist', track: 'Track' },
-},{
+}, {
 	description: 'should remove 【genre】 from the beginning of the title',
 	source: '【Genre】 Artist - Track',
 	expected: { artist: 'Artist', track: 'Track' },


### PR DESCRIPTION
Old xKito videos still have those weird brackets. I have been using this change locally for about a year now.