### PR TITLE
Add Audiomack support

### DIFF
--- a/src/connectors/audiomack.js
+++ b/src/connectors/audiomack.js
@@ -1,0 +1,22 @@
+'use strict';
+
+Connector.playerSelector = '.player__inner';
+
+Connector.currentTimeSelector = '.player__waveform .waveform__elapsed';
+
+Connector.trackSelector = '.player__title';
+
+Connector.durationSelector = '.player__waveform .waveform__duration';
+
+Connector.artistSelector = '.player__artist';
+
+Connector.playButtonSelector = '.player__controls > .play-button--paused';
+
+Connector.getTrackArt = () => {
+	const trackArt = $('.avatar-container img').attr('src');
+	if (!trackArt) {
+		return null;
+	}
+	const endIdx = trackArt.includes('?') ? trackArt.indexOf('?') : trackArt.length;
+	return trackArt.substr(0, endIdx);
+};

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1219,5 +1219,10 @@ define(function() {
 		matches: ['*://www.radiojavan.com/*'],
 		js: 'connectors/radiojavan.js',
 		id: 'radiojavan',
+	}, {
+		label: 'Audiomack',
+		matches: ['*://audiomack.com/*'],
+		js: 'connectors/audiomack.js',
+		id: 'audiomack',
 	}];
 });


### PR DESCRIPTION
Closes #2129

Tests and lints fine

The `getTrackArt` function is because the img src contains a query string that gives you a tiny 48px icon, so it strips out the query string and gives you the full image.

The `currentTimeSelector` doesn't appear to work and I'm not sure why. If you console.log that css selector, you get the current time, and it is in a format that is compatible with the `Util.stringToSeconds` function. The `durationSelector` has a similar css selector and works fine.