### PR TITLE
Add duration selectors for Hype Machine (Premieres).

### DIFF
--- a/src/connectors/hypem-premieres.js
+++ b/src/connectors/hypem-premieres.js
@@ -11,3 +11,7 @@ Connector.trackSelector = 'li.active .title';
 Connector.trackArtSelector = 'img#album-big';
 
 Connector.isPlaying = () => $('.hype-player').hasClass('playing');
+
+Connector.currentTimeSelector = '.current_pos';
+
+Connector.durationSelector = 'li.active .duration';

--- a/src/connectors/hypem.js
+++ b/src/connectors/hypem.js
@@ -20,3 +20,7 @@ Connector.getUniqueID = () => {
 };
 
 Connector.isPlaying = () => $('#playerPlay').hasClass('pause');
+
+Connector.currentTimeSelector = '#player-time-position';
+
+Connector.durationSelector = '#player-time-total';

--- a/tests/connectors/hypem.js
+++ b/tests/connectors/hypem.js
@@ -3,6 +3,6 @@
 module.exports = function(driver, connectorSpec) {
 	connectorSpec.shouldBehaveLikeMusicSite(driver, {
 		url: 'http://hypem.com/artist/Violet+Days+x+Win+and+Woo',
-		playButtonSelector: '.tools .playdiv'
+		playButtonSelector: '#playerPlay'
 	});
 };


### PR DESCRIPTION
Previously this wasn't implemented so scrobbling would always happen after 30s. This is very annoying when trying to make edits to track info.