### PR TITLE
Add "Explicit" metafilter, Setup filters for Amazon Prime Music

### DIFF
--- a/src/connectors/amazon.js
+++ b/src/connectors/amazon.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const filter = new MetadataFilter({ album: MetadataFilter.decodeHtmlEntities });
-
 Connector.playerSelector = '#dragonflyTransport .rightSide';
 
 Connector.getArtist = () => {
@@ -40,4 +38,4 @@ Connector.getUniqueID = () => {
 	return null;
 };
 
-Connector.applyFilter(filter);
+Connector.applyFilter(MetadataFilter.getAmazonFilter());

--- a/src/core/content/filter.js
+++ b/src/core/content/filter.js
@@ -224,6 +224,17 @@ class MetadataFilter {
 	}
 
 	/**
+	 * Remove "Explicit"-like strings from the text.
+	 * @param  {String} text String to be filtered
+	 * @return {String} Filtered string
+	 */
+	static removeExplicit(text) {
+		return MetadataFilter.filterWithFilterRules(
+			text, MetadataFilter.EXPLICIT_FILTER_RULES
+		);
+	}
+
+	/**
 	 * Replace "Title - X Remix" suffix with "Title (X Remix) and similar".
 	 * @param  {String} text String to be filtered
 	 * @return {String} Filtered string
@@ -388,6 +399,13 @@ class MetadataFilter {
 		];
 	}
 
+	static get EXPLICIT_FILTER_RULES() {
+		return [
+			// Explicit
+			{ source: /\s(\(|\[)Explicit(\)|\])/i, target: '' },
+		];
+	}
+
 	/**
 	 * Filter rules to remove "(Album|Stereo|Mono Version)"-like strings
 	 * from a text.
@@ -478,6 +496,30 @@ class MetadataFilter {
 			album: [
 				MetadataFilter.removeRemastered,
 				MetadataFilter.fixTrackSuffix,
+				MetadataFilter.removeLive,
+			],
+		});
+	}
+
+	/**
+	 * Get predefined filter object
+	 * @return {MetadataFilter} Filter object
+	 */
+	static getAmazonFilter() {
+		return new MetadataFilter({
+			track: [
+				MetadataFilter.removeExplicit,
+				MetadataFilter.removeRemastered,
+				MetadataFilter.fixTrackSuffix,
+				MetadataFilter.removeVersion,
+				MetadataFilter.removeLive,
+			],
+			album: [
+				MetadataFilter.decodeHtmlEntities,
+				MetadataFilter.removeExplicit,
+				MetadataFilter.removeRemastered,
+				MetadataFilter.fixTrackSuffix,
+				MetadataFilter.removeVersion,
 				MetadataFilter.removeLive,
 			],
 		});


### PR DESCRIPTION
**Describe the changes you made**
Removes the unnecessary "[Explicit]" tags that appear on Amazon. They mess up the scrobbling as they duplicate the songs in user's library. 

Applying other filters on top of that for Amazon in a predefined metafilter.

**Additional context**
You can see an example of what I'm talking about here:
![image](https://user-images.githubusercontent.com/13066221/70390103-1268f280-19ee-11ea-8cc4-86fcb27ab053.png)

