### PR TITLE
Add Gimme Country to existing gimmeRadio connector

### DIFF
--- a/src/connectors/gimmeradio.js
+++ b/src/connectors/gimmeradio.js
@@ -7,3 +7,10 @@ Connector.artistSelector = '.kFfdBo';
 Connector.trackSelector = '.fZIbtd';
 
 Connector.onReady = Connector.onStateChanged;
+
+Connector.isScrobblingAllowed = () => {
+	return !(
+		Connector.getArtist().includes('Gimme Country') ||
+		Connector.getArtist().includes('Gimme Radio')
+	);
+};

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1068,6 +1068,8 @@ const connectors = [{
 	matches: [
 		'*://gimmeradio.com/*',
 		'*://www.gimmeradio.com/*',
+		'*://gimmecountry.com/*',
+		'*://www.gimmecountry.com/*',
 	],
 	js: 'connectors/gimmeradio.js',
 	id: 'gimmeradio',


### PR DESCRIPTION
Adds gimmecountry.com urls to the existing gimmeradio connector.  

https://www.gimmecountry.com/  

Also adds isScrobblingAllowed function to skip scrobbling advertisements.  

https://www.last.fm/search/artists?q=gimme+radio