### PR TITLE
Add SiriusXM Player .ca (canada) url match pattern

### DIFF
--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -949,7 +949,10 @@ const connectors = [{
 	id: 'wfmu',
 }, {
 	label: 'SiriusXM',
-	matches: ['*://player.siriusxm.com/*'],
+	matches: [
+		'*://player.siriusxm.com/*',
+		'*://player.siriusxm.ca/*'
+	],
 	js: 'connectors/siriusxm-player.js',
 	id: 'siriusxm-player',
 }, {


### PR DESCRIPTION
**Describe the changes you made**

player.siriusxm.ca was not being recognized as a supported website without adding a custom match pattern.
Adding this pattern so the .ca app will be recognized by default.
