### PR TITLE
Account for TIDAL redesign.

### DIFF
--- a/src/connectors/tidal.js
+++ b/src/connectors/tidal.js
@@ -1,15 +1,19 @@
 'use strict';
 
-Connector.playerSelector = '#player';
+Connector.playerSelector = '[class^="nowPlaying"]';
 
-Connector.trackArtSelector = '.js-footer-player-image';
+Connector.playButtonSelector = `${Connector.playerSelector} [class^="playbackToggle"]`;
 
-Connector.trackSelector = `${Connector.playerSelector} [data-bind="title"]`;
+Connector.isScrobblingAllowed = () => !!$(Connector.playButtonSelector);
 
-Connector.artistSelector = `${Connector.playerSelector} [data-bind="artist"] a:first`;
+Connector.isPlaying = () => $(Connector.playButtonSelector).attr('data-test-id') === 'pause';
 
-Connector.playButtonSelector = `${Connector.playerSelector} .play-controls__play`;
+Connector.trackSelector = `${Connector.playerSelector} [class^="mediaInformation"] span:eq(0)`;
 
-Connector.currentTimeSelector = '.js-progress';
+Connector.artistSelector = `${Connector.playerSelector} [class^="mediaArtists"]`;
 
-Connector.durationSelector = '.js-duration';
+Connector.trackArtSelector = `${Connector.playerSelector} [class^="mediaImageryTrack"] img`;
+
+Connector.currentTimeSelector = `${Connector.playerSelector} [data-test-id="duration"] [class^="currentTime"]`;
+
+Connector.durationSelector = `${Connector.playerSelector} [data-test-id="duration"] [class^="duration"]`;


### PR DESCRIPTION
Redesign seemed to roll in late last week.

data-test-id attributes are probably less than ideal but until I absolutely
have to use string matches on class attributes I will not do so.

I tried to follow the old structure as much as possible; Not totally sure why
the duration and album art are not restricted to the player selector.