### PR TITLE
Apply cache size to popup title correctly

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -110,6 +110,10 @@
     "message": "This extension stores edited tracks.",
     "description": "Description of edited tracks"
   },
+  "optionsEditedTracksPopupTitle": {
+    "message": "$1 edited tracks",
+    "description": "'Edited tracks' header"
+  },
   "optionsViewEdited": {
     "message": "View",
     "description": "Button to view edited tracks"

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -276,7 +276,7 @@
 			<div class="modal-content">
 				<div class="modal-header">
 					<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span></button>
-					<h4 class="modal-title" i18n="editedTracksTitle"></h4>
+					<h4 class="modal-title"></h4>
 				</div>
 				<div class="modal-body">
 					<div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -370,8 +370,9 @@ require([
 						cacheDom.append(item);
 					}
 
-					let cacheSize = Object.keys(data).length;
-					$('#edited-track-modal .modal-title').prepend(`${cacheSize} `);
+					let cacheSizeStr = Object.keys(data).length.toString();
+					let poputTitle = chrome.i18n.getMessage('optionsEditedTracksPopupTitle', cacheSizeStr);
+					$('#edited-track-modal .modal-title').text(poputTitle);
 				}
 			});
 


### PR DESCRIPTION
Fixes an issue when cache size was applied multiple times.

Cache size valuse is applied every time the popup window is opened. Here's a representation of issue on the screenshot. The edited tracks popup window was opened triple times.
![image](https://user-images.githubusercontent.com/1119267/52534586-88f87d80-2d54-11e9-9853-00007fefd322.png)__