### PR TITLE
Fix disallowing scrobbling & don't scrobble Spotify ads

### DIFF
--- a/src/connectors/spotify.js
+++ b/src/connectors/spotify.js
@@ -25,10 +25,6 @@ Connector.isScrobblingAllowed = () => {
 };
 
 function isMusicPlaying() {
-	if (Connector.getArtist() !== 'Spotify') {
-		return true;
-	}
-
 	// When ad is playing, artist URL is like "https://shrt.spotify.com/XXX",
 	// otherwise URL leads to an artist page "https://open.spotify.com/artist/YYY".
 	let artistUrl = $('.track-info__artists a').attr('href');

--- a/src/core/content/connector.js
+++ b/src/core/content/connector.js
@@ -450,6 +450,13 @@ function BaseConnector() {
 	 * Function for all the hard work around detecting and updating state.
 	 */
 	this.stateChangedWorker = () => {
+		if (!this.isScrobblingAllowed()) {
+			this.resetState();
+			return;
+		}
+
+		isStateReset = false;
+
 		let changedFields = [];
 		let newState = this.getCurrentState();
 
@@ -484,7 +491,6 @@ function BaseConnector() {
 			}
 			// @endif
 		}
-
 	};
 
 	/**
@@ -528,16 +534,9 @@ function BaseConnector() {
 	 * if needed.
 	 */
 	this.onStateChanged = () => {
-		if (!this.isScrobblingAllowed()) {
-			this.resetState();
-			return;
-		}
-
 		if (!this.isStateChangeAllowed()) {
 			return;
 		}
-
-		isStateReset = false;
 
 		/**
 		 * Because gathering the state from DOM is quite expensive and mutation


### PR DESCRIPTION
Fixes #1599.

If a connector wants to prevent certain tracks from being scrobbled (e.g. audio ads on Spotify), it can implement `isScrobblingAllowed()` to return false when an unwanted track is playing. However, delayed execution of throttled state change processing can still allow the unwanted track to be scrobbled. In this scenario, the track will scrobble even while paused.

How this happens:
1. `stateChangedWorkerThrottled()` schedules a delayed execution of `stateChangedWorker()`.
2. An unwanted track starts playing.
3. `isScrobblingAllowed()` becomes false.
4. `onStateChange()` resets state, sets a flag to prevent resetting state again while scrobbling isn't allowed, and returns early.
5. Throttled `stateChangedWorker()` executes and processes the unwanted track, overriding the reset.
6. `onStateChange()` continues returning early without resetting state again or invoking `stateChangedWorker()`.
7. If the user pauses the unwanted track, the pause event won't be processed, so it'll scrobble even while paused.
8. Unwanted track ends and a valid track starts playing.
9. `isScrobblingAllowed()` becomes true, allowing `onStateChange()` to execute fully again. Behavior returns to normal.

To fix, we can check `isScrobblingAllowed()` every time `stateChangedWorker()` executes, including delayed execution due to throttling.