### PR TITLE
Fix URL normalizing

### DIFF
--- a/src/core/content/util.js
+++ b/src/core/content/util.js
@@ -82,6 +82,10 @@ const Util = {
 	 * @return {String} Normalized URL
 	 */
 	normalizeUrl(url) {
+		if (!url) {
+			return null;
+		}
+
 		return url.startsWith('//') ? location.protocol + url : url;
 	},
 


### PR DESCRIPTION
Relevant to #1859 

If `trackArtSelector` is set, but retrieving of the URL has failed, no `TypeError` will be thrown. The track art is an optional feature, it should not break the entire song recognition.