### PR TITLE
Add album selector for Tidal.

### DIFF
--- a/src/connectors/tidal.js
+++ b/src/connectors/tidal.js
@@ -12,6 +12,8 @@ Connector.trackSelector = `${Connector.playerSelector} [class^="mediaInformation
 
 Connector.artistSelector = `${Connector.playerSelector} [class^="mediaArtists"]`;
 
+Connector.albumSelector = `${Connector.playerSelector} [class^="infoTable--"] a[href^="/album/"]`;
+
 Connector.trackArtSelector = `${Connector.playerSelector} [class^="mediaImageryTrack"] img`;
 
 Connector.currentTimeSelector = `${Connector.playerSelector} [data-test-id="duration"] [class^="currentTime"]`;


### PR DESCRIPTION
Only works when the maximized view is open as the album title doesn't exist
anywhere on the page otherwise. So, not perfect, but it's as close as we can
get for now.