### PR TITLE
Apple Music Web Beta - Album and Title fix

### DIFF
--- a/src/connectors/apple-music.js
+++ b/src/connectors/apple-music.js
@@ -4,7 +4,7 @@
 
 const ARTISTALBUM_SEPARATOR = '—';
 
-const artistAlbumSelector = '.web-chrome-playback-lcd__sub-copy';
+const artistAlbumSelector = '.web-chrome-playback-lcd__sub-copy-scroll-inner-text-wrapper';
 
 Connector.playerSelector = '.web-chrome';
 
@@ -14,7 +14,7 @@ Connector.currentTimeSelector = '#apple-music-current-playback-time';
 
 Connector.remainingTimeSelector = '#apple-music-current-playback-time-remaining';
 
-Connector.trackSelector = '.web-chrome-playback-lcd__song-name';
+Connector.trackSelector = '.web-chrome-playback-lcd__song-name-scroll-inner-text-wrapper';
 
 Connector.getArtist = () => getArtistAlbum().artist;
 


### PR DESCRIPTION
I updated the sources that have the song title and album information, they have undergone some minor changes in the last update of the site.

I noticed that the extension was not getting the song information I was listening to correctly, so I checked the page console and confirmed that there was a problem.

![image](https://user-images.githubusercontent.com/43550940/65282645-c18edf80-db0b-11e9-9fcf-6cd91b52ca1a.png)

After changing the source for the title and album information, the extension worked again correctly.

![image](https://user-images.githubusercontent.com/43550940/65282669-d9666380-db0b-11e9-8595-0b5a6f57e0f0.png)

Considering the site is in beta, new changes like this or others may happen.
