### PR TITLE
Added one regex to the removeRemastered-filter

### DIFF
--- a/src/core/content/filter.js
+++ b/src/core/content/filter.js
@@ -141,7 +141,7 @@ class MetadataFilter {
 	}
 
 	/**
- 	 * Predefined filter functions.
+	 * Predefined filter functions.
 	 */
 
 	/**
@@ -319,6 +319,9 @@ class MetadataFilter {
 			{ source: /\(Live\s\/\sRemastered\)$/i, target: '' },
 			// Ticket To Ride - Live / Remastered
 			{ source: /-\sLive\s\/\sRemastered$/, target: '' },
+			// Mothership (Remastered)
+			// How The West Was Won [Remastered]
+			{ source: /[([]Remastered[)\]]$/, target: '' },
 		];
 	}
 

--- a/tests/core/filter.js
+++ b/tests/core/filter.js
@@ -286,6 +286,14 @@ const REMASTERED_TEST_DATA = [{
 	description: 'should remove "- YYYY Remastered Version" string',
 	source: 'Track Title - 2011 Remastered Version',
 	expected: 'Track Title'
+}, {
+	description: 'should remove "(Remastered)" string',
+	source: 'Track Title (Remastered)',
+	expected: 'Track Title'
+}, {
+	description: 'should remove "[Remastered]" string',
+	source: 'Track Title [Remastered]',
+	expected: 'Track Title'
 }];
 
 /**


### PR DESCRIPTION
I noticed the other day that the deezer connector is using the removeRemastered filter and now I was wondering why on some very common occurrences the Remastered-string is not removed. To fix this I've added a regex that matches (Remastered) and [Remastered]  at the end of the string.

The deezer search for 'Remastered' is showing me 300 albums from which >100 have just (Remastered) or [Remastered] at the end of their titles. So I think this is a worthwhile addition.


First I'd added a regex that matches Remastered with any additional text inside of rounded or square braces. This would match even ~70 more albums out of this 300 that are unmatched by the existing filter. However, there are a couple of examples (~15), like "Urban Hymns (Super Deluxe / Remastered 2016)", where Super Deluxe indicates a special edition with additional songs. And I'm unsure if it is desirable to remove this.
