### PR TITLE
Fix TIDAL issues (#1874)

### DIFF
--- a/src/connectors/tidal.js
+++ b/src/connectors/tidal.js
@@ -6,7 +6,7 @@ Connector.playButtonSelector = `${Connector.playerSelector} [class^="playbackTog
 
 Connector.isScrobblingAllowed = () => !!$(Connector.playButtonSelector);
 
-Connector.isPlaying = () => $(Connector.playButtonSelector).attr('data-test-id') === 'pause';
+Connector.isPlaying = () => $(Connector.playButtonSelector).attr('data-test') === 'pause';
 
 Connector.trackSelector = `${Connector.playerSelector} [class^="mediaInformation"] span:eq(0)`;
 


### PR DESCRIPTION
Simple change of attribute name stopped the connector from recognising playing state. Fixed for TIDAL Web Player 3.7.0--31 (NP: 2.3.8.1)