### PR TITLE
feature/#1852Support_For_R-a-d.io

### DIFF
--- a/src/connectors/r-a-d.io.js
+++ b/src/connectors/r-a-d.io.js
@@ -5,3 +5,7 @@ Connector.artistTrackSelector = '#np';
 Connector.playButtonSelector = '#stream-play';
 
 Connector.playerSelector = '.dynamic-row > .col-md-6';
+
+Connector.durationSelector = '#progress-length';
+
+Connector.currentTimeSelector = '#progress-current';

--- a/src/connectors/r-a-d.io.js
+++ b/src/connectors/r-a-d.io.js
@@ -1,7 +1,7 @@
-'use strict'
+'use strict';
 
-Connector.artistTrackSelector = '#np'
+Connector.artistTrackSelector = '#np';
 
 Connector.playButtonSelector = '#stream-play';
 
-Connector.playerSelector = '.dynamic-row > .col-md-6'
+Connector.playerSelector = '.dynamic-row > .col-md-6';

--- a/src/connectors/r-a-d.io.js
+++ b/src/connectors/r-a-d.io.js
@@ -1,7 +1,0 @@
-'use strict'
-
-Connector.artistTrackSelector = '#np'
-
-Connector.playButtonSelector = '#stream-play';
-
-Connector.playerSelector = '.dynamic-row > .col-md-6'

--- a/src/connectors/r-a-d.io.js
+++ b/src/connectors/r-a-d.io.js
@@ -1,0 +1,7 @@
+'use strict'
+
+Connector.artistTrackSelector = '#np'
+
+Connector.playButtonSelector = '#stream-play';
+
+Connector.playerSelector = '.dynamic-row > .col-md-6'

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1279,9 +1279,5 @@ define(function() {
 		label: 'Funkwhale',
 		matches: [''],
 		js: ['connectors/funkwhale.js'],
-	}, {
-			label: 'R-a-dio',
-			matches: ['*://r-a-d.io/*', '*://www.r-a-d.io/*'],
-			js: ['connectors/r-a-d.io.js'],
 	}];
 });

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1280,8 +1280,8 @@ define(function() {
 		matches: [''],
 		js: ['connectors/funkwhale.js'],
 	}, {
-			label: 'R-a-dio',
-			matches: ['*://r-a-d.io/*', '*://www.r-a-d.io/*'],
-			js: ['connectors/r-a-d.io.js'],
+		label: 'R-a-dio',
+		matches: ['*://r-a-d.io/*', '*://www.r-a-d.io/*'],
+		js: ['connectors/r-a-d.io.js'],
 	}];
 });

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1281,7 +1281,7 @@ define(function() {
 		js: ['connectors/funkwhale.js'],
 	}, {
 		label: 'R-a-dio',
-		matches: ['*://r-a-d.io/*', '*://www.r-a-d.io/*'],
+		matches: ['*://r-a-d.io/*'],
 		js: ['connectors/r-a-d.io.js'],
 	}];
 });

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1279,5 +1279,9 @@ define(function() {
 		label: 'Funkwhale',
 		matches: [''],
 		js: ['connectors/funkwhale.js'],
+	}, {
+			label: 'R-a-dio',
+			matches: ['*://r-a-d.io/*', '*://www.r-a-d.io/*'],
+			js: ['connectors/r-a-d.io.js'],
 	}];
 });


### PR DESCRIPTION
Added support for R-a-d.io required in #1852 
I've tested scrobbling to Last.fm in Chrome Version 71.0.3578.98 (Official Build) (64-bit) both unpacked and compiled versions.
Command `>grunt` exited without errors.