### PR TITLE
Implement residentadvisor connector

### DIFF
--- a/src/connectors/residentadvisor.js
+++ b/src/connectors/residentadvisor.js
@@ -2,6 +2,23 @@
 
 const domain = 'https://www.residentadvisor.net';
 
+let PLAYER_TYPES = {
+	// https://www.residentadvisor.net/tracks ("Popular tracks" at the top)
+	// https://www.residentadvisor.net/tracks/931382 ("Popular tracks" at the bottom)
+	POPULAR: 'Popular tracks',
+	// https://www.residentadvisor.net/tracks ("Archived tracks" in the middle)
+	ARCHIVED: 'Archived tracks',
+	// https://www.residentadvisor.net/tracks/931382 ("Single track" in the middle)
+	SINGLE: 'Single track',
+	// https://www.residentadvisor.net/record-label.aspx?id=15687&show=tracks (Label tracks)
+	// https://www.residentadvisor.net/dj/hotsince82/tracks (DJ tracks)
+	DJ_OR_LABEL: 'DJ tracks or label tracks',
+	// https://www.residentadvisor.net/dj/secretsundaze/top10?chart=214484 (Chart tracks)
+	CHART: 'Chart track',
+
+	UNKNOWN: 'Player not found'
+};
+
 Connector.playerSelector = '.content-list';
 
 Connector.playButtonSelector = '.controls .play';
@@ -21,41 +38,35 @@ function getTrackContainer() {
 
 function typeOfTrack(trackContainer) {
 	if ($(trackContainer).is('article')) {
-		// https://www.residentadvisor.net/tracks ("Popular tracks" at the top)
-		// https://www.residentadvisor.net/tracks/931382 ("Popular tracks" at the bottom)
-		return 'popular';
+		return PLAYER_TYPES.POPULAR;
 	}
 	if ($(trackContainer).is('ul')) {
-		// https://www.residentadvisor.net/tracks ("Archived tracks" in the middle)
-		return 'archived';
+		return PLAYER_TYPES.ARCHIVED;
 	}
 	if ($(trackContainer).is('div')) {
-		// https://www.residentadvisor.net/tracks/931382 ("Single track" in the middle)
-		return 'single';
+		return PLAYER_TYPES.SINGLE;
 	}
 	if ($(trackContainer).is('li') && $(trackContainer).parent().hasClass('tracks')) {
-		// https://www.residentadvisor.net/record-label.aspx?id=15687&show=tracks (Label tracks)
-		// https://www.residentadvisor.net/dj/hotsince82/tracks (DJ tracks)
-		return 'djOrLabel';
+		return PLAYER_TYPES.DJ_OR_LABEL;
 	}
 	if ($(trackContainer).is('li') && $(trackContainer).parent().hasClass('chart')) {
-		// https://www.residentadvisor.net/dj/secretsundaze/top10?chart=214484 (Chart tracks)
-		return 'chart';
+		return PLAYER_TYPES.CHART;
 	}
+	return PLAYER_TYPES.UNKNOWN;
 }
 
 Connector.getTrack = () => {
 	let track = getTrackContainer();
 	switch (typeOfTrack(track)) {
-		case 'popular':
+		case PLAYER_TYPES.POPULAR:
 			return Util.splitArtistTrack($(track).find('div a').text()).track;
-		case 'single':
+		case PLAYER_TYPES.SINGLE:
 			return Util.splitArtistTrack($('#sectionHead h1').text()).track;
-		case 'djOrLabel':
+		case PLAYER_TYPES.DJ_OR_LABEL:
 			return $(track).find('.title').contents().first().text();
-		case 'chart':
+		case PLAYER_TYPES.CHART:
 			return $(track).find('.track a').text();
-		case 'archived':
+		case PLAYER_TYPES.ARCHIVED:
 			return $(track).find('li:last-child .pr8 a.f24').text();
 	}
 };
@@ -63,15 +74,15 @@ Connector.getTrack = () => {
 Connector.getArtist = () => {
 	let track = getTrackContainer();
 	switch (typeOfTrack(track)) {
-		case 'popular':
+		case PLAYER_TYPES.POPULAR:
 			return Util.splitArtistTrack($(track).find('div a').text()).artist;
-		case 'single':
+		case PLAYER_TYPES.SINGLE:
 			return Util.splitArtistTrack($('#sectionHead h1').text()).artist;
-		case 'djOrLabel':
+		case PLAYER_TYPES.DJ_OR_LABEL:
 			return parseTitle($(track).find('.title'));
-		case 'chart':
+		case PLAYER_TYPES.CHART:
 			return $(track).find('.artist a').text();
-		case 'archived':
+		case PLAYER_TYPES.ARCHIVED:
 			return $(track).find('li:last-child .pr8 div.f24').first().text();
 	}
 };
@@ -96,7 +107,7 @@ function parseTitle(title) {
 	let titleWithoutTrack = contents.text().replace(track, '');
 	let artist = titleWithoutTrack.substr(3, titleWithoutTrack.length);
 	if (artist.indexOf(' on ') >= 0) {
-		// label remains i.e. " on Foo Recordings"
+		// label remains i.e. "Daft Punk on Foo Recordings"
 		artist = artist.substr(0, artist.indexOf(' on '));
 	}
 	return artist;

--- a/src/connectors/residentadvisor.js
+++ b/src/connectors/residentadvisor.js
@@ -68,6 +68,9 @@ Connector.getTrack = () => {
 			return $(track).find('.track a').text();
 		case PLAYER_TYPES.ARCHIVED:
 			return $(track).find('li:last-child .pr8 a.f24').text();
+		case PLAYER_TYPES.UNKNOWN:
+		default:
+			console.log('ResidentAdvisor connector: player not found');
 	}
 };
 
@@ -84,6 +87,9 @@ Connector.getArtist = () => {
 			return $(track).find('.artist a').text();
 		case PLAYER_TYPES.ARCHIVED:
 			return $(track).find('li:last-child .pr8 div.f24').first().text();
+		case PLAYER_TYPES.UNKNOWN:
+		default:
+			console.log('ResidentAdvisor connector: player not found');
 	}
 };
 

--- a/src/connectors/residentadvisor.js
+++ b/src/connectors/residentadvisor.js
@@ -8,96 +8,96 @@ Connector.playButtonSelector = '.controls .play';
 
 // This identifies the track element depending on the parents of the play button
 function getTrackContainer() {
-  let track;
-  // Iterate through all parents until it also finds a cover art
-  $('.play.paused').parents().each((_i, parent) => {
-    if ($(parent).find('img[src^="/images/cover/"]').length > 0) {
-      track = parent;
-      return false;
-    }
-  });
-  return track;
+	let track;
+	// Iterate through all parents until it also finds a cover art
+	$('.play.paused').parents().each((_i, parent) => {
+		if ($(parent).find('img[src^="/images/cover/"]').length > 0) {
+			track = parent;
+			return false;
+		}
+	});
+	return track;
 }
 
 function typeOfTrack(trackContainer) {
-  if ($(trackContainer).is('article')) {
-    // https://www.residentadvisor.net/tracks ("Popular tracks" at the top)
-    // https://www.residentadvisor.net/tracks/931382 ("Popular tracks" at the bottom)
-    return 'popular';
-  }
-  if ($(trackContainer).is('ul')) {
-    // https://www.residentadvisor.net/tracks ("Archived tracks" in the middle)
-    return 'archived';
-  }
-  if ($(trackContainer).is('div')) {
-    // https://www.residentadvisor.net/tracks/931382 ("Single track" in the middle)
-    return 'single';
-  }
-  if ($(trackContainer).is('li') && $(trackContainer).parent().hasClass('tracks')) {
-    // https://www.residentadvisor.net/record-label.aspx?id=15687&show=tracks (Label tracks)
-    // https://www.residentadvisor.net/dj/hotsince82/tracks (DJ tracks)
-    return 'djOrLabel';
-  }
-  if ($(trackContainer).is('li') && $(trackContainer).parent().hasClass('chart')) {
-    // https://www.residentadvisor.net/dj/secretsundaze/top10?chart=214484 (Chart tracks)
-    return 'chart';
-  }
+	if ($(trackContainer).is('article')) {
+		// https://www.residentadvisor.net/tracks ("Popular tracks" at the top)
+		// https://www.residentadvisor.net/tracks/931382 ("Popular tracks" at the bottom)
+		return 'popular';
+	}
+	if ($(trackContainer).is('ul')) {
+		// https://www.residentadvisor.net/tracks ("Archived tracks" in the middle)
+		return 'archived';
+	}
+	if ($(trackContainer).is('div')) {
+		// https://www.residentadvisor.net/tracks/931382 ("Single track" in the middle)
+		return 'single';
+	}
+	if ($(trackContainer).is('li') && $(trackContainer).parent().hasClass('tracks')) {
+		// https://www.residentadvisor.net/record-label.aspx?id=15687&show=tracks (Label tracks)
+		// https://www.residentadvisor.net/dj/hotsince82/tracks (DJ tracks)
+		return 'djOrLabel';
+	}
+	if ($(trackContainer).is('li') && $(trackContainer).parent().hasClass('chart')) {
+		// https://www.residentadvisor.net/dj/secretsundaze/top10?chart=214484 (Chart tracks)
+		return 'chart';
+	}
 }
 
 Connector.getTrack = () => {
-  let track = getTrackContainer();
-  switch(typeOfTrack(track)) {
-    case 'popular':
-      return Util.splitArtistTrack($(track).find('div a').text()).track;
-    case 'single':
-      return Util.splitArtistTrack($('#sectionHead h1').text()).track;
-    case 'djOrLabel':
-      return $(track).find('.title').contents().first().text();
-    case 'chart':
-      return $(track).find('.track a').text();
-    case 'archived':
-      return $(track).find('li:last-child .pr8 a.f24').text();
-  }
-}
+	let track = getTrackContainer();
+	switch (typeOfTrack(track)) {
+		case 'popular':
+			return Util.splitArtistTrack($(track).find('div a').text()).track;
+		case 'single':
+			return Util.splitArtistTrack($('#sectionHead h1').text()).track;
+		case 'djOrLabel':
+			return $(track).find('.title').contents().first().text();
+		case 'chart':
+			return $(track).find('.track a').text();
+		case 'archived':
+			return $(track).find('li:last-child .pr8 a.f24').text();
+	}
+};
 
 Connector.getArtist = () => {
-  let track = getTrackContainer();
-  switch(typeOfTrack(track)) {
-    case 'popular':
-      return Util.splitArtistTrack($(track).find('div a').text()).artist;
-    case 'single':
-      return Util.splitArtistTrack($('#sectionHead h1').text()).artist;
-    case 'djOrLabel':
-      return parseTitle($(track).find('.title'));
-    case 'chart':
-      return $(track).find('.artist a').text();
-    case 'archived':
-      return $(track).find('li:last-child .pr8 div.f24').first().text();
-  }
-}
+	let track = getTrackContainer();
+	switch (typeOfTrack(track)) {
+		case 'popular':
+			return Util.splitArtistTrack($(track).find('div a').text()).artist;
+		case 'single':
+			return Util.splitArtistTrack($('#sectionHead h1').text()).artist;
+		case 'djOrLabel':
+			return parseTitle($(track).find('.title'));
+		case 'chart':
+			return $(track).find('.artist a').text();
+		case 'archived':
+			return $(track).find('li:last-child .pr8 div.f24').first().text();
+	}
+};
 
 Connector.getUniqueId = () => {
-  return getTrackContainer().find('.play.player').attr('data-trackid');
-}
+	return getTrackContainer().find('.play.player').attr('data-trackid');
+};
 
 Connector.isPlaying = () => $('.play.paused').length > 0;
 
 Connector.getTrackArt = () => {
-  return 'https://www.residentadvisor.net' + $(getTrackContainer()).find('img[src^="/images/cover/"]').first().attr('src');
-}
+	return `https://www.residentadvisor.net${$(getTrackContainer()).find('img[src^="/images/cover/"]').first().attr('src')}`;
+};
 
 Connector.isTrackArtDefault = (trackArtUrl) => {
-  return trackArtUrl === domain + '/images/cover/blank.jpg'
-}
+	return trackArtUrl === `${domain}/images/cover/blank.jpg`;
+};
 
 function parseTitle(title) {
-  let contents = title.contents();
-  let track = contents.eq(0).text();
-  let titleWithoutTrack = contents.text().replace(track, '');
-  let artist = titleWithoutTrack.substr(3, titleWithoutTrack.length);
-  if (artist.indexOf(' on ') >= 0) {
-    // label remains i.e. " on Foo Recordings"
-    artist = artist.substr(0, artist.indexOf(' on '));
-  }
-  return artist;
+	let contents = title.contents();
+	let track = contents.eq(0).text();
+	let titleWithoutTrack = contents.text().replace(track, '');
+	let artist = titleWithoutTrack.substr(3, titleWithoutTrack.length);
+	if (artist.indexOf(' on ') >= 0) {
+		// label remains i.e. " on Foo Recordings"
+		artist = artist.substr(0, artist.indexOf(' on '));
+	}
+	return artist;
 }

--- a/src/connectors/residentadvisor.js
+++ b/src/connectors/residentadvisor.js
@@ -8,8 +8,10 @@ Connector.playButtonSelector = '.controls .play';
 
 function getTrackContainer() {
   let track = $('.play.paused').parents().eq(2);
-  if (track.is('article')) {
-    return track; // recommended
+  if (track.is('article') || track.parent().hasClass('chart')) {
+    return track; // recommended or chart track
+  } else if (track.is('li')) {
+    return track.parents().eq(2); // DJ track
   } else {
     return track.parent(); // archive track or single track
   }
@@ -28,27 +30,27 @@ function isTrackSingle() {
 }
 
 function isDjTrack() {
-  return false;
+  return getTrackContainer().is('li') && !getTrackContainer().parent().hasClass('chart');
 }
 
 function isChartTrack() {
-  return false;
+  return getTrackContainer().is('li') && getTrackContainer().parent().hasClass('chart');
 }
 
 Connector.getTrackArt = () => {
-  let artPath;
+  let img;
   if (isTrackRecommended()) {
-    artPath = getTrackContainer().find('a img').attr('src'); // /images/cover/tr-929172.jpg
+    img = getTrackContainer().find('a img');
   } else if (isTrackSingle()) {
-    artPath = getTrackContainer().find('.fl .pr16 img').attr('src');
+    img = getTrackContainer().find('.fl .pr16 img');
   } else if (isDjTrack()) {
-
+    img = getTrackContainer().find('.image a img');
   } else if (isChartTrack()) {
-
+    img = getTrackContainer().find('.cover a img');
   } else if (isArchivedTrack()) {
-    artPath = getTrackContainer().find('li:first-child .pr8 a img').attr('src');
+    img = getTrackContainer().find('li:first-child .pr8 a img');
   }
-  return domain + artPath;
+  return domain + img.attr('src');
 }
 
 Connector.getTrack = () => {
@@ -57,9 +59,9 @@ Connector.getTrack = () => {
   } else if (isTrackSingle()) {
     return Util.splitArtistTrack($('#sectionHead h1').text()).track;
   } else if (isDjTrack()) {
-
+    return getTrackContainer().find('.title a').text();
   } else if (isChartTrack()) {
-
+    return getTrackContainer().find('.track a').text();
   } else if (isArchivedTrack()) {
     return getTrackContainer().find('li:last-child .pr8 a.f24').text();
   }
@@ -71,26 +73,19 @@ Connector.getArtist = () => {
   } else if (isTrackSingle()) {
     return Util.splitArtistTrack($('#sectionHead h1').text()).artist;
   } else if (isDjTrack()) {
-
+    let title = getTrackContainer().find('.title').clone();
+    title.find('a').remove();
+    title = title.text().trim();
+    return title.substr(3, title.length - 6);
   } else if (isChartTrack()) {
-
+    return getTrackContainer().find('.artist a').text();
   } else if (isArchivedTrack()) {
     return getTrackContainer().find('li:last-child .pr8 div.f24').first().text();
   }
 }
 
 Connector.getUniqueId = () => {
-  if (isTrackRecommended()) {
-    return getTrackContainer().find('.play.player').attr('data-trackid');
-  } else if (isTrackSingle()) {
-    return getTrackContainer().find('.play.player').attr('data-trackid');
-  } else if (isDjTrack()) {
-
-  } else if (isChartTrack()) {
-
-  } else if (isArchivedTrack()) {
-
-  }
+  return getTrackContainer().find('.play.player').attr('data-trackid');
 }
 
 Connector.isPlaying = () => $('.play.paused').length > 0;

--- a/src/connectors/residentadvisor.js
+++ b/src/connectors/residentadvisor.js
@@ -6,38 +6,6 @@ Connector.playerSelector = '.content-list';
 
 Connector.playButtonSelector = '.controls .play';
 
-// This identifies the track element depending on the context of the play button
-function getTrackContainer() {
-  let ggParent = $('.play.paused').parents().eq(2);
-  let level;
-  if (ggParent.is('article') || ggParent.parent().hasClass('chart')) {
-    level = 0; // recommended or chart track
-  } else {
-    level = 1 // archive / single / label / DJ track
-  }
-  return ggParent.parents().eq(level);
-}
-
-function isTrackRecommended() {
-  return getTrackContainer().is('article');
-}
-
-function isArchivedTrack() {
-  return getTrackContainer().is('ul');
-}
-
-function isTrackSingle() {
-  return getTrackContainer().is('div');
-}
-
-function isDjOrLabelTrack() {
-  return getTrackContainer().is('li') && getTrackContainer().parent().hasClass('tracks');
-}
-
-function isChartTrack() {
-  return getTrackContainer().is('li') && getTrackContainer().parent().hasClass('chart');
-}
-
 Connector.getTrackArt = () => {
   let artSelector;
   if (isTrackRecommended()) {
@@ -68,26 +36,13 @@ Connector.getTrack = () => {
   }
 }
 
-function betweenOnAndBy(title) {
-  let contents = title.contents();
-  let track = contents.eq(0).text();
-  let titleWithoutTrack = contents.text().replace(track, '');
-  let artist = titleWithoutTrack.substr(3, titleWithoutTrack.length);
-  let indexOn = artist.indexOf(' on '); // label remains i.e. " on Foo Recordings"
-  if (indexOn >= 0) {
-    return artist.substr(0, indexOn);
-  } else {
-    return artist;
-  }
-}
-
 Connector.getArtist = () => {
   if (isTrackRecommended()) {
     return Util.splitArtistTrack(getTrackContainer().find('div a').text()).artist;
   } else if (isTrackSingle()) {
     return Util.splitArtistTrack($('#sectionHead h1').text()).artist;
   } else if (isDjOrLabelTrack()) {
-    return betweenOnAndBy(getTrackContainer().find('.title'));
+    return parseTitle(getTrackContainer().find('.title'));
   } else if (isChartTrack()) {
     return getTrackContainer().find('.artist a').text();
   } else if (isArchivedTrack()) {
@@ -103,4 +58,47 @@ Connector.isPlaying = () => $('.play.paused').length > 0;
 
 Connector.isTrackArtDefault = (trackArtUrl) => {
   return trackArtUrl === domain + '/images/cover/blank.jpg'
+}
+
+// This identifies the track element depending on the context of the play button
+function getTrackContainer() {
+  let ggParent = $('.play.paused').parents().eq(2);
+  if (ggParent.is('article') || ggParent.parent().hasClass('chart')) {
+    return ggParent; // recommended or chart track
+  } else {
+    return ggParent.parents().eq(1); // archive / single / label / DJ track
+  }
+}
+
+function isTrackRecommended() {
+  return getTrackContainer().is('li');
+}
+
+function isArchivedTrack() {
+  return getTrackContainer().is('ul');
+}
+
+function isTrackSingle() {
+  return getTrackContainer().is('div');
+}
+
+function isDjOrLabelTrack() {
+  return getTrackContainer().is('li') && getTrackContainer().parent().hasClass('tracks');
+}
+
+function isChartTrack() {
+  return getTrackContainer().is('li') && getTrackContainer().parent().hasClass('chart');
+}
+
+function parseTitle(title) {
+  let contents = title.contents();
+  let track = contents.eq(0).text();
+  let titleWithoutTrack = contents.text().replace(track, '');
+  let artist = titleWithoutTrack.substr(3, titleWithoutTrack.length);
+  let indexOn = artist.indexOf(' on '); // label remains i.e. " on Foo Recordings"
+  if (indexOn >= 0) {
+    return artist.substr(0, indexOn);
+  } else {
+    return artist;
+  }
 }

--- a/src/connectors/residentadvisor.js
+++ b/src/connectors/residentadvisor.js
@@ -17,16 +17,29 @@ function isTrackInRecommended() {
   return getTrackContainer().is('article');
 }
 
-Connector.getTrackContainerArt = () => {
-  let artPath = getTrackContainer().find('a img').attr('src'); // /images/cover/tr-929172.jpg
-  return 'https://www.residentadvisor.net' + artPath
+Connector.getTrackArt = () => {
+  let artPath;
+  if (isTrackInRecommended()) {
+    artPath = getTrackContainer().find('a img').attr('src'); // /images/cover/tr-929172.jpg
+  } else {
+    artPath = getTrackContainer().find('li:first-child .pr8 a img').attr('src');
+  }
+  return 'https://www.residentadvisor.net' + artPath;
 }
 
-Connector.getArtistTrack = () => {
+Connector.getTrack = () => {
   if (isTrackInRecommended()) {
-    return Util.splitArtistTrack(getTrackContainer().find('div a').text());
+    return Util.splitArtistTrack(getTrackContainer().find('div a').text()).track;
   } else {
-    return $(getTrackContainer).find('li:last-child .pr8 .f24')
+    return getTrackContainer().find('li:last-child .pr8 div.f24').first().text();
+  }
+}
+
+Connector.getArtist = () => {
+  if (isTrackInRecommended()) {
+    return Util.splitArtistTrack(getTrackContainer().find('div a').text()).artist;
+  } else {
+    return getTrackContainer().find('li:last-child .pr8 a.f24').text();
   }
 }
 

--- a/src/connectors/residentadvisor.js
+++ b/src/connectors/residentadvisor.js
@@ -1,0 +1,37 @@
+'use strict';
+
+Connector.playerSelector = '.plus8 .pr8 .strip ul.list, #tracks-in-archive';
+
+Connector.playButtonSelector = '.controls .play';
+
+function getTrackContainer() {
+  let track = $('.play.paused').parent().parent().parent();
+  if (track.is('article')) {
+    return track; // recommended track
+  } else {
+    return track.parent(); // archive track
+  }
+}
+
+function isTrackInRecommended() {
+  return getTrackContainer().is('article');
+}
+
+Connector.getTrackContainerArt = () => {
+  let artPath = getTrackContainer().find('a img').attr('src'); // /images/cover/tr-929172.jpg
+  return 'https://www.residentadvisor.net' + artPath
+}
+
+Connector.getArtistTrack = () => {
+  if (isTrackInRecommended()) {
+    return Util.splitArtistTrack(getTrackContainer().find('div a').text());
+  } else {
+    return $(getTrackContainer).find('li:last-child .pr8 .f24')
+  }
+}
+
+Connector.getUniqueId = () => {
+  return getTrackContainer().find('.play.player').attr('data-trackid');
+}
+
+Connector.isPlaying = () => $('.play.paused').length > 0;

--- a/src/connectors/residentadvisor.js
+++ b/src/connectors/residentadvisor.js
@@ -13,7 +13,7 @@ function getTrackContainer() {
   if (ggParent.is('article') || ggParent.parent().hasClass('chart')) {
     level = 0; // recommended or chart track
   } else {
-    level = 1 // archive / single  / label / DJ track
+    level = 1 // archive / single / label / DJ track
   }
   return ggParent.parents().eq(level);
 }
@@ -68,27 +68,26 @@ Connector.getTrack = () => {
   }
 }
 
+function betweenOnAndBy(title) {
+  let contents = title.contents();
+  let track = contents.eq(0).text();
+  let titleWithoutTrack = contents.text().replace(track, '');
+  let artist = titleWithoutTrack.substr(3, titleWithoutTrack.length);
+  let indexOn = artist.indexOf(' on '); // label remains i.e. " on Foo Recordings"
+  if (indexOn >= 0) {
+    return artist.substr(0, indexOn);
+  } else {
+    return artist;
+  }
+}
+
 Connector.getArtist = () => {
   if (isTrackRecommended()) {
     return Util.splitArtistTrack(getTrackContainer().find('div a').text()).artist;
   } else if (isTrackSingle()) {
     return Util.splitArtistTrack($('#sectionHead h1').text()).artist;
   } else if (isDjOrLabelTrack()) {
-    let artistH1 = $('#featureHead h1').text();
-    if (artistH1 === '') {
-      let contents = getTrackContainer().find('.title').contents();
-      if (contents.length === 3) {
-        // no link, so need to remove "by"
-        let byArtist = getTrackContainer().find('.title').contents().eq(2).text();
-        let artist = byArtist.substr(3, byArtist.length);
-        return artist
-      } else {
-        // get the artist link text
-        return getTrackContainer().find('.title').contents().eq(3).text();
-      }
-    } else {
-      return artistH1;
-    }
+    return betweenOnAndBy(getTrackContainer().find('.title'));
   } else if (isChartTrack()) {
     return getTrackContainer().find('.artist a').text();
   } else if (isArchivedTrack()) {

--- a/src/connectors/residentadvisor.js
+++ b/src/connectors/residentadvisor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-Connector.playerSelector = '.plus8 .pr8 .strip ul.list, #tracks';
+Connector.playerSelector = '.content-list';
 
 Connector.playButtonSelector = '.controls .play';
 
@@ -31,7 +31,7 @@ Connector.getTrack = () => {
   if (isTrackInRecommended()) {
     return Util.splitArtistTrack(getTrackContainer().find('div a').text()).track;
   } else {
-    return getTrackContainer().find('li:last-child .pr8 div.f24').first().text();
+    return getTrackContainer().find('li:last-child .pr8 a.f24').text();
   }
 }
 
@@ -39,7 +39,7 @@ Connector.getArtist = () => {
   if (isTrackInRecommended()) {
     return Util.splitArtistTrack(getTrackContainer().find('div a').text()).artist;
   } else {
-    return getTrackContainer().find('li:last-child .pr8 a.f24').text();
+    return getTrackContainer().find('li:last-child .pr8 div.f24').first().text();
   }
 }
 

--- a/src/connectors/residentadvisor.js
+++ b/src/connectors/residentadvisor.js
@@ -10,10 +10,10 @@ function getTrackContainer() {
   let track = $('.play.paused').parents().eq(2);
   if (track.is('article') || track.parent().hasClass('chart')) {
     return track; // recommended or chart track
-  } else if (track.is('li')) {
-    return track.parents().eq(2); // DJ track
-  } else {
+  } else if (track.is('li') && track.parent().is('ul') || track.parent().hasClass('plus8')) {
     return track.parent(); // archive track or single track
+  } else {
+    return track.parents().eq(1); // DJ track
   }
 }
 
@@ -30,7 +30,7 @@ function isTrackSingle() {
 }
 
 function isDjTrack() {
-  return getTrackContainer().is('li') && !getTrackContainer().parent().hasClass('chart');
+  return getTrackContainer().is('li') && getTrackContainer().parent().hasClass('tracks');
 }
 
 function isChartTrack() {
@@ -38,28 +38,39 @@ function isChartTrack() {
 }
 
 Connector.getTrackArt = () => {
-  let img;
+  let artSelector;
   if (isTrackRecommended()) {
-    img = getTrackContainer().find('a img');
+    artSelector = 'a img';
   } else if (isTrackSingle()) {
-    img = getTrackContainer().find('.fl .pr16 img');
+    artSelector = '.fl .pr16 img';
   } else if (isDjTrack()) {
-    img = getTrackContainer().find('.image a img');
+    artSelector = '.image a img';
   } else if (isChartTrack()) {
-    img = getTrackContainer().find('.cover a img');
+    artSelector = '.cover a img';
   } else if (isArchivedTrack()) {
-    img = getTrackContainer().find('li:first-child .pr8 a img');
+    artSelector = 'li:first-child .pr8 a img';
   }
-  return domain + img.attr('src');
+  return domain + getTrackContainer().find(artSelector).attr('src');
 }
 
+function parseTitle(title) {
+  // we can receive either of:
+  //  - TRACK by ARTIST on LABEL
+  //  - TRACK by ARTIST
+  // TRACK and ARTIST are not always links, so we parse the string
+  return {
+    artist: 'tofix',
+    track: 'tofix'
+  }
+}
 Connector.getTrack = () => {
   if (isTrackRecommended()) {
     return Util.splitArtistTrack(getTrackContainer().find('div a').text()).track;
   } else if (isTrackSingle()) {
     return Util.splitArtistTrack($('#sectionHead h1').text()).track;
   } else if (isDjTrack()) {
-    return getTrackContainer().find('.title a').text();
+    let title = getTrackContainer().find('.title').text())
+    return parseTitle(title).track;
   } else if (isChartTrack()) {
     return getTrackContainer().find('.track a').text();
   } else if (isArchivedTrack()) {
@@ -73,10 +84,8 @@ Connector.getArtist = () => {
   } else if (isTrackSingle()) {
     return Util.splitArtistTrack($('#sectionHead h1').text()).artist;
   } else if (isDjTrack()) {
-    let title = getTrackContainer().find('.title').clone();
-    title.find('a').remove();
-    title = title.text().trim();
-    return title.substr(3, title.length - 6);
+    let title = getTrackContainer().find('.title').text())
+    return parseTitle(title).artist;
   } else if (isChartTrack()) {
     return getTrackContainer().find('.artist a').text();
   } else if (isArchivedTrack()) {

--- a/src/connectors/residentadvisor.js
+++ b/src/connectors/residentadvisor.js
@@ -2,7 +2,7 @@
 
 const domain = 'https://www.residentadvisor.net';
 
-let PLAYER_TYPES = {
+const PLAYER_TYPES = {
 	// https://www.residentadvisor.net/tracks ("Popular tracks" at the top)
 	// https://www.residentadvisor.net/tracks/931382 ("Popular tracks" at the bottom)
 	POPULAR: 'Popular tracks',

--- a/src/connectors/residentadvisor.js
+++ b/src/connectors/residentadvisor.js
@@ -1,64 +1,100 @@
 'use strict';
 
+const domain = 'https://www.residentadvisor.net';
+
 Connector.playerSelector = '.content-list';
 
 Connector.playButtonSelector = '.controls .play';
 
 function getTrackContainer() {
-  let track = $('.play.paused').parent().parent().parent();
+  let track = $('.play.paused').parents().eq(2);
   if (track.is('article')) {
-    return track; // recommended or single track
+    return track; // recommended
   } else {
-    return track.parent(); // archive track
+    return track.parent(); // archive track or single track
   }
 }
 
-function isTrackInRecommended() {
+function isTrackRecommended() {
   return getTrackContainer().is('article');
+}
+
+function isArchivedTrack() {
+  return getTrackContainer().is('ul');
 }
 
 function isTrackSingle() {
   return getTrackContainer().is('div');
 }
 
+function isDjTrack() {
+  return false;
+}
+
+function isChartTrack() {
+  return false;
+}
+
 Connector.getTrackArt = () => {
   let artPath;
-  if (isTrackInRecommended()) {
+  if (isTrackRecommended()) {
     artPath = getTrackContainer().find('a img').attr('src'); // /images/cover/tr-929172.jpg
   } else if (isTrackSingle()) {
     artPath = getTrackContainer().find('.fl .pr16 img').attr('src');
-  } else {
+  } else if (isDjTrack()) {
+
+  } else if (isChartTrack()) {
+
+  } else if (isArchivedTrack()) {
     artPath = getTrackContainer().find('li:first-child .pr8 a img').attr('src');
   }
-  return 'https://www.residentadvisor.net' + artPath;
+  return domain + artPath;
 }
 
 Connector.getTrack = () => {
-  if (isTrackInRecommended()) {
+  if (isTrackRecommended()) {
     return Util.splitArtistTrack(getTrackContainer().find('div a').text()).track;
   } else if (isTrackSingle()) {
     return Util.splitArtistTrack($('#sectionHead h1').text()).track;
-  } else {
+  } else if (isDjTrack()) {
+
+  } else if (isChartTrack()) {
+
+  } else if (isArchivedTrack()) {
     return getTrackContainer().find('li:last-child .pr8 a.f24').text();
   }
 }
 
 Connector.getArtist = () => {
-  if (isTrackInRecommended()) {
+  if (isTrackRecommended()) {
     return Util.splitArtistTrack(getTrackContainer().find('div a').text()).artist;
   } else if (isTrackSingle()) {
     return Util.splitArtistTrack($('#sectionHead h1').text()).artist;
-  } else {
+  } else if (isDjTrack()) {
+
+  } else if (isChartTrack()) {
+
+  } else if (isArchivedTrack()) {
     return getTrackContainer().find('li:last-child .pr8 div.f24').first().text();
   }
 }
 
 Connector.getUniqueId = () => {
-  return getTrackContainer().find('.play.player').attr('data-trackid');
+  if (isTrackRecommended()) {
+    return getTrackContainer().find('.play.player').attr('data-trackid');
+  } else if (isTrackSingle()) {
+    return getTrackContainer().find('.play.player').attr('data-trackid');
+  } else if (isDjTrack()) {
+
+  } else if (isChartTrack()) {
+
+  } else if (isArchivedTrack()) {
+
+  }
 }
 
 Connector.isPlaying = () => $('.play.paused').length > 0;
 
 Connector.isTrackArtDefault = (trackArtUrl) => {
-  return trackArtUrl === 'https://www.residentadvisor.net/images/cover/blank.jpg'
+  return trackArtUrl === domain + '/images/cover/blank.jpg'
 }

--- a/src/connectors/residentadvisor.js
+++ b/src/connectors/residentadvisor.js
@@ -7,7 +7,7 @@ Connector.playButtonSelector = '.controls .play';
 function getTrackContainer() {
   let track = $('.play.paused').parent().parent().parent();
   if (track.is('article')) {
-    return track; // recommended track
+    return track; // recommended or single track
   } else {
     return track.parent(); // archive track
   }
@@ -17,10 +17,16 @@ function isTrackInRecommended() {
   return getTrackContainer().is('article');
 }
 
+function isTrackSingle() {
+  return getTrackContainer().is('div');
+}
+
 Connector.getTrackArt = () => {
   let artPath;
   if (isTrackInRecommended()) {
     artPath = getTrackContainer().find('a img').attr('src'); // /images/cover/tr-929172.jpg
+  } else if (isTrackSingle()) {
+    artPath = getTrackContainer().find('.fl .pr16 img').attr('src');
   } else {
     artPath = getTrackContainer().find('li:first-child .pr8 a img').attr('src');
   }
@@ -30,6 +36,8 @@ Connector.getTrackArt = () => {
 Connector.getTrack = () => {
   if (isTrackInRecommended()) {
     return Util.splitArtistTrack(getTrackContainer().find('div a').text()).track;
+  } else if (isTrackSingle()) {
+    return Util.splitArtistTrack($('#sectionHead h1').text()).track;
   } else {
     return getTrackContainer().find('li:last-child .pr8 a.f24').text();
   }
@@ -38,6 +46,8 @@ Connector.getTrack = () => {
 Connector.getArtist = () => {
   if (isTrackInRecommended()) {
     return Util.splitArtistTrack(getTrackContainer().find('div a').text()).artist;
+  } else if (isTrackSingle()) {
+    return Util.splitArtistTrack($('#sectionHead h1').text()).artist;
   } else {
     return getTrackContainer().find('li:last-child .pr8 div.f24').first().text();
   }

--- a/src/connectors/residentadvisor.js
+++ b/src/connectors/residentadvisor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-Connector.playerSelector = '.plus8 .pr8 .strip ul.list, #tracks-in-archive';
+Connector.playerSelector = '.plus8 .pr8 .strip ul.list, #tracks';
 
 Connector.playButtonSelector = '.controls .play';
 
@@ -48,3 +48,7 @@ Connector.getUniqueId = () => {
 }
 
 Connector.isPlaying = () => $('.play.paused').length > 0;
+
+Connector.isTrackArtDefault = (trackArtUrl) => {
+  return trackArtUrl === 'https://www.residentadvisor.net/images/cover/blank.jpg'
+}

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1209,6 +1209,10 @@ define(function() {
 		matches: ['*://aphextwin.warp.net/*'],
 		js: ['connectors/warp-aphextwin.js'],
 	}, {
+		label: 'Resident Advisor',
+		matches: ['*://www.residentadvisor.net/*'],
+		js: ['connectors/residentadvisor.js'],
+	}, {
 		label: 'Zachary Seguin Music',
 		matches: ['*://music.zacharyseguin.ca/*'],
 		js: ['connectors/musickit.js'],

--- a/tests/connectors/residentadvisor.js
+++ b/tests/connectors/residentadvisor.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = function(driver, connectorSpec) {
+	connectorSpec.shouldBehaveLikeMusicSite(driver, {
+		url: 'https://www.residentadvisor.net/'
+	});
+};


### PR DESCRIPTION
Hey,

Here is a connector for https://residentadvisor.net. It is unusually complex because the website does not have a single player, but 7 different types for which the track information is not always located at the same place. Test examples (also added in the code):

 - https://www.residentadvisor.net/tracks ("Popular tracks" at the top)
 - https://www.residentadvisor.net/tracks/931382 ("Popular tracks" at the bottom)
 - https://www.residentadvisor.net/tracks ("Archived tracks" in the middle)
 - https://www.residentadvisor.net/tracks/931382 ("Single track" in the middle)
 - https://www.residentadvisor.net/record-label.aspx?id=15687&show=tracks ("Label tracks" in the middle)
 - https://www.residentadvisor.net/dj/hotsince82/tracks ("DJ tracks" in the middle)
 - https://www.residentadvisor.net/dj/secretsundaze/top10?chart=214484 ("Chart tracks" in the middle)

Hopefully I haven't forgotten any of them but I will open a new PR if I find any more. RA also embeds soundcloud songs in some places, but this PR does not take care of it.

The track info we have access to are: track name, track artist and cover. I think I found where to get the track duration, but I'm not sure how to get it from inside the connector. If you start playing a track and type the following in the console, it gives the track duration:

    soundManager.sounds[Object.keys(soundManager.sounds)[0]].duration

But when putting a  debugger in the connector, it's undefined. How to include it?

Thanks!
