### PR TITLE
Implement basic YT Music connector.

### DIFF
--- a/src/connectors/youtube-music.js
+++ b/src/connectors/youtube-music.js
@@ -22,8 +22,8 @@ Connector.isPlaying = () => {
 	return $('.ytmusic-player-bar.play-pause-button').attr('title') === 'Pause';
 };
 
-let separateArtist = byline => byline.split('•')[0];
-let separateAlbum = byline => byline.split('•')[1];
+let separateArtist = (byline) => byline.split('•')[0];
+let separateAlbum = (byline) => byline.split('•')[1];
 
 const filter = new MetadataFilter({
 	artist: separateArtist,

--- a/src/connectors/youtube-music.js
+++ b/src/connectors/youtube-music.js
@@ -1,0 +1,32 @@
+'use strict';
+
+Connector.playerSelector = 'ytmusic-player-bar';
+
+Connector.getTrackArt = () => {
+	let trackArtUrl = $('.ytmusic-player-bar.image').attr('src');
+	if (trackArtUrl) {
+		return trackArtUrl.substring(0, trackArtUrl.lastIndexOf('='));
+	}
+	return null;
+};
+
+Connector.artistSelector = '.ytmusic-player-bar.byline';
+
+Connector.trackSelector = '.ytmusic-player-bar.title';
+
+Connector.albumSelector = '.ytmusic-player-bar.byline';
+
+Connector.timeInfoSelector = '.ytmusic-player-bar.time-info';
+
+Connector.isPlaying = () => {
+	return $('.ytmusic-player-bar.play-pause-button').attr('title') === 'Pause';
+};
+
+let separateArtist = byline => byline.split('•')[0];
+let separateAlbum = byline => byline.split('•')[1];
+
+const filter = new MetadataFilter({
+	artist: separateArtist,
+	album: separateAlbum
+});
+Connector.applyFilter(filter);

--- a/src/connectors/youtube-music.js
+++ b/src/connectors/youtube-music.js
@@ -10,23 +10,12 @@ Connector.getTrackArt = () => {
 	return null;
 };
 
-Connector.artistSelector = '.ytmusic-player-bar.byline';
+Connector.artistSelector = 'ytmusic-player-queue-item[selected] .byline';
 
-Connector.trackSelector = '.ytmusic-player-bar.title';
-
-Connector.albumSelector = '.ytmusic-player-bar.byline';
+Connector.trackSelector = 'ytmusic-player-queue-item[selected] .song-title';
 
 Connector.timeInfoSelector = '.ytmusic-player-bar.time-info';
 
 Connector.isPlaying = () => $('.ytmusic-player-bar.play-pause-button').attr('title') === 'Pause';
 
 Connector.isScrobblingAllowed = () => $('.ytmusic-player-bar.advertisement').is(':hidden');
-
-let separateArtist = (byline) => byline.split('•')[0];
-let separateAlbum = (byline) => byline.split('•')[1];
-
-const filter = new MetadataFilter({
-	artist: separateArtist,
-	album: separateAlbum
-});
-Connector.applyFilter(filter);

--- a/src/connectors/youtube-music.js
+++ b/src/connectors/youtube-music.js
@@ -18,9 +18,9 @@ Connector.albumSelector = '.ytmusic-player-bar.byline';
 
 Connector.timeInfoSelector = '.ytmusic-player-bar.time-info';
 
-Connector.isPlaying = () => {
-	return $('.ytmusic-player-bar.play-pause-button').attr('title') === 'Pause';
-};
+Connector.isPlaying = () => $('.ytmusic-player-bar.play-pause-button').attr('title') === 'Pause';
+
+Connector.isScrobblingAllowed = () => $('.ytmusic-player-bar.advertisement').length > 0;
 
 let separateArtist = (byline) => byline.split('•')[0];
 let separateAlbum = (byline) => byline.split('•')[1];

--- a/src/connectors/youtube-music.js
+++ b/src/connectors/youtube-music.js
@@ -20,7 +20,7 @@ Connector.timeInfoSelector = '.ytmusic-player-bar.time-info';
 
 Connector.isPlaying = () => $('.ytmusic-player-bar.play-pause-button').attr('title') === 'Pause';
 
-Connector.isScrobblingAllowed = () => $('.ytmusic-player-bar.advertisement').length > 0;
+Connector.isScrobblingAllowed = () => $('.ytmusic-player-bar.advertisement').is(':hidden');
 
 let separateArtist = (byline) => byline.split('•')[0];
 let separateAlbum = (byline) => byline.split('•')[1];

--- a/src/connectors/youtube-music.js
+++ b/src/connectors/youtube-music.js
@@ -19,3 +19,5 @@ Connector.timeInfoSelector = '.ytmusic-player-bar.time-info';
 Connector.isPlaying = () => $('.ytmusic-player-bar.play-pause-button').attr('title') === 'Pause';
 
 Connector.isScrobblingAllowed = () => $('.ytmusic-player-bar.advertisement').is(':hidden');
+
+Connector.filter = MetadataFilter.getYoutubeFilter();

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1203,5 +1203,9 @@ define(function() {
 		label: 'Zachary Seguin Music',
 		matches: ['*://music.zacharyseguin.ca/*'],
 		js: ['connectors/musickit.js'],
+	}, {
+		label: 'YouTube Music',
+		matches: ['*://music.youtube.com/*'],
+		js: ['connectors/youtube-music.js'],
 	}];
 });

--- a/tests/connectors/youtube-music.js
+++ b/tests/connectors/youtube-music.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = function(driver, connectorSpec) {
+	connectorSpec.shouldBehaveLikeMusicSite(driver, {
+		url: 'https://music.youtube.com/watch?v=MyZ4nrqYYDE',
+		playButtonSelector: '.ytmusic-player-bar.play-pause-button'
+	});
+};


### PR DESCRIPTION
See #1641 

I've deliberately waited to add tests because this is incomplete. The way YT has set up this new page is a bit strange. On the upside, the elements don't move around as you navigate so we can lock onto the bar. However, now-playing status and artist/album splitting are based on hardcoding strings at the moment. Now-playing especially may not work in non-English locales. Also the way artists are handled is a little weird, features get put in the artist field on the page but are also included in track titles. Since artists are hyperlinked it is possible to pull apart the main artist from their features, but I have not done so at this point.

TL;DR: No tests yet, C+C accepted and encouraged!