### PR TITLE
monstercat connector: fix artistTitle selector

### DIFF
--- a/src/connectors/monstercat.js
+++ b/src/connectors/monstercat.js
@@ -2,6 +2,6 @@
 
 Connector.playerSelector = '.controls';
 
-Connector.artistTrackSelector = '.scroll-title';
+Connector.artistTrackSelector = '.controls .scroll-title';
 
 Connector.isPlaying = () => $('.controls .fa-pause').length > 0;


### PR DESCRIPTION
on release pages, like <https://www.monstercat.com/release/MCEP140>, the artistTitle selector selects not only the currently playing track, but every title and artist name in the release

this fixes that