### PR TITLE
Add album selector for Hype Machine premieres.

### DIFF
--- a/src/connectors/hypem-premieres.js
+++ b/src/connectors/hypem-premieres.js
@@ -4,6 +4,8 @@ Connector.playerSelector = '.hype-player';
 
 Connector.artistSelector = '#album-header-artist';
 
+Connector.albumSelector = '#album-header-title';
+
 Connector.trackSelector = 'li.active .title';
 
 Connector.trackArtSelector = 'img#album-big';


### PR DESCRIPTION
For some reason I didn't implement this when writing the connector, but it's easy enough to add and in the same vein as the artist selector.