### PR TITLE
Use a DOM-injcted file for deezer.com for better data 

### DIFF
--- a/src/connectors/deezer-dom-inject.js
+++ b/src/connectors/deezer-dom-inject.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const DEEZER_MAIN_ARTIST = '0';
-const DEEZER_FEATURED_ARTIST = '5';
-
 initConnector();
 
 function initConnector() {
@@ -39,69 +36,17 @@ function getState() {
 	const item = player.getCurrentSong();
 
 	return {
-		artist: lastfmifyArtists(item),
-		title: lastfmifyTitle(item),
+		artist: item.ART_NAME,
+		title: item.SNG_TITLE,
 		album: item.ALB_TITLE,
 		duration: player.getDuration(),
 		currentTime: player.getPosition(),
 		uniqueId: item.SNG_ID,
 		isPlaying: player.isPlaying(),
-		trackArt: getTrackArt(item.ALB_PICTURE),
-		artists: item.ARTISTS
+		trackArt: getTrackArt(item.ALB_PICTURE)
 	};
 }
 
 function getTrackArt(pic) {
 	return `https://e-cdns-images.dzcdn.net/images/cover/${pic}/264x264-000000-80-0-0.jpg`;
-}
-
-function lastfmifyArtists(item) {
-	let artists = item.ARTISTS;
-	artists = getArtistsnamesByRole(item, DEEZER_MAIN_ARTIST);
-	if (artists.length <= 1) {
-		return item.ART_NAME;
-	}
-
-	return getArtistsList(artists);
-}
-
-function lastfmifyTitle(item) {
-	let title = item.SNG_TITLE;
-	if (item.VERSION !== '') {
-		title = `${title} ${item.VERSION}`;
-	}
-
-	// don't add featured artists from the item object to the title
-	// if there is already feature information included
-	if (title.search(/\s[([]?[f|F](eat\.|eaturing)\s([^ ]+)/i) !== -1) {
-		return title;
-	}
-
-	let artists = getArtistsnamesByRole(item, DEEZER_FEATURED_ARTIST);
-	if (artists.length === 0) {
-		return title;
-	}
-
-	return `${title} (feat. ${getArtistsList(artists)})`;
-}
-
-function getArtistsnamesByRole(item, roleId) {
-	return item.ARTISTS.filter((a) => a.ROLE_ID === roleId) // 0: main artist; 5: featured artist
-		.sort((a, b) => a.ARTISTS_SONG_ORDER < b.ARTISTS_SONG_ORDER) // respect ordering
-		.map((a) => a.ART_NAME) // array of artistnames from array of items
-		.filter(removeDuplicateArtists);
-}
-
-function removeDuplicateArtists(artist, index, artists) {
-	// make sure an artistname is not a comma- or ampersand-seperated list
-	// of artistnames which are already included in the artists array
-	let dupes = artist.split(/\s&\s|\sand\s/i);
-	return dupes.length === 1 || !dupes.every((a) => artists.includes(a));
-}
-
-function getArtistsList(artists) {
-	// concat artists with ',' but last artist with '&'
-	return artists.reduce(function concatArtists(string, artist, index, arr) {
-		return string + (arr.length === index + 1 ? ' & ' : ', ') + artist;
-	});
 }

--- a/src/connectors/deezer-dom-inject.js
+++ b/src/connectors/deezer-dom-inject.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const DEEZER_MAIN_ARTIST = '0';
+const DEEZER_FEATURED_ARTIST = '5';
+
 initConnector();
 
 function initConnector() {
@@ -53,9 +56,8 @@ function getTrackArt(pic) {
 }
 
 function lastfmifyArtists(item) {
-
 	let artists = item.ARTISTS;
-	artists = getArtistsnamesByRole(item, '0'); // main artists only
+	artists = getArtistsnamesByRole(item, DEEZER_MAIN_ARTIST);
 	if (artists.length <= 1) {
 		return item.ART_NAME;
 	}
@@ -75,7 +77,7 @@ function lastfmifyTitle(item) {
 		return title;
 	}
 
-	let artists = getArtistsnamesByRole(item, '5'); // featured artists only
+	let artists = getArtistsnamesByRole(item, DEEZER_FEATURED_ARTIST);
 	if (artists.length === 0) {
 		return title;
 	}
@@ -84,14 +86,13 @@ function lastfmifyTitle(item) {
 }
 
 function getArtistsnamesByRole(item, roleId) {
-
 	return item.ARTISTS.filter((a) => a.ROLE_ID === roleId) // 0: main artist; 5: featured artist
 		.sort((a, b) => a.ARTISTS_SONG_ORDER < b.ARTISTS_SONG_ORDER) // respect ordering
-		.map((a) => a.ART_NAME) // array of artistnames from arry of items
-		.filter(removeDublicateArtists);
+		.map((a) => a.ART_NAME) // array of artistnames from array of items
+		.filter(removeDuplicateArtists);
 }
 
-function removeDublicateArtists(artist, index, artists) {
+function removeDuplicateArtists(artist, index, artists) {
 	// make sure an artistname is not a comma- or ampersand-seperated list
 	// of artistnames which are already included in the artists array
 	let dupes = artist.split(/\s&\s|\sand\s/i);

--- a/src/connectors/deezer-dom-inject.js
+++ b/src/connectors/deezer-dom-inject.js
@@ -1,20 +1,29 @@
 'use strict';
 
-if (window.dzPlayer) {
-	addEventListeners();
-} else {
-	document.addEventListener('Events.player.playerLoaded', addEventListeners);
-}
+initConnector();
 
-document.addEventListener('Events.player.playerLoaded', addEventListeners);
+function initConnector() {
+	let retries = 0;
+	if (window.dzPlayer && window.Events) {
+		addEventListeners();
+	} else if (retries < 6) {
+		window.setTimeout(function() {
+			initConnector();
+			retries++;
+		}, 1007);
+	} else {
+		console.log('web-scrobbler: Failed to initialize deezer connector!');
+	}
+}
 
 function addEventListeners() {
-	Events.subscribe(Events.player.play, sendEvent);
-	Events.subscribe(Events.player.paused, sendEvent);
-	Events.subscribe(Events.player.resume, sendEvent);
+	const ev = window.Events;
+	ev.subscribe(ev.player.play, sendEvent);
+	ev.subscribe(ev.player.paused, sendEvent);
+	ev.subscribe(ev.player.resume, sendEvent);
 }
 
-function sendEvent(e) {
+function sendEvent() {
 	window.postMessage({
 		sender: 'web-scrobbler',
 		type: 'DEEZER_STATE',
@@ -23,16 +32,17 @@ function sendEvent(e) {
 }
 
 function getState() {
-	const item = dzPlayer.getCurrentSong();
+	const player = window.dzPlayer;
+	const item = player.getCurrentSong();
 
 	return {
-		artist: item.ART_NAME,
-		title: item.SNG_TITLE,
+		artist: lastfmifyArtists(item),
+		title: lastfmifyTitle(item),
 		album: item.ALB_TITLE,
-		duration: dzPlayer.getDuration(),
-		currentTime: dzPlayer.getPosition(),
+		duration: player.getDuration(),
+		currentTime: player.getPosition(),
 		uniqueId: item.SNG_ID,
-		isPlaying: dzPlayer.isPlaying(),
+		isPlaying: player.isPlaying(),
 		trackArt: getTrackArt(item.ALB_PICTURE),
 		artists: item.ARTISTS
 	};
@@ -40,4 +50,57 @@ function getState() {
 
 function getTrackArt(pic) {
 	return `https://e-cdns-images.dzcdn.net/images/cover/${pic}/264x264-000000-80-0-0.jpg`;
+}
+
+function lastfmifyArtists(item) {
+
+	let artists = item.ARTISTS;
+	artists = getArtistsnamesByRole(item, '0'); // main artists only
+	if (artists.length <= 1) {
+		return item.ART_NAME;
+	}
+
+	return getArtistsList(artists);
+}
+
+function lastfmifyTitle(item) {
+	let title = item.SNG_TITLE;
+	if (item.VERSION !== '') {
+		title = `${title} ${item.VERSION}`;
+	}
+
+	// don't add featured artists from the item object to the title
+	// if there is already feature information included
+	if (title.search(/\s[([]?[f|F](eat\.|eaturing)\s([^ ]+)/i) !== -1) {
+		return title;
+	}
+
+	let artists = getArtistsnamesByRole(item, '5'); // featured artists only
+	if (artists.length === 0) {
+		return title;
+	}
+
+	return `${title} (feat. ${getArtistsList(artists)})`;
+}
+
+function getArtistsnamesByRole(item, roleId) {
+
+	return item.ARTISTS.filter((a) => a.ROLE_ID === roleId) // 0: main artist; 5: featured artist
+		.sort((a, b) => a.ARTISTS_SONG_ORDER < b.ARTISTS_SONG_ORDER) // respect ordering
+		.map((a) => a.ART_NAME) // array of artistnames from arry of items
+		.filter(removeDublicateArtists);
+}
+
+function removeDublicateArtists(artist, index, artists) {
+	// make sure an artistname is not a comma- or ampersand-seperated list
+	// of artistnames which are already included in the artists array
+	let dupes = artist.split(/\s&\s|\sand\s/i);
+	return dupes.length === 1 || !dupes.every((a) => artists.includes(a));
+}
+
+function getArtistsList(artists) {
+	// concat artists with ',' but last artist with '&'
+	return artists.reduce(function concatArtists(string, artist, index, arr) {
+		return string + (arr.length === index + 1 ? ' & ' : ', ') + artist;
+	});
 }

--- a/src/connectors/deezer-dom-inject.js
+++ b/src/connectors/deezer-dom-inject.js
@@ -1,0 +1,43 @@
+'use strict';
+
+if (window.dzPlayer) {
+	addEventListeners();
+} else {
+	document.addEventListener('Events.player.playerLoaded', addEventListeners);
+}
+
+document.addEventListener('Events.player.playerLoaded', addEventListeners);
+
+function addEventListeners() {
+	Events.subscribe(Events.player.play, sendEvent);
+	Events.subscribe(Events.player.paused, sendEvent);
+	Events.subscribe(Events.player.resume, sendEvent);
+}
+
+function sendEvent(e) {
+	window.postMessage({
+		sender: 'web-scrobbler',
+		type: 'DEEZER_STATE',
+		state: getState()
+	}, '*');
+}
+
+function getState() {
+	const item = dzPlayer.getCurrentSong();
+
+	return {
+		artist: item.ART_NAME,
+		title: item.SNG_TITLE,
+		album: item.ALB_TITLE,
+		duration: dzPlayer.getDuration(),
+		currentTime: dzPlayer.getPosition(),
+		uniqueId: item.SNG_ID,
+		isPlaying: dzPlayer.isPlaying(),
+		trackArt: getTrackArt(item.ALB_PICTURE),
+		artists: item.ARTISTS
+	};
+}
+
+function getTrackArt(pic) {
+	return `https://e-cdns-images.dzcdn.net/images/cover/${pic}/264x264-000000-80-0-0.jpg`;
+}

--- a/src/connectors/deezer.js
+++ b/src/connectors/deezer.js
@@ -1,71 +1,28 @@
 'use strict';
 
-setupConnector();
+let state = {};
 
-function setupConnector() {
-	if (isNewDeezer()) {
-		setupNewDeezer();
-	} else {
-		setupOldDeezer();
+Connector.getArtist = () => state.artist;
+Connector.getTrack = () => state.title;
+Connector.getAlbum = () => state.album;
+Connector.getDuration = () => state.duration;
+Connector.getCurrentTime = () => state.currentTime;
+Connector.getRemainingTime = () => state.duration - state.currentTime;
+Connector.getUniqueID = () => state.uniqueId;
+Connector.isPlaying = () => state.isPlaying;
+Connector.getTrackArt = () => state.trackArt;
+
+Connector.filter = MetadataFilter.getRemasteredFilter().extend(MetadataFilter.getDoubleTitleFilter());
+
+Connector.onScriptEvent = (e) => {
+	switch (e.data.type) {
+	case 'DEEZER_STATE':
+		state = e.data.state;
+		Connector.onStateChanged();
+		break;
+	default:
+		break;
 	}
-	Connector.filter = MetadataFilter.getRemasteredFilter().extend(MetadataFilter.getDoubleTitleFilter());
 }
 
-function isNewDeezer() {
-	return $('body').hasClass('electron-ui');
-}
-
-function setupNewDeezer() {
-	Connector.playerSelector = 'div#page_player';
-
-	Connector.getArtist = () => {
-		let artists;
-		if ($('div.track-title').length > 0) { // from player
-			artists = $('div.track-title a.track-link').toArray();
-			artists.shift();
-		} else { // from open queuelist
-			artists = $('div.queuelist-cover-subtitle a.queuelist-cover-link').toArray();
-		}
-		return Util.joinArtists(artists);
-	};
-
-	Connector.getTrack = () => {
-		let track;
-		if ($('div.track-title').length > 0) { // from player
-			track = $('div.track-title a.track-link:eq(0)').text();
-		} else { // from open queuelist
-			track = $('div.queuelist-cover-title a.queuelist-cover-link').text();
-		}
-		return track;
-	};
-
-	Connector.currentTimeSelector = '.slider-counter.slider-counter-current';
-
-	Connector.durationSelector = '.slider-counter.slider-counter-max';
-
-	Connector.getTrackArt = () => {
-		let trackArtUrl = $('button.queuelist .picture-img.active').attr('src');
-		return trackArtUrl.replace('/28x28-', '/264x264-');
-	};
-
-	Connector.isPlaying = () => $('.player-controls .svg-icon.svg-icon-pause').length > 0;
-}
-
-function setupOldDeezer() {
-	Connector.playerSelector = '#page_sidebar';
-
-	Connector.getArtist = () => {
-		let artists = $('.player-track-artist').children().toArray();
-		return Util.joinArtists(artists);
-	};
-
-	Connector.trackSelector = '.player-track-title';
-
-	Connector.currentTimeSelector = '.player-progress .progress-time';
-
-	Connector.durationSelector = '.player-progress .progress-length';
-
-	Connector.trackArtSelector = '.player-cover img';
-
-	Connector.isPlaying = () => $('#player .svg-icon-pause').length > 0;
-}
+Connector.injectScript('connectors/deezer-dom-inject.js');

--- a/src/connectors/deezer.js
+++ b/src/connectors/deezer.js
@@ -16,13 +16,13 @@ Connector.filter = MetadataFilter.getRemasteredFilter().extend(MetadataFilter.ge
 
 Connector.onScriptEvent = (e) => {
 	switch (e.data.type) {
-	case 'DEEZER_STATE':
-		state = e.data.state;
-		Connector.onStateChanged();
-		break;
-	default:
-		break;
+		case 'DEEZER_STATE':
+			state = e.data.state;
+			Connector.onStateChanged();
+			break;
+		default:
+			break;
 	}
-}
+};
 
 Connector.injectScript('connectors/deezer-dom-inject.js');

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,6 +15,7 @@
 
   "web_accessible_resources": [
     "icons/icon128.png",
+    "connectors/deezer-dom-inject.js",
     "connectors/musickit-dom-inject.js",
     "connectors/soundcloud-dom-inject.js",
     "connectors/vk-dom-inject.js"


### PR DESCRIPTION
After I'd adapted the deezer connector for the new layout some days ago I was not very happy with the result, so I have build this new connector which is using the internal (unofficial) deezer api. I believe this is better for various reasons:

- Not DOM-dependent, it is working out of the box with the old and the new (... and future) page layout.

- The internal api is stable since three years, probably longer.

- More complete data as the albumname and the songId (used as uniqueId) are not available in the DOM but through the api.

- The data provided by the api distinguishes between main artists and featured artists. When the old connector is submitting  an ugly list of comma-seperated artistnames, the new connecter is building a more lastm-conform representation by adding the featured artists to the title. Examples:

  old: https://www.last.fm/music/Tyler,+The+Creator,+Rex+Orange+County,+Anna+Of+The+North/_/Boredom (3899 scrobbles)
  new: https://www.last.fm/music/Tyler,+the+Creator/_/Boredom+(feat.+Rex+Orange+County+&+Anna+Of+The+North) (12.9K scrobbles)

  old: https://www.last.fm/music/Underworld,+Iggy+Pop/_/Bells+&+Circles  (317 scrobbles)
  new: https://www.last.fm/music/Underworld+&+Iggy+Pop/_/Bells+&+Circles (3664 scrobbles)

I'm using this for a week now and I'm very pleased with the results :-)

I'm not sure if the retry-loop in initConnector() is necessary, it was never executed so far. Maybe the core source is taking care that the page is ready before injecting?