### PR TITLE
Refactor stringToSeconds with simple regex

### DIFF
--- a/src/core/content/util.js
+++ b/src/core/content/util.js
@@ -31,34 +31,15 @@ const Util = {
 		if (!str) {
 			return 0;
 		}
+		const negativeExpression = /-/g;
+		const digitsExpression = /\d\d/g;
 
-		let s = str.toString().trim();
-		let val = 0;
-		let seconds = 0;
+		const seconds = str.match(digitsExpression)
+			.reverse()
+			.map((current) => parseInt(current, 10))
+			.reduce((total, current, i) => total + current * Math.pow(60, i));
 
-		const isNegative = s.startsWith('-');
-		if (isNegative) {
-			s = s.substr(1);
-		}
-
-		for (let i = 0; i < 3; i++) {
-			const idx = s.lastIndexOf(':');
-			if (idx > -1) {
-				val = parseInt(s.substr(idx + 1), 10);
-				seconds += val * Math.pow(60, i);
-				s = s.substr(0, idx);
-			} else {
-				val = parseInt(s, 10);
-				seconds += val * Math.pow(60, i);
-				break;
-			}
-		}
-
-		if (isNegative) {
-			seconds = -seconds;
-		}
-
-		return seconds;
+		return (negativeExpression.test(str)) ? -seconds : seconds;
 	},
 
 	/**

--- a/src/core/content/util.js
+++ b/src/core/content/util.js
@@ -28,9 +28,11 @@ const Util = {
 	 * @return {Number} Seconds
 	 */
 	stringToSeconds(str) {
-		if (!str) {
+		const timeFormatExpression = /^\s*-?(\d\d:){0,2}(\d\d)\s*$/g;
+		if (!timeFormatExpression.test(str)) {
 			return 0;
 		}
+
 		const negativeExpression = /-/g;
 		const digitsExpression = /\d\d/g;
 

--- a/src/core/content/util.js
+++ b/src/core/content/util.js
@@ -28,13 +28,13 @@ const Util = {
 	 * @return {Number} Seconds
 	 */
 	stringToSeconds(str) {
-		const timeFormatExpression = /^\s*-?(\d\d:){0,2}(\d\d)\s*$/g;
+		const timeFormatExpression = /^\s*-?((\d{1,2}:\d\d:\d\d)|(\d{1,2}:\d\d)|(\d{1,2}))\s*$/g;
 		if (!timeFormatExpression.test(str)) {
 			return 0;
 		}
 
 		const negativeExpression = /-/g;
-		const digitsExpression = /\d\d/g;
+		const digitsExpression = /\d{1,2}/g;
 
 		const seconds = str.match(digitsExpression)
 			.reverse()

--- a/tests/content/util.js
+++ b/tests/content/util.js
@@ -119,8 +119,8 @@ const ESCAPE_BAD_TIME_VALUES_DATA = [{
  * @type {Array}
  */
 const STRING_TO_SECONDS_DATA = [{
-	description: 'should trim string and parse time',
-	args: ['01:10:30 '],
+	description: 'should parse time that contains leading and trailing whitespace',
+	args: [' 01:10:30 '],
 	expected: 4230,
 }, {
 	description: 'should parse time in hh:mm:ss format',
@@ -129,6 +129,10 @@ const STRING_TO_SECONDS_DATA = [{
 }, {
 	description: 'should parse negative time',
 	args: ['-01:10'],
+	expected: -70,
+}, {
+	description: 'should parse negative time that contains leading and trailing whitespace',
+	args: [' -01:10 '],
 	expected: -70,
 }, {
 	description: 'should parse time in mm:ss format',

--- a/tests/content/util.js
+++ b/tests/content/util.js
@@ -154,6 +154,14 @@ const STRING_TO_SECONDS_DATA = [{
 	description: 'should not parse malformed format',
 	args: [NaN],
 	expected: 0,
+}, {
+	description: 'should not parse a format without colons',
+	args: ['01 10 30'],
+	expected: 0,
+}, {
+	description: 'should not parse a format with days',
+	args: ['01:00:00:00'],
+	expected: 0,
 }];
 
 /**

--- a/tests/content/util.js
+++ b/tests/content/util.js
@@ -174,6 +174,14 @@ const STRING_TO_SECONDS_DATA = [{
 	description: 'should not parse a format with days',
 	args: ['01:00:00:00'],
 	expected: 0,
+}, {
+	description: 'should not parse mm:s format',
+	args: ['12:4'],
+	expected: 0,
+}, {
+	description: 'should not parse hh:m:s format',
+	args: ['12:3:4'],
+	expected: 0,
 }];
 
 /**

--- a/tests/content/util.js
+++ b/tests/content/util.js
@@ -127,6 +127,10 @@ const STRING_TO_SECONDS_DATA = [{
 	args: ['01:10:30'],
 	expected: 4230,
 }, {
+	description: 'should parse time in h:mm:ss format',
+	args: ['5:20:00'],
+	expected: 19200,
+}, {
 	description: 'should parse negative time',
 	args: ['-01:10'],
 	expected: -70,
@@ -139,9 +143,17 @@ const STRING_TO_SECONDS_DATA = [{
 	args: ['05:20'],
 	expected: 320,
 }, {
+	description: 'should parse time in m:ss format',
+	args: ['5:20'],
+	expected: 320,
+}, {
 	description: 'should parse time in ss format',
 	args: ['20'],
 	expected: 20,
+}, {
+	description: 'should parse time in s format',
+	args: ['2'],
+	expected: 2,
 }, {
 	description: 'should not parse empty string',
 	args: [''],


### PR DESCRIPTION
**Describe the changes you made**
Refactored Util.stringToSeconds by using two simple regex matchers. There is also no longer a need to trim the string, since the expressions only match on the negative sign or groups of two digits.

**Additional context**
I also a updated the tests to include leading whitespace and added a test with whitespace around a negative time.