### PR TITLE
Improve youtube filters and title processing

### DIFF
--- a/src/core/content/filter.js
+++ b/src/core/content/filter.js
@@ -280,6 +280,8 @@ class MetadataFilter {
 			{ source: /^(|.*\s)"(.{5,})"(\s.*|)$/, target: '$2' },
 			// 'Track title'
 			{ source: /^(|.*\s)'(.{5,})'(\s.*|)$/, target: '$2' },
+			// (*01/01/1999*)
+			{ source: /\s*\(.*[0-9]{1,2}\/[0-9]{1,2}\/[0-9]{2,4}.*\)/i, target: '' },
 
 
 			// labels

--- a/src/core/content/util.js
+++ b/src/core/content/util.js
@@ -6,10 +6,10 @@
 
 const Util = {
 	youtubeTitleRegExps: [
-		// Artist "Track"
+		// Artist "Track", Artist: "Track", Artist - "Track", etc.
 		{
-			pattern: /(.+?)\s"(.+?)"/,
-			groups: { artist: 1, track: 2 }
+			pattern: /(.+?)(\s|-|—|:)+\s*"(.+?)"/,
+			groups: { artist: 1, track: 3 }
 		},
 		// Artist「Track」 (Japanese tracks)
 		{

--- a/tests/core/filter.js
+++ b/tests/core/filter.js
@@ -240,6 +240,10 @@ const YOUTUBE_TEST_DATA = [{
 	description: 'should leave single quotes around joined',
 	source: 'Track \'n\' Title',
 	expected: 'Track \'n\' Title'
+}, {
+	description: 'should remove "(whatever 2/12/18)" string',
+	source: 'Track Title (whatever 2/12/18)',
+	expected: 'Track Title'
 }];
 
 /**

--- a/tests/core/util.js
+++ b/tests/core/util.js
@@ -187,6 +187,14 @@ const PROCESS_YOUTUBE_TITLE_DATA = [{
 	description: 'should process inverted tracks with parens original artist',
 	source: 'Original Artist - Track (cover by Artist)',
 	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should process tracks with seperators and quotes',
+	source: 'Artist - "Track Name"',
+	expected: { artist: 'Artist', track: 'Track Name' }
+}, {
+	description: 'should process tracks with seperators without leading whitespace and quotes',
+	source: 'Artist: "Track Name"',
+	expected: { artist: 'Artist', track: 'Track Name' }
 }];
 
 /**


### PR DESCRIPTION
- Add filter for live videos where format is 'Artist - Track Name (Venue name 01/01/2000)'

- Prevent trailing separators ending up in artist name when both quotes and seperators are used, for example:
Artist - "Track Name"
Artist: "Track Name"
Artist:"Track Name"
Before last.fm was cleaning these out of the artist name most of, but not all, the time.

Examples that this fixes:
https://www.youtube.com/watch?v=p_kgIJ5ffJI
https://www.youtube.com/watch?v=gtXPxXBWsVk