### PR TITLE
Update amazon music's get artist selector.

### DIFF
--- a/src/connectors/amazon.js
+++ b/src/connectors/amazon.js
@@ -5,7 +5,7 @@ const filter = new MetadataFilter({ album: MetadataFilter.decodeHtmlEntities });
 Connector.playerSelector = '#dragonflyTransport .rightSide';
 
 Connector.getArtist = () => {
-	return $('.trackInfoContainer .trackArtist a').attr('title');
+	return $('.trackInfoContainer .trackArtist a, .trackInfoContainer .trackArtist span').attr('title');
 };
 
 Connector.trackSelector = '.trackInfoContainer .trackTitle';


### PR DESCRIPTION
This PR fixes #1587.  

`getArtist` in amazon's connector is looking for `.trackInfoContainer .trackArtist a`, instead its  `.trackInfoContainer .trackArtist span`  in case of `music.amazon.in`.