### PR TITLE
Improve Amazon Connector with normalized featured artists 

### DIFF
--- a/src/core/content/filter.js
+++ b/src/core/content/filter.js
@@ -251,6 +251,17 @@ class MetadataFilter {
 	}
 
 	/**
+	 * Generates normalized "feat. Artist B" text from [feat. Artist B] style
+	 * @param  {String} text String to be filtered
+	 * @return {String} Transformed string
+	 */
+	static normalizeFeature(text) {
+		return MetadataFilter.filterWithFilterRules(
+			text, MetadataFilter.NORMALIZE_FEATURE_FILTER_RULES
+		);
+	}
+
+	/**
 	 * Remove "feat"-like strings from the text.
 	 * @param  {String} text String to be filtered
 	 * @return {String} Filtered string
@@ -441,6 +452,13 @@ class MetadataFilter {
 		];
 	}
 
+	static get NORMALIZE_FEATURE_FILTER_RULES() {
+		return [
+			// [Feat. Artist] or (Feat. Artist) -> Feat. Artist
+			{ source: /\s[([](feat. .+)[)\]]/i, target: ' $1' },
+		];
+	}
+
 	/**
 	 * Filter rules to remove "(Album|Stereo|Mono Version)"-like strings
 	 * from a text.
@@ -538,6 +556,9 @@ class MetadataFilter {
 	/* istanbul ignore next */
 	static getAmazonFilter() {
 		return new MetadataFilter({
+			artist: [
+				MetadataFilter.normalizeFeature,
+			],
 			track: [
 				MetadataFilter.removeCleanExplicit,
 				MetadataFilter.removeFeature,
@@ -555,6 +576,7 @@ class MetadataFilter {
 				MetadataFilter.removeLive,
 			],
 			albumArtist: [
+				MetadataFilter.normalizeFeature,
 				MetadataFilter.albumArtistFromArtist,
 			],
 		});

--- a/src/core/content/filter.js
+++ b/src/core/content/filter.js
@@ -244,7 +244,10 @@ class MetadataFilter {
 	 * @return {String} Transformed string
 	 */
 	static albumArtistFromArtist(text) {
-		return text.split(' feat. ')[0];
+		if (text.includes(' feat. ')) {
+			return text.split(' feat. ')[0];
+		}
+		return text;
 	}
 
 	/**

--- a/tests/content/filter.js
+++ b/tests/content/filter.js
@@ -715,7 +715,7 @@ const FILTERS_TEST_DATA = [{
 	fields: ['track'],
 	testData: FEATURE_FILTER_RULES_TEST_DATA,
 }, {
-	description: 'Noralize feature text filter function',
+	description: 'Normalize feature text filter function',
 	filterFunc: MetadataFilter.normalizeFeature,
 	fields: ['albumArtist'],
 	testData: NORMALIZE_FEATURE_TEXT_FILTER_RULES_TEST_DATA,

--- a/tests/content/filter.js
+++ b/tests/content/filter.js
@@ -610,6 +610,10 @@ const ALBUM_ARTIST_FROM_ARTIST_FILTER_RULES_TEST_DATA = [{
 	description: 'should remove featured artist from suffix',
 	source: 'Artist A feat. Artist B, Artist C & Artist D',
 	expected: 'Artist A'
+}, {
+	description: 'should return original text if feat. not present',
+	source: 'Artist A',
+	expected: 'Artist A'
 }];
 
 const NORMALIZE_FEATURE_TEXT_FILTER_RULES_TEST_DATA = [{

--- a/tests/content/filter.js
+++ b/tests/content/filter.js
@@ -714,6 +714,11 @@ const FILTERS_TEST_DATA = [{
 	filterFunc: MetadataFilter.removeFeature,
 	fields: ['track'],
 	testData: FEATURE_FILTER_RULES_TEST_DATA,
+}, {
+	description: 'Noralize feature text filter function',
+	filterFunc: MetadataFilter.normalizeFeature,
+	fields: ['albumArtist'],
+	testData: NORMALIZE_FEATURE_TEXT_FILTER_RULES_TEST_DATA,
 }];
 
 /**

--- a/tests/content/filter.js
+++ b/tests/content/filter.js
@@ -612,6 +612,20 @@ const ALBUM_ARTIST_FROM_ARTIST_FILTER_RULES_TEST_DATA = [{
 	expected: 'Artist A'
 }];
 
+const NORMALIZE_FEATURE_TEXT_FILTER_RULES_TEST_DATA = [{
+	description: 'should transform [feat. Artist B] to feat. Artist B',
+	source: 'Artist A [feat. Artist B]',
+	expected: 'Artist A feat. Artist B'
+}, {
+	description: 'should not transform if no match for [feat. Artist B]',
+	source: 'Artist A',
+	expected: 'Artist A'
+}, {
+	description: 'should not transform if no match for [feat. Artist B]',
+	source: 'Artist A feat. Artist B',
+	expected: 'Artist A feat. Artist B'
+}];
+
 const FEATURE_FILTER_RULES_TEST_DATA = [{
 	description: 'should remove featured artist from suffix',
 	source: 'Artist A [feat. Artist B]',


### PR DESCRIPTION
**Describe the changes you made**
The text that appears in Artist tag as featured artist, i.e. "Artist A feat. B" differs between the album pages and the library pages (where it is [feat. Artist B]) in square brackets.

This case normalizes the artist tag to not contain the square brackets if they are present.

**Additional context**
Library page
![image](https://user-images.githubusercontent.com/13066221/70737641-04daa200-1d39-11ea-8e56-bc185adcdd12.png)

Album page
![image](https://user-images.githubusercontent.com/13066221/70737670-13c15480-1d39-11ea-83da-5919977133ba.png)