### PR TITLE
Fixed the non-working emby connector. issue (#2479)

### DIFF
--- a/src/connectors/emby.js
+++ b/src/connectors/emby.js
@@ -4,9 +4,9 @@ const trackArtSelector = '.nowPlayingBarInfoContainer .nowPlayingImage';
 
 Connector.playerSelector = '.nowPlayingBar';
 
-Connector.artistSelector = '.nowPlayingBarText .textActionButton[data-type="MusicArtist"]';
+Connector.artistSelector = '.nowPlayingBarText .nowPlayingBarSecondaryText';
 
-Connector.trackSelector = '.nowPlayingBarText .textActionButton[data-type="MusicAlbum"]';
+Connector.trackSelector = '.nowPlayingBarText .textActionButton';
 
 Connector.trackArtSelector = trackArtSelector;
 


### PR DESCRIPTION
I did some debugging, I found that when "data-type" is "MusicAlbum", the song name can be correctly identified. Look at the picture below.
![0.png](https://i.loli.net/2020/07/15/Cew2rX4yqVkDNWh.png)
It cannot be recognized when "data-type" is "Audio".
![1.png](https://i.loli.net/2020/07/15/T7yiXzZNLwSI1qr.png)

I parsed it using another method. I have compiled and tested on jellyfin on MS Edge browser. It works fine.
