### PR TITLE
Update bandcamp-embed connector to match all domains

### DIFF
--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -42,8 +42,8 @@ define(function() {
 		],
 		js: ['connectors/pitchfork.js'],
 	}, {
-		label: 'Bandcamp Daily',
-		matches: ['*://daily.bandcamp.com/*'],
+		label: 'Bandcamp embeds',
+		matches: ['*://*/*'],
 		js: ['connectors/bandcamp-embed.js'],
 		allFrames: true,
 	}, {


### PR DESCRIPTION
This change is to not only scrobble Bandcamp embeds from:
- https://daily.bandcamp.com/2019/07/26/bandcamp-essential-releases-july-26/#more-106210

but also from any other websites:
- https://en.support.wordpress.com/audio/bandcamp/
- http://www.simonlittlebass.com/2012/01/31/bandcamp-tips-embedding-bandcamp-players-on-your-site/
- etc.