### PR TITLE
Add option to use Tidal-provided shorter track names.

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -52,6 +52,14 @@
     "message": "Scrobble podcasts on Google Music",
     "description": "Option label"
   },
+  "optionTdlShortTrackNames": {
+    "message": "Use short track names",
+    "description": "Option title"
+  },
+  "optionTdlShortTrackNamesTitle": {
+    "message": "Tidal provides shortened track names for certain tracks (without \"Remastered\", etc.)",
+    "Description": "Option label"
+  },
   "optionYtDesc": {
     "message": "If you turn off both options, the extension will scrobble Youtube videos from all categories.",
     "description": "Description of Youtube options"

--- a/src/connectors/tidal.js
+++ b/src/connectors/tidal.js
@@ -1,5 +1,9 @@
 'use strict';
 
+let useShortTrackNames = false;
+
+readConnectorOptions();
+
 Connector.playerSelector = '[class^="nowPlaying"]';
 
 Connector.playButtonSelector = `${Connector.playerSelector} [class*="playbackToggle"]`;
@@ -8,7 +12,18 @@ Connector.isScrobblingAllowed = () => !!$(Connector.playButtonSelector);
 
 Connector.isPlaying = () => $(Connector.playButtonSelector).attr('data-test') === 'pause';
 
-Connector.trackSelector = `${Connector.playerSelector} [class^="mediaInformation"] span:eq(0)`;
+const fullTrackSelector = `${Connector.playerSelector} [class^="mediaInformation"] span:nth-child(1) a`;
+const shortTrackSelector = `${Connector.playerSelector} [class^="infoTableWrapper"] > table:nth-child(1) > tbody > tr:nth-child(1) > td:nth-child(2)`;
+
+Connector.getTrack = () => Util.getTextFromSelectors(useShortTrackNames ? shortTrackSelector : fullTrackSelector);
+
+Connector.getUniqueID = () => {
+	const trackUrl = $(fullTrackSelector).attr('href');
+	if (trackUrl) {
+		return trackUrl.split('/').pop();
+	}
+	return null;
+};
 
 Connector.artistSelector = `${Connector.playerSelector} [class^="mediaArtists"]`;
 
@@ -19,3 +34,7 @@ Connector.trackArtSelector = `${Connector.playerSelector} [class^="mediaImageryT
 Connector.currentTimeSelector = `${Connector.playerSelector} [data-test="duration"] [class^="currentTime"]`;
 
 Connector.durationSelector = `${Connector.playerSelector} [data-test="duration"] [class^="duration"]`;
+
+async function readConnectorOptions() {
+	useShortTrackNames = await Util.getOption('Tidal', 'useShortTrackNames');
+}

--- a/src/core/background/storage/options.js
+++ b/src/core/background/storage/options.js
@@ -53,6 +53,9 @@ define((require) => {
 		GoogleMusic: {
 			scrobblePodcasts: true
 		},
+		Tidal: {
+			useShortTrackNames: false
+		},
 		YouTube: {
 			scrobbleMusicOnly: false,
 			scrobbleEntertainmentOnly: false

--- a/src/ui/options/index.html
+++ b/src/ui/options/index.html
@@ -89,6 +89,14 @@
 									</div>
 								</div>
 
+								<h5>Tidal</h5>
+								<div class="options-block">
+									<div class="form-check">
+										<input class="form-check-input" type="checkbox" id="tdl-short-track-names">
+										<label class="form-check-label" for="tdl-short-track-names" i18n="optionTdlShortTrackNames" i18n-title="optionTdlShortTrackNamesTitle"></label>
+									</div>
+								</div>
+
 								<h5>YouTube</h5>
 								<div class="options-block">
 									<div class="form-check">

--- a/src/ui/options/options.js
+++ b/src/ui/options/options.js
@@ -17,6 +17,9 @@ define((require) => {
 		GoogleMusic: {
 			'#gm-podcasts': 'scrobblePodcasts'
 		},
+		Tidal: {
+			'#tdl-short-track-names': 'useShortTrackNames'
+		},
 		YouTube: {
 			'#yt-music-only': 'scrobbleMusicOnly',
 			'#yt-entertainment-only': 'scrobbleEntertainmentOnly',


### PR DESCRIPTION
I noticed that Tidal recently started updating their info table, especially for jazz records. There is now a table row for the track name stripped of any extra bits of information. For example, the track [Out Of The Night (Rudy Van Gelder Edition / 1999 Digital Remaster / 24-Bit Mastering)](https://listen.tidal.com/album/1381684/track/1381690) shows up in the info table as simply "Out Of The Night". We can use this to make for cleaner scrobbles. As a bonus that info table appears to be populated now even if the fullscreen now playing drawer isn't open.

I can put this behind an option if people want to be able to scrobble the full-information track names, but for now this is perfect for my own use. Any other Tidal user opinions?