### PR TITLE
Remove double title from track names on Deezer

### DIFF
--- a/src/connectors/deezer.js
+++ b/src/connectors/deezer.js
@@ -15,6 +15,6 @@ Connector.durationSelector = '.player-progress .progress-length';
 
 Connector.trackArtSelector = '.player-cover img';
 
-Connector.filter = MetadataFilter.getRemasteredFilter();
+Connector.filter = MetadataFilter.getRemasteredFilter().extend(MetadataFilter.getDoubleTitleFilter());
 
 Connector.isPlaying = () => $('#player .svg-icon-pause').length > 0;

--- a/src/core/content/filter.js
+++ b/src/core/content/filter.js
@@ -356,6 +356,29 @@ class MetadataFilter {
 			album: MetadataFilter.removeRemastered
 		});
 	}
+
+	/**
+	 * "REAL_TITLE : REAL_TILE" -> "REAL_TITLE"
+	 * @param  {String} text String to be filtered
+	 * @return {String} Filtered string
+	 */
+	static removeDoubleTitle(text) {
+		const splitted = text.split(' : ');
+		if (splitted.length !== 2 || splitted[0] !== splitted[1]) {
+			return text;
+		}
+		return splitted[0];
+	}
+
+	/**
+	 * Get predefined filter object that uses 'removeDoubleTitle' function.
+	 * @return {MetadataFilter} Filter object
+	 */
+	static getDoubleTitleFilter() {
+		return new MetadataFilter({
+			track: MetadataFilter.removeDoubleTitle,
+		});
+	}
 }
 
 /**

--- a/tests/core/filter.js
+++ b/tests/core/filter.js
@@ -354,6 +354,24 @@ const REMOVE_ZERO_WIDTH_TEST_DATA = [{
 	expected: 'String'
 }];
 
+const REMOVE_DOUBLE_TITLE_TEST_DATA = [{
+	description: 'should do nothing when separated strings are different',
+	source: 'Some data : another data',
+	expected: 'Some data : another data'
+}, {
+	description: 'should do nothing when separator was not found',
+	source: 'Some Track title with colon: but without separator',
+	expected: 'Some Track title with colon: but without separator'
+}, {
+	description: 'should remove double title',
+	source: 'Some track name With double title : Some track name With double title',
+	expected: 'Some track name With double title'
+}, {
+	description: 'should do nothing when there are more than one separator',
+	source: 'this is weird : this is weird : this is weird',
+	expected: 'this is weird : this is weird : this is weird'
+}];
+
 /**
  * Filters data is an array of objects. Each object must contain
  * four fields: 'description', 'filter', 'fields' and 'testData'.
@@ -400,6 +418,11 @@ const FILTERS_DATA = [{
 	}).extend(MetadataFilter.getTrimFilter()),
 	fields: ['artist', 'track', 'album'],
 	testData: EXTENDED_FILTER_TEST_DATA,
+}, {
+	description: 'removeDoubleTitle',
+	filter: new MetadataFilter({ track: MetadataFilter.removeDoubleTitle }),
+	fields: ['track'],
+	testData: REMOVE_DOUBLE_TITLE_TEST_DATA,
 }];
 
 /**


### PR DESCRIPTION
Add metadata filter that makes "REAL_TITLE : REAL_TITLE" become REAL_TITLE on
Deezer.

Examples:
https://www.deezer.com/en/album/12589906
https://www.deezer.com/en/album/13568363