### PR TITLE
Change title selector for NPR First Listen.

### DIFF
--- a/src/connectors/npr.js
+++ b/src/connectors/npr.js
@@ -17,7 +17,7 @@ Connector.getArtistTrack = () => {
 	let artist = null;
 	let track = null;
 
-	const rawText = $('.item-current').text();
+	const rawText = $('.audio-title').text();
 	const result = rawText.match(titleRegEx);
 	if (result) {
 		artist = result[1];


### PR DESCRIPTION
Noticed the current connector wasn't working for
https://www.npr.org/2020/01/28/799335901/first-listen-hop-along-frances-quinlan-likewise. Haven't
checked older pages yet, though the streams usually disappear after the album
is officially released (so I think it's less important if the old format is
still on the old pages.)
