### PR TITLE
Updated filter to normalise " - X Remix" to "(X Remix)" to cover other variations

### DIFF
--- a/src/core/content/filter.js
+++ b/src/core/content/filter.js
@@ -233,13 +233,13 @@ class MetadataFilter {
 	}
 
 	/**
-	 * Replace "Title - X Remix" suffix with "Title (X Remix)".
+	 * Replace "Title - X Remix" suffix with "Title (X Remix) and similar".
 	 * @param  {String} text String to be filtered
 	 * @return {String} Filtered string
 	 */
-	static fixRemixSuffix(text) {
+	static fixTrackSuffix(text) {
 		return MetadataFilter.filterWithFilterSet(
-			text, MetadataFilter.REMIX_FILTERS
+			text, MetadataFilter.SUFFIX_FILTERS
 		);
 	}
 
@@ -386,7 +386,7 @@ class MetadataFilter {
 		];
 	}
 
-	static get REMIX_FILTERS() {
+	static get SUFFIX_FILTERS() {
 		return [
 			// "- X Remix" -> "(X Remix)" and similar
 			{ source: /-\s(.+?)\s((Re)?mix|edit|dub|mix|vip|version)$/i, target: '($1 $2)' },
@@ -436,12 +436,12 @@ class MetadataFilter {
 		return new MetadataFilter({
 			track: [
 				MetadataFilter.removeRemastered,
-				MetadataFilter.fixRemixSuffix,
+				MetadataFilter.fixTrackSuffix,
 				MetadataFilter.removeLive,
 			],
 			album: [
 				MetadataFilter.removeRemastered,
-				MetadataFilter.fixRemixSuffix,
+				MetadataFilter.fixTrackSuffix,
 				MetadataFilter.removeLive,
 			],
 		});

--- a/src/core/content/filter.js
+++ b/src/core/content/filter.js
@@ -388,9 +388,9 @@ class MetadataFilter {
 
 	static get REMIX_FILTERS() {
 		return [
-			// "- X Remix" -> "(X Remix)"
-			{ source: /-\s(.+?)\sRemix$/, target: '($1 Remix)' },
-			{ source: /-\sRemix$/, target: '(Remix)' },
+			// "- X Remix" -> "(X Remix)" and similar
+			{ source: /-\s(.+?)\s((Re)?mix|edit|dub|mix|vip|version)$/($1 $2)/i, target: '($1 $2)' },
+			{ source: /-\s(Remix|VIP)$/i, target: '($1)' },
 		];
 	}
 

--- a/src/core/content/filter.js
+++ b/src/core/content/filter.js
@@ -389,7 +389,7 @@ class MetadataFilter {
 	static get REMIX_FILTERS() {
 		return [
 			// "- X Remix" -> "(X Remix)" and similar
-			{ source: /-\s(.+?)\s((Re)?mix|edit|dub|mix|vip|version)$/($1 $2)/i, target: '($1 $2)' },
+			{ source: /-\s(.+?)\s((Re)?mix|edit|dub|mix|vip|version)$/i, target: '($1 $2)' },
 			{ source: /-\s(Remix|VIP)$/i, target: '($1)' },
 		];
 	}

--- a/tests/core/filter.js
+++ b/tests/core/filter.js
@@ -424,6 +424,62 @@ const FIX_REMIX_SUFFIX_TEST_DATA = [{
 	description: 'should replace invalid suffix',
 	source: 'Track Title - Remix',
 	expected: 'Track Title (Remix)'
+}, {
+	description: 'should replace invalid suffix',
+	source: 'Track A - Remix',
+	expected: 'Track A (Remix)'
+}, {
+	description: 'should replace invalid suffix',
+	source: 'Track A - Group X dub',
+	expected: 'Track A (Group X dub)'
+}, {
+	description: 'should replace invalid suffix',
+	source: 'Track A - Group X edit',
+	expected: 'Track A (Group X edit)'
+}, {
+	description: 'should replace invalid suffix',
+	source: 'Track A - Group X mix',
+	expected: 'Track A (Group X mix)'
+}, {
+	description: 'should replace invalid suffix',
+	source: 'Track A - Group X Remix Edit',
+	expected: 'Track A (Group X Remix Edit)'
+}, {
+	description: 'should replace invalid suffix',
+	source: 'Track A - VIP',
+	expected: 'Track A (VIP)'
+}, {
+	description: 'should replace invalid suffix',
+	source: 'Track A - Radio Edit',
+	expected: 'Track A (Radio Edit)'
+}, {
+	description: 'should replace invalid suffix',
+	source: 'Track A - X Radio Edit',
+	expected: 'Track A (X Radio Edit)'
+}, {
+	description: 'should replace invalid suffix',
+	source: 'Track A - Short Version',
+	expected: 'Track A (Short Version)'
+}, {
+	description: 'should replace invalid suffix',
+	source: 'Track A - Original Mix',
+	expected: 'Track A (Original Mix)'
+}, {
+	description: 'should replace invalid suffix',
+	source: 'Track A - Radio Version',
+	expected: 'Track A (Radio Version)'
+}, {
+	description: 'should replace invalid suffix',
+	source: 'Track A - Group X Radio Mix',
+	expected: 'Track A (Group X Radio Mix)'
+}, {
+	description: 'should replace invalid suffix',
+	source: 'Track A - Continuous Mix',
+	expected: 'Track A (Continuous Mix)'
+}, {
+	description: 'should replace invalid suffix',
+	source: 'Track A - Factoria Vocal Mix',
+	expected: 'Track A (Factoria Vocal Mix)'
 }];
 
 /**
@@ -478,8 +534,8 @@ const FILTERS_DATA = [{
 	fields: ['track'],
 	testData: REMOVE_DOUBLE_TITLE_TEST_DATA,
 }, {
-	description: 'fixRemixSuffix',
-	filter: new MetadataFilter({ track: MetadataFilter.fixRemixSuffix }),
+	description: 'fixTrackSuffix',
+	filter: new MetadataFilter({ track: MetadataFilter.fixTrackSuffix }),
 	fields: ['track'],
 	testData: FIX_REMIX_SUFFIX_TEST_DATA,
 }];


### PR DESCRIPTION
**Describe the changes you made**
Extended filter that normalises " - Remix" to "(Remix)" to cover other varieties, as discussed in issue #1991.

Output of a small test script (first line original, second normalised):

```$ ./test.sh
Track A - Remix
Track A (Remix)

Track A - Group X dub
Track A (Group X dub)

Track A - Group X edit
Track A (Group X edit)

Track A - Group X mix
Track A (Group X mix)

Track A - Group X Remix Edit
Track A (Group X Remix Edit)

Track A - VIP
Track A (VIP)

Track A - Radio Edit
Track A (Radio Edit)

Track A - X Radio Edit
Track A (X Radio Edit)

Track A - Short Version
Track A (Short Version)

Track A - Original Mix
Track A (Original Mix)

Track A - Radio Version
Track A (Radio Version)

Track A - Group X Radio Mix
Track A (Group X Radio Mix)

Track A - Continuous Mix
Track A (Continuous Mix)

Track A - Factoria Vocal Mix
Track A (Factoria Vocal Mix)
```
