### PR TITLE
Add "feat. Artist" filter for Amazon tracks, Album Artist data from Artist tag and improved Explicit tag handling

### DIFF
--- a/src/connectors/amazon.js
+++ b/src/connectors/amazon.js
@@ -6,6 +6,8 @@ Connector.getArtist = () => {
 	return $('.trackInfoContainer .trackArtist a, .trackInfoContainer .trackArtist span').attr('title');
 };
 
+Connector.getAlbumArtist = Connector.getArtist;
+
 Connector.trackSelector = '.trackInfoContainer .trackTitle';
 
 Connector.albumSelector = '.trackSourceLink a';

--- a/src/connectors/amazon.js
+++ b/src/connectors/amazon.js
@@ -10,6 +10,24 @@ Connector.trackSelector = '.trackInfoContainer .trackTitle';
 
 Connector.albumSelector = '.trackSourceLink a';
 
+Connector.getAlbum = () => {
+	if ($('.trackSourceLink a').attr('href').includes('albums')) {
+		return $('.trackSourceLink a').text();
+	}
+
+	if ($('tr.selectable.currentlyPlaying td.albumCell')) {
+		return $('tr.selectable.currentlyPlaying td.albumCell').attr('title');
+	}
+
+	if ($('.nowPlayingDetail img.albumImage')) {
+		return $('.nowPlayingDetail img.albumImage').att('title');
+	}
+
+	if ($('.trackSourceLink a').data('ui-click-action') === 'selectAlbum') {
+		return $('.trackSourceLink a').attr('title');
+	}
+};
+
 Connector.currentTimeSelector = '.songDuration.timeElapsed';
 
 Connector.playButtonSelector = '.rightSide .playbackControls .playerIconPlay';

--- a/src/connectors/amazon.js
+++ b/src/connectors/amazon.js
@@ -10,8 +10,6 @@ Connector.getAlbumArtist = Connector.getArtist;
 
 Connector.trackSelector = '.trackInfoContainer .trackTitle';
 
-Connector.albumSelector = '.trackSourceLink a';
-
 Connector.getAlbum = () => {
 	if ($('.trackSourceLink a').attr('href').includes('albums')) {
 		return $('.trackSourceLink a').text();

--- a/src/connectors/amazon.js
+++ b/src/connectors/amazon.js
@@ -8,19 +8,7 @@ Connector.getArtist = () => {
 
 Connector.trackSelector = '.trackInfoContainer .trackTitle';
 
-Connector.getAlbum = () => {
-	if ($('tr.selectable.currentlyPlaying td.albumCell')) {
-		return $('tr.selectable.currentlyPlaying td.albumCell').attr('title');
-	}
-
-	if ($('.nowPlayingDetail img.albumImage')) {
-		return $('.nowPlayingDetail img.albumImage').att('title');
-	}
-
-	if ($('.trackSourceLink a').data('ui-click-action') === 'selectAlbum') {
-		return $('.trackSourceLink a').attr('title');
-	}
-};
+Connector.albumSelector = '.trackSourceLink a';
 
 Connector.currentTimeSelector = '.songDuration.timeElapsed';
 

--- a/src/core/content/filter.js
+++ b/src/core/content/filter.js
@@ -235,6 +235,17 @@ class MetadataFilter {
 	}
 
 	/**
+	 * Remove "feat"-like strings from the text.
+	 * @param  {String} text String to be filtered
+	 * @return {String} Filtered string
+	 */
+	static removeFeature(text) {
+		return MetadataFilter.filterWithFilterRules(
+			text, MetadataFilter.FEATURE_FILTER_RULES
+		);
+	}
+
+	/**
 	 * Replace "Title - X Remix" suffix with "Title (X Remix) and similar".
 	 * @param  {String} text String to be filtered
 	 * @return {String} Filtered string
@@ -406,6 +417,13 @@ class MetadataFilter {
 		];
 	}
 
+	static get FEATURE_FILTER_RULES() {
+		return [
+			// [Feat. Artist] or (Feat. Artist)
+			{ source: /\s[([]feat. .+[)\]]/i, target: '' },
+		];
+	}
+
 	/**
 	 * Filter rules to remove "(Album|Stereo|Mono Version)"-like strings
 	 * from a text.
@@ -511,6 +529,7 @@ class MetadataFilter {
 		return new MetadataFilter({
 			track: [
 				MetadataFilter.removeExplicit,
+				MetadataFilter.removeFeature,
 				MetadataFilter.removeRemastered,
 				MetadataFilter.fixTrackSuffix,
 				MetadataFilter.removeVersion,

--- a/src/core/content/filter.js
+++ b/src/core/content/filter.js
@@ -235,6 +235,15 @@ class MetadataFilter {
 	}
 
 	/**
+	 * Generates Album Artist from Artist when "feat. Artist B" is present
+	 * @param  {String} text String to be filtered
+	 * @return {String} Transformed string
+	 */
+	static albumArtistFromArtist(text) {
+		return text.split(' feat. ')[0];
+	}
+
+	/**
 	 * Remove "feat"-like strings from the text.
 	 * @param  {String} text String to be filtered
 	 * @return {String} Filtered string
@@ -544,6 +553,9 @@ class MetadataFilter {
 				MetadataFilter.fixTrackSuffix,
 				MetadataFilter.removeVersion,
 				MetadataFilter.removeLive,
+			],
+			albumArtist: [
+				MetadataFilter.albumArtistFromArtist,
 			],
 		});
 	}

--- a/src/core/content/filter.js
+++ b/src/core/content/filter.js
@@ -224,13 +224,13 @@ class MetadataFilter {
 	}
 
 	/**
-	 * Remove "Explicit"-like strings from the text.
+	 * Remove "Explicit" and "Clean"-like strings from the text.
 	 * @param  {String} text String to be filtered
 	 * @return {String} Filtered string
 	 */
-	static removeExplicit(text) {
+	static removeCleanExplicit(text) {
 		return MetadataFilter.filterWithFilterRules(
-			text, MetadataFilter.EXPLICIT_FILTER_RULES
+			text, MetadataFilter.CLEAN_EXPLICIT_FILTER_RULES
 		);
 	}
 
@@ -410,10 +410,12 @@ class MetadataFilter {
 		];
 	}
 
-	static get EXPLICIT_FILTER_RULES() {
+	static get CLEAN_EXPLICIT_FILTER_RULES() {
 		return [
 			// (Explicit) or [Explicit]
 			{ source: /\s[([]Explicit[)\]]/i, target: '' },
+			// (Clean) or [Clean]
+			{ source: /\s[([]Clean[)\]]/i, target: '' },
 		];
 	}
 
@@ -528,7 +530,7 @@ class MetadataFilter {
 	static getAmazonFilter() {
 		return new MetadataFilter({
 			track: [
-				MetadataFilter.removeExplicit,
+				MetadataFilter.removeCleanExplicit,
 				MetadataFilter.removeFeature,
 				MetadataFilter.removeRemastered,
 				MetadataFilter.fixTrackSuffix,
@@ -537,7 +539,7 @@ class MetadataFilter {
 			],
 			album: [
 				MetadataFilter.decodeHtmlEntities,
-				MetadataFilter.removeExplicit,
+				MetadataFilter.removeCleanExplicit,
 				MetadataFilter.removeRemastered,
 				MetadataFilter.fixTrackSuffix,
 				MetadataFilter.removeVersion,

--- a/src/core/content/filter.js
+++ b/src/core/content/filter.js
@@ -429,6 +429,8 @@ class MetadataFilter {
 			{ source: /-\sStereo Version$/, target: '' },
 			// Pure McCartney (Deluxe Edition)
 			{ source: /\(Deluxe Edition\)$/, target: '' },
+			// 6 Foot 7 Foot (Explicit Version)
+			{ source: /[([]Explicit Version[)\]]/i, target: '' },
 		];
 	}
 

--- a/src/core/content/filter.js
+++ b/src/core/content/filter.js
@@ -401,8 +401,8 @@ class MetadataFilter {
 
 	static get EXPLICIT_FILTER_RULES() {
 		return [
-			// Explicit
-			{ source: /\s(\(|\[)Explicit(\)|\])/i, target: '' },
+			// (Explicit) or [Explicit]
+			{ source: /\s[([]Explicit[)\]]/i, target: '' },
 		];
 	}
 

--- a/tests/content/filter.js
+++ b/tests/content/filter.js
@@ -598,6 +598,30 @@ const CLEAN_EXPLICIT_FILTER_RULES_TEST_DATA = [{
 	expected: 'Track'
 }];
 
+const ALBUM_ARTIST_FROM_ARTIST_FILTER_RULES_TEST_DATA = [{
+	description: 'should remove featured artist from suffix',
+	source: 'Artist A feat. Artist B',
+	expected: 'Artist A'
+}, {
+	description: 'should remove featured artist from suffix',
+	source: 'Artist A feat. Artist B, Artist C',
+	expected: 'Artist A'
+}, {
+	description: 'should remove featured artist from suffix',
+	source: 'Artist A feat. Artist B, Artist C & Artist D',
+	expected: 'Artist A'
+}];
+
+const FEATURE_FILTER_RULES_TEST_DATA = [{
+	description: 'should remove featured artist from suffix',
+	source: 'Artist A [feat. Artist B]',
+	expected: 'Artist A'
+}, {
+	description: 'should remove featured artist from suffix',
+	source: 'Artist A (feat. Artist B)',
+	expected: 'Artist A'
+}];
+
 /**
  * Filters data is an array of objects. Each object must contain
  * four fields: 'description', 'filter', 'fields' and 'testData'.
@@ -662,6 +686,16 @@ const FILTERS_TEST_DATA = [{
 	filterFunc: MetadataFilter.removeCleanExplicit,
 	fields: ['track'],
 	testData: CLEAN_EXPLICIT_FILTER_RULES_TEST_DATA,
+}, {
+	description: 'Album Artist from Artist filter function',
+	filterFunc: MetadataFilter.albumArtistFromArtist,
+	fields: ['albumArtist'],
+	testData: ALBUM_ARTIST_FROM_ARTIST_FILTER_RULES_TEST_DATA,
+}, {
+	description: 'Feature filter function',
+	filterFunc: MetadataFilter.removeFeature,
+	fields: ['track'],
+	testData: FEATURE_FILTER_RULES_TEST_DATA,
 }];
 
 /**

--- a/tests/content/filter.js
+++ b/tests/content/filter.js
@@ -580,13 +580,21 @@ const SUFFIX_FILTER_RULES_TEST_DATA = [{
 	expected: 'Track A (Factoria Vocal Mix)'
 }];
 
-const EXPLICIT_FILTER_RULES_TEST_DATA = [{
+const CLEAN_EXPLICIT_FILTER_RULES_TEST_DATA = [{
 	description: 'should remove [Explicit] suffix',
 	source: 'Track [Explicit]',
 	expected: 'Track'
 }, {
 	description: 'should remove (Explicit) suffix',
 	source: 'Track (Explicit)',
+	expected: 'Track'
+}, {
+	description: 'should remove [Clean] suffix',
+	source: 'Track [Clean]',
+	expected: 'Track'
+}, {
+	description: 'should remove (Clean) suffix',
+	source: 'Track (Clean)',
 	expected: 'Track'
 }];
 
@@ -650,10 +658,10 @@ const FILTERS_TEST_DATA = [{
 	fields: ['track'],
 	testData: LIVE_FILTER_RULES_TEST_DATA,
 }, {
-	description: 'Explicit filter function',
-	filterFunc: MetadataFilter.removeExplicit,
+	description: 'Clean/Explicit filter function',
+	filterFunc: MetadataFilter.removeCleanExplicit,
 	fields: ['track'],
-	testData: EXPLICIT_FILTER_RULES_TEST_DATA,
+	testData: CLEAN_EXPLICIT_FILTER_RULES_TEST_DATA,
 }];
 
 /**


### PR DESCRIPTION
**Describe the changes you made**
Added a filter that removes "[feat. Artist]" tags from the track's `Title` metadata in Amazon Music.

Some tracks contain "(Explicit Version)" that needed to be handling for "Explicit" filtering. Added this as a case under "Version" filtering. 

**Additional context**
Effectively, all the changes combined turn this:
![image](https://user-images.githubusercontent.com/13066221/70390809-86a69480-19f4-11ea-830c-b2693fd184d6.png)
into this:
![image](https://user-images.githubusercontent.com/13066221/70390887-3e3ba680-19f5-11ea-9718-465515025ab5.png)