### PR TITLE
Update bandcamp-embed connector

### DIFF
--- a/src/connectors/bandcamp-embed.js
+++ b/src/connectors/bandcamp-embed.js
@@ -5,18 +5,18 @@
  * Currently used for Bandcamp Daily.
  */
 
-Connector.playerSelector = '#player';
+Connector.playerSelector = '#p-daily-article';
 
-Connector.artistSelector = '#artist';
+Connector.artistSelector = '.player.playing .mpartist';
 
-Connector.trackSelector = '.currenttrack .tracktitle';
+Connector.trackSelector = '.player.playing .mptracktitle';
 
-Connector.albumSelector = '#album';
+Connector.albumSelector = '.player.playing .mptralbum';
 
-Connector.currentTimeSelector = '.currenttrack .currenttime';
+Connector.currentTimeSelector = '.player.playing .mptime > span:first-child';
 
-Connector.durationSelector = '.currenttrack .tracktime';
+Connector.durationSelector = '.player.playing .mptime > span:last-child';
 
-Connector.trackArtSelector = '.art';
+Connector.trackArtSelector = '.player.playing .mpaa img';
 
-Connector.isPlaying = () => $('#player').hasClass('playing');
+Connector.isPlaying = () => $('.player.playing').length > 0;


### PR DESCRIPTION
Update bandcamp-embed to work with new Bandcamp Daily player

**Describe the changes you made**
Updated selectors to work with new page design.

**Additional context**
Addresses issue #2245 , where the bandcamp-embed.js connector no longer works with the new bandcamp daily redesign.
I think the playerSelector is too broad, but I couldn't get it to work with any other element on the page, including the floating player at the bottom, which I think may be re-created or not updated when not in view.
Tested in Firefox 73.0b11 (64-bit) on windows 10.
