### PR TITLE
Set player selector to body to fix issues when switching screens on JQBX

### DIFF
--- a/src/connectors/jqbx.js
+++ b/src/connectors/jqbx.js
@@ -1,6 +1,6 @@
 'use strict';
 
-Connector.playerSelector = '.music';
+Connector.playerSelector = 'body';
 
 Connector.trackSelector = '.name > a';
 


### PR DESCRIPTION
**Describe the changes you made**
Fix JQBX connector when '.music' element is changed once the page is loaded (e.g. when switching rooms)

**Additional context**
As discussed on the Discord, the quickest and most obvious solution was to set the playerSelector to 'body'