### PR TITLE
Add pan y rosas discos connector.

### DIFF
--- a/src/connectors/panyrosasdiscos.js
+++ b/src/connectors/panyrosasdiscos.js
@@ -4,24 +4,18 @@ Connector.playerSelector = '#interfaceMI_0';
 
 Connector.pauseButtonSelector = '#statusMI_0 .mjp-playing';
 
-const splitAlbumData = () => {
+Connector.trackSelector = '#T_mp3j_0';
+
+Connector.getTrackInfo = () => {
 	const text = Util.getTextFromSelectors('.entry-title');
 	const pattern = /(pyr[0-9]+) (.+) – (.+)/g;
 	const matches = [...text.matchAll(pattern)][0];
 	return {
-		catalog: matches[1],
+		uniqueID: `${matches[1]}#${$('.mp3j_A_current').attr('id')}`,
 		artist: matches[2],
 		album: matches[3],
 	};
 };
-
-Connector.getArtist = () => splitAlbumData().artist;
-
-Connector.getAlbum = () => splitAlbumData().album;
-
-Connector.trackSelector = '#T_mp3j_0';
-
-Connector.getUniqueID = () => `${splitAlbumData().catalog}#${$('.mp3j_A_current').attr('id')}`;
 
 Connector.trackArtSelector = '.entry-content > p > a > img';
 

--- a/src/connectors/panyrosasdiscos.js
+++ b/src/connectors/panyrosasdiscos.js
@@ -17,7 +17,7 @@ Connector.getTrackInfo = () => {
 	};
 };
 
-Connector.trackArtSelector = '.entry-content > p > a > img';
+Connector.trackArtSelector = '.entry-content img:eq(0)';
 
 Connector.currentTimeSelector = '#P-Time-MI_0';
 

--- a/src/connectors/panyrosasdiscos.js
+++ b/src/connectors/panyrosasdiscos.js
@@ -1,0 +1,30 @@
+'use strict';
+
+Connector.playerSelector = '#interfaceMI_0';
+
+Connector.pauseButtonSelector = '#statusMI_0 .mjp-playing';
+
+const splitAlbumData = () => {
+	const text = Util.getTextFromSelectors('.entry-title');
+	const pattern = /(pyr[0-9]+) (.+) – (.+)/g;
+	const matches = [...text.matchAll(pattern)][0];
+	return {
+		catalog: matches[1],
+		artist: matches[2],
+		album: matches[3],
+	};
+};
+
+Connector.getArtist = () => splitAlbumData().artist;
+
+Connector.getAlbum = () => splitAlbumData().album;
+
+Connector.trackSelector = '#T_mp3j_0';
+
+Connector.getUniqueID = () => `${splitAlbumData().catalog}#${$('.mp3j_A_current').attr('id')}`;
+
+Connector.trackArtSelector = '.entry-content > p > a > img';
+
+Connector.currentTimeSelector = '#P-Time-MI_0';
+
+Connector.durationSelector = '#T-Time-MI_0';

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1234,5 +1234,10 @@ define(function() {
 		matches: ['*://www.thecurrent.org/*'],
 		js: 'connectors/thecurrent.js',
 		id: 'thecurrent',
+	}, {
+		label: 'pan y rosas discos',
+		matches: ['*://www.panyrosasdiscos.net/*'],
+		js: 'connectors/panyrosasdiscos.js',
+		id: 'panyrosasdiscos',
 	}];
 });


### PR DESCRIPTION
pan y rosas discos is a Chicago netlabel which puts out various kinds of experimental music. This connector seems to work well on most of the catalog, though it looks like pyr060 and older use a different player. Support for that player is not implemented yet.