### PR TITLE
Fix Tidal connector not recognizing plays after 10/23 update.

### DIFF
--- a/src/connectors/tidal.js
+++ b/src/connectors/tidal.js
@@ -4,7 +4,7 @@ let useShortTrackNames = false;
 
 readConnectorOptions();
 
-Connector.playerSelector = '[class^="nowPlaying"]';
+Connector.playerSelector = '#nowPlaying';
 
 Connector.playButtonSelector = `${Connector.playerSelector} [class*="playbackToggle"]`;
 


### PR DESCRIPTION
I noticed that after the most recent Tidal update no plays were being recognized. Looking at the DOM, it doesn't appear much has changed, so I'm wondering if something is funky with the `^=` and `*=` selectors. Unfortunately, most of those have to stay but the `playerSelector` can be simplified now. This gets scrobbling to work again, though I'm still experiencing weird behavior around the footer player, for example when clearing the play queue. I'll do some more digging but this should be a good-enough band-aid fix for now.
