### PR TITLE
Fix Spotify track and time selectors

### DIFF
--- a/src/connectors/spotify.js
+++ b/src/connectors/spotify.js
@@ -8,7 +8,7 @@ Connector.playerSelector = '.now-playing-bar';
 
 Connector.getArtist = () => $('.track-info__artists a').first().text();
 
-Connector.trackSelector = '.track-info__name a';
+Connector.trackSelector = '.Root__now-playing-bar .track-info__name a';
 
 Connector.trackArtSelector = '.now-playing__cover-art .cover-art-image-loaded';
 

--- a/src/connectors/spotify.js
+++ b/src/connectors/spotify.js
@@ -4,7 +4,7 @@
  * The connector for new version of Spotify (open.spotify.com).
  */
 
-Connector.playerSelector = '.now-playing-bar';
+Connector.playerSelector = '.Root__now-playing-bar';
 
 Connector.getArtist = () => $('.track-info__artists a').first().text();
 
@@ -14,9 +14,9 @@ Connector.trackArtSelector = '.now-playing__cover-art .cover-art-image-loaded';
 
 Connector.playButtonSelector = '.control-button[class*="spoticon-play-"]';
 
-Connector.currentTimeSelector = '.playback-bar__progress-time:first-child';
+Connector.currentTimeSelector = '.Root__now-playing-bar .playback-bar__progress-time:first-child';
 
-Connector.durationSelector = '.playback-bar__progress-time:last-child';
+Connector.durationSelector = '.Root__now-playing-bar .playback-bar__progress-time:last-child';
 
 Connector.filter = MetadataFilter.getRemasteredFilter();
 


### PR DESCRIPTION
Fixes track title duplication (#1774) and incorrect track duration which caused missed scrobbles.