### PR TITLE
Fix typo in contributing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,7 +54,7 @@ committing the changes they meet our requirements by running `grunt lint`.
 If you're not familiar with Grunt, please read [this article][Grunt].
 
 We also use EditorConfig, which helps to keep code in the same code style
-in different code editors and IDE's. If you haven't use EditorConfig before,
+in different code editors and IDE's. If you haven't used EditorConfig before,
 you can visit [EditorConfig website][EditorConfig] for further information.
 
 [CommitMessages]: http://chris.beams.io/posts/git-commit/


### PR DESCRIPTION
**Describe the changes you made**
I fixed a small typo in `CONTRIBUTING.md`, updating the word "use" to "used" in the "Coding conventions" section.

**Additional context**
None
