### PR TITLE
Add support for musi.sh (#1876)

### DIFF
--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1248,6 +1248,10 @@ define(function() {
 		matches: ['*://playapplemusic.com/*'],
 		js: ['connectors/musickit.js'],
 	}, {
+		label: 'Musish',
+		matches: ['*://musi.sh/*'],
+		js: ['connectors/musickit.js'],
+	}, {
 		label: '1001tracklists',
 		matches: ['*://www.1001tracklists.com/tracklist/*'],
 		js: ['connectors/1001tracklists.js'],


### PR DESCRIPTION
This is another Apple Music player based on MusicKit JS. Simple addition to src/core/connectors.js.