### PR TITLE
[Info] Add user play count from Last.fm

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -493,6 +493,10 @@
     "message": "View track page",
     "description": "Placeholder of album input"
   },
+  "infoYourScrobbles": {
+    "message": "Your scrobbles",
+    "description": "Label for user play count"
+  },
 
 
   "pageActionBase": {

--- a/src/core/background/pipeline/metadata.js
+++ b/src/core/background/pipeline/metadata.js
@@ -12,7 +12,7 @@ define((require) => {
 		'duration', 'artist', 'track'
 	];
 	const METADATA_TO_COPY = [
-		'artistThumbUrl', 'artistUrl', 'trackUrl', 'albumUrl'
+		'artistThumbUrl', 'artistUrl', 'trackUrl', 'albumUrl', 'userPlayCount'
 	];
 
 	/**

--- a/src/core/background/scrobbler/lastfm.js
+++ b/src/core/background/scrobbler/lastfm.js
@@ -79,7 +79,7 @@ define((require) => {
 			let trackUrl = $doc.find('track > url').text();
 			let albumUrl = $doc.find('album > url').text();
 
-			let userPlayCount = $doc.find('userplaycount').text();
+			let userPlayCount = parseInt($doc.find('userplaycount').text());
 
 			return {
 				artist, track, album, duration, userloved,

--- a/src/core/background/scrobbler/lastfm.js
+++ b/src/core/background/scrobbler/lastfm.js
@@ -79,9 +79,11 @@ define((require) => {
 			let trackUrl = $doc.find('track > url').text();
 			let albumUrl = $doc.find('album > url').text();
 
+			let userPlayCount = $doc.find('userplaycount').text();
+
 			return {
 				artist, track, album, duration, userloved,
-				artistThumbUrl, artistUrl, albumUrl, trackUrl
+				artistThumbUrl, artistUrl, albumUrl, trackUrl, userPlayCount
 			};
 		}
 	}

--- a/src/ui/popups/info.css
+++ b/src/ui/popups/info.css
@@ -115,3 +115,12 @@ input {
 	cursor: default !important;
 	text-decoration: none !important;
 }
+
+.user-play-count {
+	background-color: #247ba0;
+	border-radius: 3px;
+	color: white;
+	display: inline-block;
+	font-size: x-small;
+	padding: 0 5px;
+}

--- a/src/ui/popups/info.css
+++ b/src/ui/popups/info.css
@@ -121,6 +121,11 @@ input {
 	border-radius: 3px;
 	color: white;
 	display: inline-block;
-	font-size: x-small;
+	font-size: 0.75rem;
+	margin-top: 4px;
 	padding: 0 5px;
+}
+.user-play-count::before {
+	content: '\f202';
+	font-family: 'Font Awesome 5 Brands';
 }

--- a/src/ui/popups/info.html
+++ b/src/ui/popups/info.html
@@ -30,6 +30,10 @@
 			<div class="albumArtist">
 				<a id="albumArtist" href="#" target="_blank"></a>
 			</div>
+			<div class="user-play-count">
+				<span id="userPlayCountLabel"></span>
+				<span id="userPlayCount"></span>
+			</div>
 		</div>
 		<div id="edit" data-hide="true">
 			<input type="text" id="track-input" i18n-placeholder="infoTrackPlaceholder" i18n-title="infoTrackPlaceholder" tabindex="1" />

--- a/src/ui/popups/info.html
+++ b/src/ui/popups/info.html
@@ -11,6 +11,7 @@
 	<script type="text/javascript" src="/ui/popups/info.js"></script>
 	<script type="text/javascript" src="/core/i18n.js"></script>
 
+	<link rel="stylesheet" href="/vendor/fontawesome/css/brands.min.css">
 	<link rel="stylesheet" href="/ui/popups/info.css" />
 </head>
 

--- a/src/ui/popups/info.js
+++ b/src/ui/popups/info.js
@@ -115,7 +115,7 @@ require([
 
 	function fillUserPlayCount() {
 		const playCount = getUserPlayCount();
-		if (playCount === '0') {
+		if (playCount === 0) {
 			$('.user-play-count').hide();
 			return;
 		}
@@ -314,7 +314,7 @@ require([
 	}
 
 	function getUserPlayCount() {
-		return song.metadata.userPlayCount || '0';
+		return song.metadata.userPlayCount || 0;
 	}
 
 	function swapTitleAndArtist() {

--- a/src/ui/popups/info.js
+++ b/src/ui/popups/info.js
@@ -114,8 +114,14 @@ require([
 	}
 
 	function fillUserPlayCount() {
+		const playCount = getUserPlayCount();
+		if (playCount === '0') {
+			$('.user-play-count').hide();
+			return;
+		}
+		$('.user-play-count').show();
 		$('#userPlayCountLabel').text(`${i18n('infoYourScrobbles')}:`);
-		$('#userPlayCount').text(getUserPlayCount());
+		$('#userPlayCount').text(playCount);
 	}
 
 	function getTrackInfo() {

--- a/src/ui/popups/info.js
+++ b/src/ui/popups/info.js
@@ -113,6 +113,11 @@ require([
 		$('#album-art').css('background-image', `url("${getCoverArt()}")`);
 	}
 
+	function fillUserPlayCount() {
+		$('#userPlayCountLabel').text(`${i18n('infoYourScrobbles')}:`);
+		$('#userPlayCount').text(getUserPlayCount());
+	}
+
 	function getTrackInfo() {
 		let trackInfo = {};
 		for (let field of EDITED_TRACK_FIELDS) {
@@ -211,6 +216,7 @@ require([
 	function updatePopupView() {
 		fillMetadataLabels(getTrackInfo());
 		fillAlbumCover();
+		fillUserPlayCount();
 
 		configControls();
 		updateControls();
@@ -299,6 +305,10 @@ require([
 	function getCoverArt() {
 		return song.parsed.trackArt || song.metadata.artistThumbUrl ||
 			'/icons/cover_art_default.png';
+	}
+
+	function getUserPlayCount() {
+		return song.metadata.userPlayCount || '0';
 	}
 
 	function swapTitleAndArtist() {


### PR DESCRIPTION
It's often desirable to see how many times we have scrobbled the currently playing song in the past.

The Last.fm `track.getinfo` API returns among other things a count that represents the number of times the user has previously scrobbled the song. It is represented by the `<userplaycount>` element.

This PR makes visual and logic code changes to display user's play count as **Your scrobbles** in the Info popup.

Fixes #2028

<img width="396" alt="user-play-count-web-scrobbler" src="https://user-images.githubusercontent.com/1288616/66259100-c8d01180-e7ca-11e9-865a-9514f9bde043.png">

**TODO:**
* Add a way to toggle 'Your scrobbles' on/off from extension options page
* Add relevant unit test(s)

cc @alexesprit
