### PR TITLE
Implement Apple MusicKit JS connector

### DIFF
--- a/src/connectors/musickit-dom-inject.js
+++ b/src/connectors/musickit-dom-inject.js
@@ -1,0 +1,44 @@
+'use strict';
+
+/**
+ * This script runs in the context of the player page to access the MusicKit
+ * global. It listens to events directly from the player and propagates these
+ * events to the extension via 'postMessage'.
+ */
+if (window.MusicKit) {
+	addEventListeners();
+} else {
+	document.addEventListener('musickitloaded', addEventListeners);
+}
+
+function addEventListeners() {
+	const Events = window.MusicKit.Events;
+	player().addEventListener(Events.metadataDidChange, sendEvent);
+	player().addEventListener(Events.playbackStateDidChange, sendEvent);
+}
+
+function player() {
+	return window.MusicKit.getInstance().player;
+}
+
+function sendEvent() {
+	window.postMessage({
+		sender: 'web-scrobbler',
+		type: 'MUSICKIT_STATE',
+		state: getState(),
+	}, '*');
+}
+
+function getState() {
+	const item = player().nowPlayingItem;
+	return {
+		albumName: item.albumName,
+		artistName: item.artistName,
+		artworkURL: item.artworkURL,
+		title: item.title,
+		duration: player().currentPlaybackDuration,
+		currentTime: player().currentPlaybackTime,
+		isPlaying: player().isPlaying,
+		id: item.id,
+	};
+}

--- a/src/connectors/musickit.js
+++ b/src/connectors/musickit.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/** Connector for Apple's MusicKit JS. */
+let state = {};
+
+Connector.getArtist = () => state.artistName;
+Connector.getTrack = () => state.title;
+Connector.getAlbum = () => state.albumName;
+Connector.getDuration = () => state.duration;
+Connector.getCurrentTime = () => state.currentTime;
+Connector.getRemainingTime =
+		() => Connector.getDuration() - Connector.getCurrentTime();
+Connector.getUniqueID = () => state.id;
+Connector.isPlaying = () => state.isPlaying;
+Connector.getTrackArt = () => state.artworkURL;
+
+Connector.onScriptEvent = (e) => {
+	switch (e.data.type) {
+		case 'MUSICKIT_STATE':
+			state = e.data.state;
+			Connector.onStateChanged();
+			break;
+		default:
+			break;
+	}
+};
+
+Connector.injectScript('connectors/musickit-dom-inject.js');

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1191,5 +1191,9 @@ define(function() {
 		label: 'Hotmixradio.fr',
 		matches: ['*://hotmixradio.fr/*', '*://www.hotmixradio.fr/*'],
 		js: ['connectors/hotmixradio.js'],
+	}, {
+		label: 'Zachary Seguin Music',
+		matches: ['*://music.zacharyseguin.ca/*'],
+		js: ['connectors/musickit.js'],
 	}];
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,6 +15,7 @@
 
   "web_accessible_resources": [
     "icons/icon128.png",
+    "connectors/musickit-dom-inject.js",
     "connectors/soundcloud-dom-inject.js",
     "connectors/vk-dom-inject.js"
   ],

--- a/tests/connectors/musickit.js
+++ b/tests/connectors/musickit.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = function(driver, connectorSpec) {
+	connectorSpec.shouldBehaveLikeMusicSite(driver, {
+		url: 'https://music.zacharyseguin.ca/recommendations'
+	});
+};


### PR DESCRIPTION
Inject script reads directly from the MusicKit global and postMessages back to the connector. Should work for any site using MusicKit JS for playback.

Added support for Zachary Seguin Music (https://music.zacharyseguin.ca)