### PR TITLE
Fix play button selector for TIDAL.

### DIFF
--- a/src/connectors/tidal.js
+++ b/src/connectors/tidal.js
@@ -2,7 +2,7 @@
 
 Connector.playerSelector = '[class^="nowPlaying"]';
 
-Connector.playButtonSelector = `${Connector.playerSelector} [class^="playbackToggle"]`;
+Connector.playButtonSelector = `${Connector.playerSelector} [class*="playbackToggle"]`;
 
 Connector.isScrobblingAllowed = () => !!$(Connector.playButtonSelector);
 


### PR DESCRIPTION
They added another class in front of it. It would be really nice if there were
a good way to combine the class selector (`.`) and the prefix attribute
selector (`[class|=]`) so you could select on classes in any order.