### PR TITLE
Add DNA Lounge connector

### DIFF
--- a/src/connectors/dnalounge.js
+++ b/src/connectors/dnalounge.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const DNA_PREFIX = 'DNA Pizza Music Videos: ';
+
+// The Artist+Track is displayed in the text of this Element
+Connector.playerSelector = '#metadata';
+Connector.artistTrack = '#metadata';
+
+Connector.getArtistTrack = () => {
+  let [artist, track] = $('#metadata').text().replace(DNA_PREFIX, '').split(' -- ');
+  // dnalounge has optional (uncensored) text and the year in the track name.
+  track = track.replace(' (uncensored)', '').replace(/ \([0-9]{4}\)[ ]*$/, '');
+  return { artist, track };
+};
+
+Connector.isPlaying = () => {
+  return ! $('.video_embed').hasClass('vjs-pause');
+};

--- a/src/connectors/dnalounge.js
+++ b/src/connectors/dnalounge.js
@@ -8,8 +8,8 @@ Connector.artistTrack = '#metadata';
 
 Connector.getArtistTrack = () => {
 	let [artist, track] = $('#metadata').text().replace(DNA_PREFIX, '').split(' -- ');
-	// dnalounge has optional (uncensored) text and the year in the track name.
-	track = track.replace(' (uncensored)', '').replace(/ \([0-9]{4}\)[ ]*$/, '');
+	// dnalounge has optional (uncensored) text, star, and the year in the track name.
+	track = track.replace(' (uncensored)', '').replace(' ★', '').replace(/ \([0-9]{4}\)[ ]*$/, '');
 	return { artist, track };
 };
 

--- a/src/connectors/dnalounge.js
+++ b/src/connectors/dnalounge.js
@@ -7,12 +7,12 @@ Connector.playerSelector = '#metadata';
 Connector.artistTrack = '#metadata';
 
 Connector.getArtistTrack = () => {
-  let [artist, track] = $('#metadata').text().replace(DNA_PREFIX, '').split(' -- ');
-  // dnalounge has optional (uncensored) text and the year in the track name.
-  track = track.replace(' (uncensored)', '').replace(/ \([0-9]{4}\)[ ]*$/, '');
-  return { artist, track };
+	let [artist, track] = $('#metadata').text().replace(DNA_PREFIX, '').split(' -- ');
+	// dnalounge has optional (uncensored) text and the year in the track name.
+	track = track.replace(' (uncensored)', '').replace(/ \([0-9]{4}\)[ ]*$/, '');
+	return { artist, track };
 };
 
 Connector.isPlaying = () => {
-  return ! $('.video_embed').hasClass('vjs-pause');
+	return ! $('.video_embed').hasClass('vjs-pause');
 };

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1700,6 +1700,13 @@ const connectors = [{
 	],
 	js: 'connectors/rtbf.js',
 	id: 'rtbf',
+}, {
+	label: 'DNA Lounge',
+	matches: [
+		'*://www.dnalounge.com/webcast/video.html'
+	],
+	js: 'connectors/dnalounge.js',
+	id: 'dnalounge',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
- Supports video player on webcast/video.html
- Only uses artist + track
- Removes the year and (uncensored) variants

Still needs support for custom, non-video webcasts