### PR TITLE
[#1937] fix login with listenbrainz on firefox 60.x esr

### DIFF
--- a/src/core/background/scrobbler/listenbrainz.js
+++ b/src/core/background/scrobbler/listenbrainz.js
@@ -185,7 +185,7 @@ define((require) => {
 
 		async fetchSession(url) {
 			this.debugLog(`Use ${url}`);
-			let promise = fetch(url, { method: 'GET' , credentials: 'same-origin'});
+			let promise = fetch(url, { method: 'GET', credentials: 'same-origin' });
 			let timeout = BaseScrobbler.REQUEST_TIMEOUT;
 
 			let response = await Util.timeoutPromise(timeout, promise);

--- a/src/core/background/scrobbler/listenbrainz.js
+++ b/src/core/background/scrobbler/listenbrainz.js
@@ -185,7 +185,7 @@ define((require) => {
 
 		async fetchSession(url) {
 			this.debugLog(`Use ${url}`);
-			let promise = fetch(url, { method: 'GET' });
+			let promise = fetch(url, { method: 'GET' , credentials: 'same-origin'});
 			let timeout = BaseScrobbler.REQUEST_TIMEOUT;
 
 			let response = await Util.timeoutPromise(timeout, promise);


### PR DESCRIPTION
It seems like firefox had different default fetch settings for plugins. Therefore cookies for listenbrainz simply were not provided to request. And it seems like somewhere between versions 60.x and 66.x default behavior was changed, that's why you can successfully connect with listenbrainz now.
This change explicitly sets credentials policy of fetch to 'same-origin' allowing to pass cookies to fetch and connect account.