### PR TITLE
Fix genre page issue (#2416) and unique ID issue (#2417) for Free Music Archive connector

### DIFF
--- a/src/connectors/freemusicarchive.js
+++ b/src/connectors/freemusicarchive.js
@@ -59,10 +59,9 @@ function setupCommonProps() {
 			return null;
 		}
 
-		const match = /(tid-\d+)/.exec(playingItem.className);
+		const match = /tid-(\d+)/.exec(playingItem.className);
 		if (match) {
-			const idString = match[0].split('-');
-			return idString[1];
+			return match[1];
 		}
 		return null;
 	};

--- a/src/connectors/freemusicarchive.js
+++ b/src/connectors/freemusicarchive.js
@@ -61,7 +61,8 @@ function setupCommonProps() {
 
 		const match = /(tid-\d+)/.exec(playingItem.className);
 		if (match) {
-			return match[0];
+			const idString = match[0].split('-');
+			return idString[1];
 		}
 		return null;
 	};

--- a/src/connectors/freemusicarchive.js
+++ b/src/connectors/freemusicarchive.js
@@ -2,7 +2,7 @@
 
 const filter = new MetadataFilter({ track: removeQuotes });
 
-const trackSelectorCommon = '.gcol-electronic .playtxt a';
+const trackSelectorCommon = '.play-item.gcol-electronic .playtxt a';
 
 const pageSelectors = {
 	artist: '.bcrumb h1 .minitag-artist',
@@ -54,7 +54,7 @@ function setupCommonProps() {
 	Connector.pauseButtonSelector = '.playbtn-paused';
 
 	Connector.getUniqueID = () => {
-		const playingItem = document.querySelector('.gcol-electronic');
+		const playingItem = document.querySelector('.play-item.gcol-electronic');
 		if (!playingItem) {
 			return null;
 		}
@@ -100,20 +100,20 @@ function setupSongPlayer() {
 
 // https://freemusicarchive.org/music/charts/this-week
 function setupChartsPlayer() {
-	Connector.artistSelector = '.gcol-electronic .chartcol-artist a';
+	Connector.artistSelector = '.play-item.gcol-electronic .chartcol-artist a';
 
-	Connector.trackSelector = '.gcol-electronic .chartcol-track a';
+	Connector.trackSelector = '.play-item.gcol-electronic .chartcol-track a';
 
-	Connector.albumSelector = '.gcol-electronic .chartcol-album a';
+	Connector.albumSelector = '.play-item.gcol-electronic .chartcol-album a';
 }
 
 // https://freemusicarchive.org/genre/Blues
 function setupGenresPlayer() {
-	Connector.artistSelector = '.gcol-electronic .ptxt-artist a';
+	Connector.artistSelector = '.play-item.gcol-electronic .ptxt-artist a';
 
-	Connector.trackSelector = '.gcol-electronic .ptxt-track a';
+	Connector.trackSelector = '.play-item.gcol-electronic .ptxt-track a';
 
-	Connector.albumSelector = '.gcol-electronic .ptxt-album a';
+	Connector.albumSelector = '.play-item.gcol-electronic .ptxt-album a';
 }
 
 // https://freemusicarchive.org/static
@@ -128,7 +128,7 @@ function setupDefaultPlayer() {
 }
 
 function getAlbumCommon() {
-	const playingItem = document.querySelector('.gcol-electronic');
+	const playingItem = document.querySelector('.play-item.gcol-electronic');
 	if (playingItem) {
 		const albumItem = playingItem.closest('.colr-lrg-10pad');
 		if (albumItem) {
@@ -140,7 +140,7 @@ function getAlbumCommon() {
 }
 
 function getDurationCommon() {
-	const playingItemName = document.querySelector('.gcol-electronic .playtxt');
+	const playingItemName = document.querySelector('.play-item.gcol-electronic .playtxt');
 	if (playingItemName) {
 		const durationStr = playingItemName.lastChild.textContent;
 		const match = /\((.+?)\)/.exec(durationStr);

--- a/src/connectors/freemusicarchive.js
+++ b/src/connectors/freemusicarchive.js
@@ -7,7 +7,7 @@ const trackSelectorCommon = '.play-item.gcol-electronic .playtxt a';
 const pageSelectors = {
 	artist: '.bcrumb h1 .minitag-artist',
 	charts: '.page-charts',
-	genres: '.subgenres',
+	genres: '#bcrumb a[href^="/genre"]',
 	album: '.bcrumb h1 .minitag-album',
 	song: '.bcrumb h1 .minitag-song',
 };


### PR DESCRIPTION
**Describe the changes you made**
As described in issues #2416 and #2417 Free Music Archive connector has some issues regarding the genre pages without a subgenre and the returned unique ID value. This PR intends to fix those issues.

#2416:
At the moment the genre page detection depends on a `.subgenres` class name, which is used on a `div` that wraps the subgenres of a genre. However, this relies on the fact that the genre has subgenres, which isn't the case when a user browses to the deepest subgenre or a genre without any subgenres. Due to the lack of that classname on those pages, song detection doesn't work.

#2417:
Free Music Archive uses numeric IDs for tracks but in the connector, a certain class name (`tid-XXXXX`) for the track is returned as the unique ID. The `tid-` bit should be stripped off the returned value for a correct ID.

**Additional context**
For more details and logs please the issue tickets.
