### PR TITLE
Add white space test cases for stringToSeconds

### DIFF
--- a/tests/content/util.js
+++ b/tests/content/util.js
@@ -119,8 +119,8 @@ const ESCAPE_BAD_TIME_VALUES_DATA = [{
  * @type {Array}
  */
 const STRING_TO_SECONDS_DATA = [{
-	description: 'should trim string and parse time',
-	args: ['01:10:30 '],
+	description: 'should parse time that contains leading and trailing whitespace',
+	args: [' 01:10:30 '],
 	expected: 4230,
 }, {
 	description: 'should parse time in hh:mm:ss format',
@@ -129,6 +129,10 @@ const STRING_TO_SECONDS_DATA = [{
 }, {
 	description: 'should parse negative time',
 	args: ['-01:10'],
+	expected: -70,
+}, {
+	description: 'should parse negative time that contains leading and trailing whitespace',
+	args: [' -01:10 '],
 	expected: -70,
 }, {
 	description: 'should parse time in mm:ss format',


### PR DESCRIPTION
**Describe the changes you made**
Ensuring the time can be parsed to seconds when there is leading white space and when there is white space in negative times.

**Additional context**
This is related to an existing PR I have open at https://github.com/web-scrobbler/web-scrobbler/pull/2523 that attempts to solve stringToSeconds using regex.

I tried adding test cases for the following scenarios, and they are failing the current implementation.
```javascript
{
	description: 'should not parse a format without colons',
	args: ['01 10 30'],
	expected: 0,
}, {
	description: 'should not parse a format with days',
	args: ['01:02:03:04'],
	expected: 0,
}
```

For `01 10 30`, it is failing because it doesn't find any colons, and tries to process the first integer, so it returns back `1` instead of `0`.

For `01:02:03:04`, it parses 3 sections from right to left, so it parses seconds, then minutes, then hours. However, it doesn't nothing with days. It returns `7384` instead of `0`.

I bring these up since these are the cases @alexesprit mentioned in the other PR I had open. Is the intention that these two test cases should return `0`, because they are thought of as bad input data? Do you **only** want to parse `hh:mm:ss`, `mm:ss`, and `ss`? I do think regex is a simple way to solve this without bringing in another package like `moment`. Either way, I think these test cases can be added and a new PR can address any future decision you have. I will keep the other PR open until you decide in case you want to reference it.