### PR TITLE
A connector for the rekt.network online radio.

### DIFF
--- a/src/connectors/rekt.network.js
+++ b/src/connectors/rekt.network.js
@@ -1,0 +1,8 @@
+'use strict';
+
+// A more specific selector simply wouldn't work
+Connector.playerSelector = 'body';
+
+Connector.artistTrackSelector = '#npTitle';
+
+Connector.playButtonSelector = '#playerPlay';

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1554,7 +1554,7 @@ const connectors = [{
 	js: 'connectors/epidemicsound.js',
 	id: 'epidemicsound',
 }, {
-	label: 'REKT.NETWORK',
+	label: 'Rekt Network',
 	matches: [
 		'*://rekt.network/*',
 	],

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1553,6 +1553,13 @@ const connectors = [{
 	],
 	js: 'connectors/epidemicsound.js',
 	id: 'epidemicsound',
+}, {
+	label: 'REKT.NETWORK',
+	matches: [
+		'*://rekt.network/*',
+	],
+	js: 'connectors/rekt.network.js',
+	id: 'rektnetwork',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
**Describe the changes you made**
This adds a connector for the rekt.network radio, which has a website on https://rekt.network/?station=rekt

**Additional context**
The rekt.network radio have regular live sendings with DJs and show hosts, and have an endless stream of music. All music are submitted to the radio by artists, or collected by other non-copyright infringing means.