### PR TITLE
Fix getAlbum for archive.org connector

### DIFF
--- a/src/connectors/archive.js
+++ b/src/connectors/archive.js
@@ -47,7 +47,7 @@ function bindNew() {
 	};
 
 	Connector.getAlbum = () => {
-		return $('.thats-left > h1').contents()[2].textContent;
+		return $('.thats-left > h1 [itemprop=name]').text();
 	};
 }
 


### PR DESCRIPTION
Connector for archive.org stopped grabbing the album name.  Simple change now grabs the album name again.  