### PR TITLE
SiriusXM Player: Updated connector to match new site design

### DIFF
--- a/src/connectors/siriusxm-player.js
+++ b/src/connectors/siriusxm-player.js
@@ -2,10 +2,12 @@
 
 Connector.playerSelector = '.sxm-player-controls';
 
-Connector.artistSelector = '.artist-name';
+Connector.artistSelector = '.sxm-player-controls .artist-name';
 
-Connector.trackSelector = '.track-name';
+Connector.trackSelector = '.sxm-player-controls .track-name';
 
-Connector.playButtonSelector = '.play-pause-btn';
+Connector.isPlaying = () => {
+	return $('.sxm-player-controls .play-pause-btn').attr('title') === 'Pause';
+};
 
 Connector.trackArtSelector = '.album-image-cell img';

--- a/src/connectors/siriusxm-player.js
+++ b/src/connectors/siriusxm-player.js
@@ -1,9 +1,11 @@
 'use strict';
 
-Connector.playerSelector = '#mainRow';
+Connector.playerSelector = '.sxm-player-controls';
 
-Connector.artistTrackSelector = '.np-track-artist';
+Connector.artistSelector = '.artist-name';
 
-Connector.playButtonSelector = '.play .RegularPlay01';
+Connector.trackSelector = '.track-name';
 
-Connector.trackArtSelector = '.np-track-art img';
+Connector.playButtonSelector = '.play-pause-btn';
+
+Connector.trackArtSelector = '.album-image-cell img';


### PR DESCRIPTION
Fixes issue https://github.com/web-scrobbler/web-scrobbler/issues/1616.

Updates the selectors and `isPlaying()` function to match new SiriusXM player web app design. 
Built and tested locally, scrobbles ok now.