### PR TITLE
Add support for GDS.FM

### DIFF
--- a/src/connectors/gds-play.fm.js
+++ b/src/connectors/gds-play.fm.js
@@ -1,0 +1,11 @@
+'use strict';
+
+Connector.playerSelector = '.meta-wrap';
+
+Connector.artistSelector = '.meta-artist';
+
+Connector.trackSelector = '.meta-title';
+
+Connector.playButtonSelector = '[src="/assets/images/play.gif"]';
+
+Connector.onReady = Connector.onStateChanged;

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1007,6 +1007,10 @@ define(function() {
 		matches: ['*://play.primephonic.com/*'],
 		js: ['connectors/primephonic.js'],
 	}, {
+		label: 'GDS.FM',
+		matches: ['*://play.gds.fm/*'],
+		js: ['connectors/gds-play.fm.js'],
+	}, {
 		label: 'Wynk Music',
 		matches: ['*://wynk.in/music*'],
 		js: ['connectors/wynk.js'],


### PR DESCRIPTION
Added connector for GDS.FM (they use capitals for their name and TLD)

**Additional context**
The main page ([gds.fm](http://gds.fm)) has an iframe with the player, but clicking on it redirects to [play.gds.fm](play.gds.fm)