### PR TITLE
Disable individual lint warnings instead of a global disable

### DIFF
--- a/src/core/content/connector.js
+++ b/src/core/content/connector.js
@@ -425,7 +425,7 @@ function BaseConnector() {
 	 *
 	 * @param {Object} event Event object
 	 */
-	this.onScriptEvent = (event) => { // eslint-disable-line
+	this.onScriptEvent = (event) => { // eslint-disable-line no-unused-vars
 		// Do nothing
 	};
 
@@ -834,5 +834,5 @@ function BaseConnector() {
 	this.stateChangedWorkerThrottled = Util.throttle(this.stateChangedWorker, 500);
 }
 
-// eslint-disable-next-line
+// eslint-disable-next-line no-unused-vars
 const Connector = window.Connector || new BaseConnector();


### PR DESCRIPTION
**Describe the changes you made**
Instead of globally disabling all lint warnings on a line, only disable the specific lint rule.

**Additional context**
None
