### PR TITLE
A connector for the nightride.fm online synthwave radio.

### DIFF
--- a/src/connectors/nightride.fm.js
+++ b/src/connectors/nightride.fm.js
@@ -1,0 +1,8 @@
+'use strict';
+
+// A more specific selector simply wouldn't work
+Connector.playerSelector = 'body';
+
+Connector.artistTrackSelector = '#npTitle';
+
+Connector.playButtonSelector = '#playerPlay';

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1553,6 +1553,13 @@ const connectors = [{
 	],
 	js: 'connectors/epidemicsound.js',
 	id: 'epidemicsound',
+}, {
+	label: 'Nightride FM',
+	matches: [
+		'*://nightride.fm/*',
+	],
+	js: 'connectors/nightride.fm.js',
+	id: 'nightridefm',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
**Describe the changes you made**
This adds a connector for the nightride.fm radio, which has a website on https://nightride.fm/

**Additional context**
The nightride.fm radio is a radio focused on the emerging synthwave and cyberpunk music genres. It have frequent live shows. All music are submitted to the radio by artists, or collected by other non-copyright infringing means.