### PR TITLE
Use icons in info popup window

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -375,10 +375,6 @@
         "message": "Kein Lieblingslied",
         "description": "Label of love/unlove button"
     },
-    "infoEdit": {
-        "message": "Bearbeiten",
-        "description": "Label of edit button"
-    },
     "infoEditTitle": {
         "message": "Titel-Metadaten bearbeiten",
         "description": "Title of edit button"
@@ -386,10 +382,6 @@
     "infoEditUnableTitle": {
         "message": "Du kannst bereits gescrobblete Titel nicht bearbeiten",
         "description": "Title of edit button"
-    },
-    "infoSwap": {
-        "message": "Austauschen",
-        "description": "Label of swap button"
     },
     "infoSwapTitle": {
         "message": "Tausche Titelname und Künstler aus",
@@ -399,14 +391,6 @@
         "message": "Du kannst einen bereits gescrobbleten Titel nicht austauschen",
         "description": "Title of swap button"
     },
-    "infoSubmit": {
-        "message": "Senden",
-        "description": "Label of submit button"
-    },
-    "infoRevert": {
-        "message": "Zurücksetzen",
-        "description": "Label of revert button"
-    },
     "infoRevertTitle": {
         "message": "Änderungen zurücksetzen",
         "description": "Title of revert button"
@@ -414,10 +398,6 @@
     "infoRevertUnableTitle": {
         "message": "Du kannst einen bereits gescrobbleten Titel nicht zurücksetzen",
         "description": "Title of revert button"
-    },
-    "infoSkip": {
-        "message": "Überspringen",
-        "description": "Label of skip button"
     },
     "infoSkipTitle": {
         "message": "Den aktuellen Titel nicht scrobblen",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -421,10 +421,6 @@
     "message": "Unlove track",
     "description": "Label of love/unlove button"
   },
-  "infoEdit": {
-    "message": "Edit",
-    "description": "Label of edit button"
-  },
   "infoEditTitle": {
     "message": "Edit track metadata",
     "description": "Title of edit button"
@@ -432,10 +428,6 @@
   "infoEditUnableTitle": {
     "message": "You cannot edit this track",
     "description": "Title of edit button"
-  },
-  "infoSwap": {
-    "message": "Swap",
-    "description": "Label of swap button"
   },
   "infoSwapTitle": {
     "message": "Swap title and artist",
@@ -445,10 +437,6 @@
     "message": "You cannot swap empty track info",
     "description": "Title of swap button"
   },
-  "infoSubmit": {
-    "message": "Submit",
-    "description": "Label of submit button"
-  },
   "infoSubmitTitle": {
     "message": "Submit changes",
     "description": "Title of submit button"
@@ -456,10 +444,6 @@
   "infoSubmitUnableTitle": {
     "message": "You cannot submit empty track info",
     "description": "Title of submit button"
-  },
-  "infoRevert": {
-    "message": "Revert",
-    "description": "Label of revert button"
   },
   "infoRevertTitle": {
     "message": "Revert changes",
@@ -469,10 +453,6 @@
     "message": "You cannot revert this track",
     "description": "Title of revert button"
   },
-  "infoSkip": {
-    "message": "Skip",
-    "description": "Label of skip button"
-  },
   "infoSkipTitle": {
     "message": "Don't scrobble current track",
     "description": "Title of skip button"
@@ -480,6 +460,10 @@
   "infoSkipUnableTitle": {
     "message": "You cannot skip this track",
     "description": "Title of skip button"
+  },
+  "infoSkippedTitle": {
+    "message": "You skipped this track",
+    "description": "Title of unskip button"
   },
   "infoOpenAlbumArt": {
     "message": "Open album art in new tab",

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -403,10 +403,6 @@
         "message": "Desamar esta canción",
         "description": "Label of love/unlove button"
     },
-    "infoEdit": {
-        "message": "Modificar",
-        "description": "Label of edit button"
-    },
     "infoEditTitle": {
         "message": "Modificar los metadatos de esta canción",
         "description": "Title of edit button"
@@ -414,10 +410,6 @@
     "infoEditUnableTitle": {
         "message": "No puede modificar canciones scrobbled",
         "description": "Title of edit button"
-    },
-    "infoSwap": {
-        "message": "Intercambiar",
-        "description": "Label of swap button"
     },
     "infoSwapTitle": {
         "message": "Intercambiar título y artista",
@@ -427,14 +419,6 @@
         "message": "No puede intercambiar canciones scrobbled",
         "description": "Title of swap button"
     },
-    "infoSubmit": {
-        "message": "Enviar",
-        "description": "Label of submit button"
-    },
-    "infoRevert": {
-        "message": "Revertir",
-        "description": "Label of revert button"
-    },
     "infoRevertTitle": {
         "message": "Revertir cambios",
         "description": "Title of revert button"
@@ -442,10 +426,6 @@
     "infoRevertUnableTitle": {
         "message": "No puede revertir canciones scrobbled",
         "description": "Title of revert button"
-    },
-    "infoSkip": {
-        "message": "Omitir",
-        "description": "Label of skip button"
     },
     "infoSkipTitle": {
         "message": "No scrobble la actual canción",

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -375,10 +375,6 @@
         "message": "Odkochaj utwór",
         "description": "Label of love/unlove button"
     },
-    "infoEdit": {
-        "message": "Edytuj",
-        "description": "Label of edit button"
-    },
     "infoEditTitle": {
         "message": "Edytuj informacje o utworze",
         "description": "Title of edit button"
@@ -386,10 +382,6 @@
     "infoEditUnableTitle": {
         "message": "Nie możesz edytować już przescrobblowanych informacji o utworze",
         "description": "Title of edit button"
-    },
-    "infoSwap": {
-        "message": "Zamień miejscami",
-        "description": "Label of swap button"
     },
     "infoSwapTitle": {
         "message": "Podmienia wartości pól tytułu i wykonawcy",
@@ -399,14 +391,6 @@
         "message": "Nie możesz zamienić już przescrobblowanych informacji o utworze",
         "description": "Title of swap button"
     },
-    "infoSubmit": {
-        "message": "Zachowaj",
-        "description": "Label of submit button"
-    },
-    "infoRevert": {
-        "message": "Odrzuć",
-        "description": "Label of revert button"
-    },
     "infoRevertTitle": {
         "message": "Odrzuć zmiany",
         "description": "Title of revert button"
@@ -414,10 +398,6 @@
     "infoRevertUnableTitle": {
         "message": "Nie możesz odrzucić zmian w przescrobblowanym utworze",
         "description": "Title of revert button"
-    },
-    "infoSkip": {
-        "message": "Pomiń",
-        "description": "Label of skip button"
     },
     "infoSkipTitle": {
         "message": "Nie scrobbluj tego utworu",

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -379,10 +379,6 @@
         "message": "Desmarcar como preferida",
         "description": "Label of love/unlove button"
     },
-    "infoEdit": {
-        "message": "Editar",
-        "description": "Label of edit button"
-    },
     "infoEditTitle": {
         "message": "Editar metadados da faixa",
         "description": "Title of edit button"
@@ -390,10 +386,6 @@
     "infoEditUnableTitle": {
         "message": "Você não pode editar uma faixa com scrobble efetuado",
         "description": "Title of edit button"
-    },
-    "infoSwap": {
-        "message": "Trocar",
-        "description": "Label of swap button"
     },
     "infoSwapTitle": {
         "message": "Trocar título e artista",
@@ -403,14 +395,6 @@
         "message": "Você não pode trocar uma faixa com scrobble efetuado",
         "description": "Title of swap button"
     },
-    "infoSubmit": {
-        "message": "Enviar",
-        "description": "Label of submit button"
-    },
-    "infoRevert": {
-        "message": "Reverter",
-        "description": "Label of revert button"
-    },
     "infoRevertTitle": {
         "message": "Reverter alterações",
         "description": "Title of revert button"
@@ -418,10 +402,6 @@
     "infoRevertUnableTitle": {
         "message": "Você não pode reverter uma faixa com scrobble efetuado",
         "description": "Title of revert button"
-    },
-    "infoSkip": {
-        "message": "Pular",
-        "description": "Label of skip button"
     },
     "infoSkipTitle": {
         "message": "Não fazer scrobble da faixa atual",

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -403,10 +403,6 @@
         "message": "Не нравится",
         "description": "Label of love/unlove button"
     },
-    "infoEdit": {
-        "message": "Изменить",
-        "description": "Label of edit button"
-    },
     "infoEditTitle": {
         "message": "Изменить информацию о треке",
         "description": "Title of edit button"
@@ -414,10 +410,6 @@
     "infoEditUnableTitle": {
         "message": "Вы не можете изменить информацию о треке, который был заскробблен",
         "description": "Title of edit button"
-    },
-    "infoSwap": {
-        "message": "Поменять",
-        "description": "Label of swap button"
     },
     "infoSwapTitle": {
         "message": "Поменять исполнителя и название трека местами",
@@ -427,14 +419,6 @@
         "message": "Вы не можете изменить заскробленный трек",
         "description": "Title of swap button"
     },
-    "infoSubmit": {
-        "message": "Принять",
-        "description": "Label of submit button"
-    },
-    "infoRevert": {
-        "message": "Отменить",
-        "description": "Label of revert button"
-    },
     "infoRevertTitle": {
         "message": "Отменить изменения",
         "description": "Title of revert button"
@@ -442,10 +426,6 @@
     "infoRevertUnableTitle": {
         "message": "Вы не можете сбросить информацию о треке, который был заскробблен",
         "description": "Title of revert button"
-    },
-    "infoSkip": {
-        "message": "Пропустить",
-        "description": "Label of skip button"
     },
     "infoSkipTitle": {
         "message": "Не скробблить текущий трек",

--- a/src/_locales/sk_SK/messages.json
+++ b/src/_locales/sk_SK/messages.json
@@ -379,10 +379,6 @@
         "message": "Odstrániť z obľúbených",
         "description": "Label of love/unlove button"
     },
-    "infoEdit": {
-        "message": "Upraviť",
-        "description": "Label of edit button"
-    },
     "infoEditTitle": {
         "message": "Upraviť metadáta skladby",
         "description": "Title of edit button"
@@ -390,10 +386,6 @@
     "infoEditUnableTitle": {
         "message": "Nie je možné upraviť už zaznamenanú skladbu",
         "description": "Title of edit button"
-    },
-    "infoSwap": {
-        "message": "Vymeniť",
-        "description": "Label of swap button"
     },
     "infoSwapTitle": {
         "message": "Vymeniť názov skladby s interpretom",
@@ -403,14 +395,6 @@
         "message": "Nie je možné vymeniť údaje zaznamenanej skladby",
         "description": "Title of swap button"
     },
-    "infoSubmit": {
-        "message": "Uložiť",
-        "description": "Label of submit button"
-    },
-    "infoRevert": {
-        "message": "Vrátiť",
-        "description": "Label of revert button"
-    },
     "infoRevertTitle": {
         "message": "Vrátiť zmeny",
         "description": "Title of revert button"
@@ -418,10 +402,6 @@
     "infoRevertUnableTitle": {
         "message": "Nie je možné vrátiť zmeny už zaznamenanej skladby",
         "description": "Title of revert button"
-    },
-    "infoSkip": {
-        "message": "Vynechať",
-        "description": "Label of skip button"
     },
     "infoSkipTitle": {
         "message": "Ignorovať práve hranú skladbu",

--- a/src/_locales/zh/messages.json
+++ b/src/_locales/zh/messages.json
@@ -375,10 +375,6 @@
         "message": "取消收藏",
         "description": "Label of love/unlove button"
     },
-    "infoEdit": {
-        "message": "编辑",
-        "description": "Label of edit button"
-    },
     "infoEditTitle": {
         "message": "编辑曲目元数据",
         "description": "Title of edit button"
@@ -386,10 +382,6 @@
     "infoEditUnableTitle": {
         "message": "无法编辑已提交曲目",
         "description": "Title of edit button"
-    },
-    "infoSwap": {
-        "message": "交换",
-        "description": "Label of swap button"
     },
     "infoSwapTitle": {
         "message": "交换曲目标题和艺术家",
@@ -399,14 +391,6 @@
         "message": "无法交换已提交曲目",
         "description": "Title of swap button"
     },
-    "infoSubmit": {
-        "message": "提交",
-        "description": "Label of submit button"
-    },
-    "infoRevert": {
-        "message": "还原",
-        "description": "Label of revert button"
-    },
     "infoRevertTitle": {
         "message": "还原变更",
         "description": "Title of revert button"
@@ -414,10 +398,6 @@
     "infoRevertUnableTitle": {
         "message": "无法还原已提交曲目",
         "description": "Title of revert button"
-    },
-    "infoSkip": {
-        "message": "跳过",
-        "description": "Label of skip button"
     },
     "infoSkipTitle": {
         "message": "不记录当前曲目",

--- a/src/ui/popups/info.css
+++ b/src/ui/popups/info.css
@@ -188,5 +188,5 @@ input {
 }
 
 [disabled] {
-	color: #999;
+	color: #aaa;
 }

--- a/src/ui/popups/info.css
+++ b/src/ui/popups/info.css
@@ -8,7 +8,7 @@ body, button, input {
 
 body {
 	background-color: #fff;
-	color: #000;
+	color: #212529;
 	font-size: 13px;
 	margin: 0px;
 	overflow: hidden;
@@ -16,7 +16,7 @@ body {
 }
 
 a {
-	color: #000;
+	color: #212529;
 	text-decoration: none;
 }
 
@@ -58,15 +58,11 @@ input {
 	width: 136px;
 }
 
-.album-art:hover {
-	cursor: pointer;
-}
-
 .edit-fields,
 .info-fields {
 	grid-column: 1;
 	grid-row: 1;
-	line-height: 1.5em;
+	line-height: 1.4em;
 }
 
 .edit-controls {
@@ -74,20 +70,6 @@ input {
 	grid-column: 1;
 	grid-row: 2;
 	justify-self: start;
-}
-
-.edit-controls > * + *:before {
-	/* content: '&nbsp;•&nbsp;' */
-	content: '\2022\0000a0';
-	display: inline-block;
-}
-
-.scrobble-controls {
-	align-self: end;
-	grid-column: 1;
-	grid-row: 2;
-	justify-self: end;
-	margin-right: 5px;
 }
 
 .artist, .album, .track {
@@ -103,37 +85,72 @@ input {
 .control-btn {
 	background: none;
 	border: none;
-	outline: none;
-	padding: 0;
-}
-
-.control-btn:hover {
-	cursor: pointer;
-	text-decoration: underline;
-}
-
-.love-btn {
+	color: #495053;
 	cursor: pointer;
 	font-family: 'Font Awesome 5 Free', serif;
-	font-size: 1rem;
+	font-size: 1.1rem;
+	outline: none;
+	padding: 0;
+	text-align: center;
+	width: 1.3rem;
+}
+
+.control-btn[disabled] {
+	cursor: default;
+}
+
+.control-btn:not([disabled]):hover::before {
+	color: #247ba0;
+}
+
+.edit-btn::before {
+	content: '\f044';
+}
+
+.revert-btn::before {
+	content: '\f0e2';
+}
+
+.skip-btn::before,
+.unskip-btn::before {
+	content: '\f05e';
+}
+
+.skip-btn:hover:not([disabled])::before {
+	color: #d51007;
+}
+
+.swap-btn::before {
+	content: '\f2f1';
+}
+
+.submit-btn::before {
+	content: '\f058';
+}
+
+.submit-btn:not([disabled]):hover::before {
+	color: #65a858;
+}
+
+.unskip-btn::before {
+	color: #d51007;
 }
 
 .unloved::before {
-	color: #999;
 	content: '\f004';
 }
 
-.unloved:hover::before {
-	color: #d510077f;
-	content: '\f004';
-}
-
-.loved::before {
+.control-btn.unloved:hover::before {
 	color: #d51007;
 	content: '\f004';
 }
 
-.loved:hover::before {
+.control-btn.loved::before {
+	color: #d51007;
+	content: '\f004';
+}
+
+.control-btn.loved:hover::before {
 	color: #d51007;
 	content: '\f7a9';
 }
@@ -143,7 +160,7 @@ input {
  */
 
 .tags {
-	margin-top: 4px;
+	margin-top: 5px;
 	white-space: nowrap;
 }
 
@@ -152,7 +169,7 @@ input {
 	border-radius: 3px;
 	color: white;
 	display: inline-block;
-	font-size: 0.75rem;
+	font-size: 12px;
 	height: 20px;
 	padding: 0 5px;
 }
@@ -172,6 +189,4 @@ input {
 
 [disabled] {
 	color: #999;
-	cursor: default !important;
-	text-decoration: none !important;
 }

--- a/src/ui/popups/info.html
+++ b/src/ui/popups/info.html
@@ -44,12 +44,11 @@
 				</div>
 			</div>
 			<div class="edit-controls">
-				<button id="edit-link" class="control-btn"></button>
-				<button id="revert-link" class="control-btn"></button>
-				<button id="skip-link" class="control-btn"></button>
-			</div>
-			<div class="scrobble-controls">
-				<div class="love-btn" id="love-link"></div>
+				<button id="edit-link" class="edit-btn control-btn"></button>
+				<button id="revert-link" class="revert-btn control-btn"></button>
+				<button id="skip-link" class="skip-btn control-btn"></button>
+				<button id="unskip-link" class="unskip-btn control-btn"></button>
+				<button id="love-link" class="love-btn control-btn"></button>
 			</div>
 		</div>
 		<div id="edit" class="popup-container" hidden>
@@ -64,8 +63,8 @@
 					i18n-title="infoAlbumArtistPlaceholder" tabindex="4" />
 			</div>
 			<div class="edit-controls">
-				<button id="submit-link" class="control-btn"></button>
-				<button id="swap-link" class="control-btn"></button>
+				<button id="submit-link" class="submit-btn control-btn"></button>
+				<button id="swap-link" class="swap-btn control-btn"></button>
 			</div>
 		</div>
 		<div class="debug-container" id="debug" hidden>

--- a/src/ui/popups/info.popup.js
+++ b/src/ui/popups/info.popup.js
@@ -90,10 +90,14 @@ class InfoPopup {
 			const isEnabled = !(isScrobbled || isSkipped);
 
 			this.view.setRevertButtonVisible(isCorrectedByUser);
+			this.view.setSkipButtonVisible(!isSkipped);
+			this.view.setUnskipButtonVisible(isSkipped);
 
 			this.view.setEditButtonState(isEnabled);
 			this.view.setRevertButtonState(isEnabled);
-			this.view.setSkipButtonState(isEnabled);
+
+			this.view.setSkipButtonState(!isScrobbled);
+			this.view.setUnskipButtonState(false);
 		} else if (this.mode === modeEdit) {
 			const isEnabled = InfoPopup.areTrackFieldsComplete(this.trackFields);
 
@@ -169,16 +173,18 @@ class InfoPopup {
 	}
 
 	onInputsChanged() {
-		const editedTrackFields = this.view.getEditedTrackFields();
-		const isInfoComplete = InfoPopup.isTrackInfoComplete(editedTrackFields);
+		const isInfoComplete = InfoPopup.areTrackFieldsComplete(
+			this.view.getEditedTrackFields()
+		);
 
 		this.view.setSubmitButtonState(isInfoComplete);
 		this.view.setSwapButtonState(isInfoComplete);
 	}
 
 	onEnterPressed() {
-		const editedTrackFields = this.view.getEditedTrackFields();
-		const isInfoComplete = InfoPopup.isTrackInfoComplete(editedTrackFields);
+		const isInfoComplete = InfoPopup.areTrackFieldsComplete(
+			this.view.getEditedTrackFields()
+		);
 
 		if (isInfoComplete) {
 			this.submitSong();

--- a/src/ui/popups/info.view.js
+++ b/src/ui/popups/info.view.js
@@ -9,6 +9,7 @@ const trackArtImgId = '#album-art-img';
 const editBtnId = '#edit-link';
 const loveBtnId = '#love-link';
 const skipBtnId = '#skip-link';
+const unskipBtnId = '#unskip-link';
 const submitBtnId = '#submit-link';
 const swapBtnId = '#swap-link';
 const revertBtnId = '#revert-link';
@@ -20,14 +21,6 @@ const fieldTitleMap = {
 	track: 'infoViewTrackPage',
 	artist: 'infoViewArtistPage',
 	albumArtist: 'infoViewArtistPage',
-};
-
-const btnTitleMap = {
-	[editBtnId]: 'infoEdit',
-	[revertBtnId]: 'infoRevert',
-	[skipBtnId]: 'infoSkip',
-	[swapBtnId]: 'infoSwap',
-	[submitBtnId]: 'infoSubmit',
 };
 
 const defaultTrackArtUrl = '/icons/cover_art_default.png';
@@ -46,7 +39,6 @@ class InfoPopupView {
 			[swapBtnId]: this.infoPopup.onSwapBtnClick,
 		};
 
-		this.initControls();
 		this.setupControlListeners();
 	}
 
@@ -131,18 +123,6 @@ class InfoPopupView {
 		);
 	}
 
-	setSkipButtonState(flag) {
-		this.setButtonState(
-			skipBtnId, flag, 'infoSkipTitle', 'infoSkipUnableTitle'
-		);
-	}
-
-	setSwapButtonState(flag) {
-		this.setButtonState(
-			swapBtnId, flag, 'infoSwapTitle', 'infoSwapUnableTitle'
-		);
-	}
-
 	setRevertButtonState(flag) {
 		this.setButtonState(
 			revertBtnId, flag, 'infoRevertTitle', 'infoRevertUnableTitle'
@@ -153,10 +133,36 @@ class InfoPopupView {
 		$(revertBtnId).prop('hidden', !flag);
 	}
 
+	setSkipButtonState(flag) {
+		this.setButtonState(
+			skipBtnId, flag, 'infoSkipTitle', 'infoSkipUnableTitle'
+		);
+	}
+
+	setSkipButtonVisible(flag) {
+		$(skipBtnId).prop('hidden', !flag);
+	}
+
 	setSubmitButtonState(flag) {
 		this.setButtonState(
 			submitBtnId, flag, 'infoSubmitTitle', 'infoSubmitUnableTitle'
 		);
+	}
+
+	setSwapButtonState(flag) {
+		this.setButtonState(
+			swapBtnId, flag, 'infoSwapTitle', 'infoSwapUnableTitle'
+		);
+	}
+
+	setUnskipButtonState(flag) {
+		this.setButtonState(
+			unskipBtnId, flag, 'infoSkippedTitle', 'infoSkippedTitle'
+		);
+	}
+
+	setUnskipButtonVisible(flag) {
+		$(unskipBtnId).prop('hidden', !flag);
 	}
 
 	/** Fields */
@@ -201,13 +207,6 @@ class InfoPopupView {
 	}
 
 	/** Internal functions */
-
-	initControls() {
-		for (const btnId in btnTitleMap) {
-			const titleId = btnTitleMap[btnId];
-			$(btnId).text(this.i18n(titleId));
-		}
-	}
 
 	setupControlListeners() {
 		for (const controlId in this.clickListeners) {


### PR DESCRIPTION
**Describe the changes you made**
The reason why I replaced text buttons with icons is to have compact controls for **each** language.

Text buttons look fine when English language is set, but in others (e.g. Russian) they have pretty long labels.

Another way to resolve the issue is to increase width of the info popup window, but it has cons:
1. The info with increased width looks quite weird.
2. You don't know if it's increased enough.

Pros:
1. Love/unlove icon now is consistent, as we use icons only.
*can't find more pros :(*

**Screenshots**

![image](https://user-images.githubusercontent.com/1119267/77834408-a1dd1180-7155-11ea-954d-b1626dd2030a.png)
*Screenshot of the info popup window after this PR is applied.*

![image](https://user-images.githubusercontent.com/1119267/77834472-f8e2e680-7155-11ea-826e-8cb63b46be18.png)
*Screenshot of the info popup window from `master` branch.*

![image](https://user-images.githubusercontent.com/1119267/77834576-ca194000-7156-11ea-975e-ef84696f745d.png)
*Screenshot of the info popup window with increased width.*