### PR TITLE
Fixes FIP title and album

### DIFF
--- a/src/connectors/fipradio.js
+++ b/src/connectors/fipradio.js
@@ -6,9 +6,9 @@ Connector.playerSelector = '#player-playing';
 
 Connector.artistSelector = '#player-playing .author .name';
 
-Connector.trackSelector = '#player-playing .title';
+Connector.trackSelector = '#player-playing div.playing-info > div.infos > div.rows-container > div.title';
 
-Connector.albumSelector = '#player-playing .album';
+Connector.albumSelector = '#player-playing div.playing-info > div.infos > div.rows-container > div.album > span.name';
 
 Connector.trackArtSelector = '#player-playing .player_img';
 


### PR DESCRIPTION
The track and album selectors for FIP returned multiple elements, which meant the track and album were always wrong. This change ensures that only a single element, containing the title/album is selected.