### PR TITLE
Remove album selector for FMA song pages

### DIFF
--- a/src/connectors/freemusicarchive.js
+++ b/src/connectors/freemusicarchive.js
@@ -94,8 +94,6 @@ function setupSongPlayer() {
 	Connector.artistSelector = '.subh1 a';
 
 	Connector.trackSelector = trackSelectorCommon;
-
-	Connector.albumSelector = '.bcrumb .txt-drk';
 }
 
 // https://freemusicarchive.org/music/charts/this-week


### PR DESCRIPTION
As there's no clear and reliable album identifier on the song pages,
it's been discussed to remove album selector on FMA song pages.

Fixes #2418 