### PR TITLE
Add funkwhale connector

### DIFF
--- a/src/connectors/funkwhale.js
+++ b/src/connectors/funkwhale.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Connector.playerSelector = '.player';
+
+Connector.trackSelector = '.small.header.discrete.link.track';
+
+Connector.artistSelector = '.meta > .artist';
+
+Connector.albumSelector = '.meta > .album';


### PR DESCRIPTION
Allows Web Scrobbler to work on [Funkwhale](https://funkwhale.audio/). As stated in #1882, Funkwhale is a self hosted service that can work on many different URLs, so no URL matching was added.