### PR TITLE
Implement warp-aphextwin connector

### DIFF
--- a/src/connectors/warp-aphextwin.js
+++ b/src/connectors/warp-aphextwin.js
@@ -2,12 +2,19 @@
 
 Connector.playerSelector = '.player';
 
-Connector.playButtonSelector = '.track-controls .player-button.play-track';
-
 Connector.trackSelector = '.current-track .js-current-track-title';
 
 Connector.durationSelector = '.current-track .js-current-track-duration';
 
-Connector.getArtist = function() {
+Connector.currentTimeSelector = '.current-time.js-current-time';
+
+Connector.playButtonSelector = '.track-controls .js-play-track';
+
+Connector.getArtist = () => {
 	return $('.current-track .js-current-track-artist').text().replace(' - ', '');
+};
+
+Connector.getAlbum = () => {
+	let releasePath = $(Connector.trackSelector).attr('href');
+	return $(`.track-list .track-release a[href="${releasePath}"]`).attr('title');
 };

--- a/src/connectors/warp-aphextwin.js
+++ b/src/connectors/warp-aphextwin.js
@@ -1,0 +1,13 @@
+'use strict';
+
+Connector.playerSelector = '.player';
+
+Connector.playButtonSelector = '.track-controls .player-button.play-track';
+
+Connector.trackSelector = '.current-track .js-current-track-title';
+
+Connector.durationSelector = '.current-track .js-current-track-duration';
+
+Connector.getArtist = function() {
+	return $('.current-track .js-current-track-artist').text().replace(' - ', '');
+};

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1205,6 +1205,10 @@ define(function() {
 		matches: ['*://hotmixradio.fr/*', '*://www.hotmixradio.fr/*'],
 		js: ['connectors/hotmixradio.js'],
 	}, {
+		label: 'Aphex Twin',
+		matches: ['*://aphextwin.warp.net/*'],
+		js: ['connectors/warp-aphextwin.js'],
+	}, {
 		label: 'Zachary Seguin Music',
 		matches: ['*://music.zacharyseguin.ca/*'],
 		js: ['connectors/musickit.js'],

--- a/tests/connectors/warp-aphextwin.js
+++ b/tests/connectors/warp-aphextwin.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = function(driver, connectorSpec) {
+	connectorSpec.shouldBehaveLikeMusicSite(driver, {
+		url: 'https://aphextwin.warp.net/'
+	});
+};


### PR DESCRIPTION
News: https://djmag.com/news/aphex-twins-entire-warp-discography-can-now-be-streamed-free
Website: https://aphextwin.warp.net

The connector for it is quite straightforward but let me know if there is anything to change, thanks.