### PR TITLE
Add RecMusic connector

### DIFF
--- a/src/connectors/recmusic.js
+++ b/src/connectors/recmusic.js
@@ -18,7 +18,9 @@ Connector.durationSelector = '.seekbar-duration:last-child';
 
 Connector.trackSelector = 'p.track-info-title';
 
-Connector.isPlaying = () => document.querySelector('.button-play').classList.contains('mk-web-icon-stop');
+Connector.pauseButtonSelector = ".button-play.mk-web-icon-stop";
+
+//Connector.isPlaying = () => document.querySelector('.button-play').classList.contains('mk-web-icon-stop');
 
 Connector.applyFilter(filter);
 

--- a/src/connectors/recmusic.js
+++ b/src/connectors/recmusic.js
@@ -6,19 +6,19 @@ const filter = new MetadataFilter({
 
 Connector.playerSelector = '.the-player';
 
-Connector.artistSelector = "a.track-info-artist";
+Connector.artistSelector = 'a.track-info-artist';
 
-Connector.albumSelector = "a.track-info-album";
+Connector.albumSelector = 'a.track-info-album';
 
-Connector.getTrackArt = () => document.querySelector('.track-info-image img').style["background-image"].slice(5, -2);
+Connector.getTrackArt = () => document.querySelector('.track-info-image img').style['background-image'].slice(5, -2);
 
-Connector.currentTimeSelector = ".seekbar-duration:nth-child(2)";
+Connector.currentTimeSelector = '.seekbar-duration:nth-child(2)';
 
-Connector.durationSelector = ".seekbar-duration:last-child";
+Connector.durationSelector = '.seekbar-duration:last-child';
 
-Connector.trackSelector = "p.track-info-title";
+Connector.trackSelector = 'p.track-info-title';
 
-Connector.isPlaying = () => document.querySelector('.button-play').classList.contains("mk-web-icon-stop");
+Connector.isPlaying = () => document.querySelector('.button-play').classList.contains('mk-web-icon-stop');
 
 Connector.applyFilter(filter);
 
@@ -29,23 +29,23 @@ Connector.applyFilter(filter);
  * @return {String} Filtered string
  */
 
-function katakanaHanToZen(text){
-  
-  let katakanaHanToZenMap = {"｡":"。","｢":"「","｣":"」","､":"、","･":"・","ｦ":"ヲ","ｧ":"ァ","ｨ":"ィ","ｩ":"ゥ","ｪ":"ェ","ｫ":"ォ","ｬ":"ャ","ｭ":"ュ","ｮ":"ョ","ｯ":"ッ","ｰ":"ー","ｱ":"ア","ｲ":"イ","ｳ":"ウ","ｴ":"エ","ｵ":"オ","ｶ":"カ","ｷ":"キ","ｸ":"ク","ｹ":"ケ","ｺ":"コ","ｻ":"サ","ｼ":"シ","ｽ":"ス","ｾ":"セ","ｿ":"ソ","ﾀ":"タ","ﾁ":"チ","ﾂ":"ツ","ﾃ":"テ","ﾄ":"ト","ﾅ":"ナ","ﾆ":"ニ","ﾇ":"ヌ","ﾈ":"ネ","ﾉ":"ノ","ﾊ":"ハ","ﾋ":"ヒ","ﾌ":"フ","ﾍ":"ヘ","ﾎ":"ホ","ﾏ":"マ","ﾐ":"ミ","ﾑ":"ム","ﾒ":"メ","ﾓ":"モ","ﾔ":"ヤ","ﾕ":"ユ","ﾖ":"ヨ","ﾗ":"ラ","ﾘ":"リ","ﾙ":"ル","ﾚ":"レ","ﾛ":"ロ","ﾜ":"ワ","ﾝ":"ン"};
-  
-  let textOutput = "";
-  
-  for(let character of text){
-    let charCode = character.charCodeAt();
-    
-    if(charCode >= 65377 && charCode <= 65437){
-      textOutput += katakanaHanToZenMap[character];
-    }else if(charCode == 65438 || charCode == 65439){
-      let lastCharCode = textOutput[textOutput.length - 1].charCodeAt();
-      textOutput = textOutput.slice(0, -1) + String.fromCharCode(lastCharCode + charCode - 65437);
-    }else{
-      textOutput += character;
-    }
-  };
-  return textOutput;
+function katakanaHanToZen(text) {
+
+	const katakanaHanToZenMap = { '｡': '。', '｢': '「', '｣': '」', '､': '、', '･': '・', 'ｦ': 'ヲ', 'ｧ': 'ァ', 'ｨ': 'ィ', 'ｩ': 'ゥ', 'ｪ': 'ェ', 'ｫ': 'ォ', 'ｬ': 'ャ', 'ｭ': 'ュ', 'ｮ': 'ョ', 'ｯ': 'ッ', 'ｰ': 'ー', 'ｱ': 'ア', 'ｲ': 'イ', 'ｳ': 'ウ', 'ｴ': 'エ', 'ｵ': 'オ', 'ｶ': 'カ', 'ｷ': 'キ', 'ｸ': 'ク', 'ｹ': 'ケ', 'ｺ': 'コ', 'ｻ': 'サ', 'ｼ': 'シ', 'ｽ': 'ス', 'ｾ': 'セ', 'ｿ': 'ソ', 'ﾀ': 'タ', 'ﾁ': 'チ', 'ﾂ': 'ツ', 'ﾃ': 'テ', 'ﾄ': 'ト', 'ﾅ': 'ナ', 'ﾆ': 'ニ', 'ﾇ': 'ヌ', 'ﾈ': 'ネ', 'ﾉ': 'ノ', 'ﾊ': 'ハ', 'ﾋ': 'ヒ', 'ﾌ': 'フ', 'ﾍ': 'ヘ', 'ﾎ': 'ホ', 'ﾏ': 'マ', 'ﾐ': 'ミ', 'ﾑ': 'ム', 'ﾒ': 'メ', 'ﾓ': 'モ', 'ﾔ': 'ヤ', 'ﾕ': 'ユ', 'ﾖ': 'ヨ', 'ﾗ': 'ラ', 'ﾘ': 'リ', 'ﾙ': 'ル', 'ﾚ': 'レ', 'ﾛ': 'ロ', 'ﾜ': 'ワ', 'ﾝ': 'ン' };
+
+	let textOutput = '';
+
+	for (const character of text) {
+		const charCode = character.charCodeAt();
+
+		if (charCode >= 65377 && charCode <= 65437) {
+			textOutput += katakanaHanToZenMap[character];
+		} else if (charCode === 65438 || charCode === 65439) {
+			const lastCharCode = textOutput[textOutput.length - 1].charCodeAt();
+			textOutput = textOutput.slice(0, -1) + String.fromCharCode(lastCharCode + charCode - 65437);
+		} else {
+			textOutput += character;
+		}
+	}
+	return textOutput;
 }

--- a/src/connectors/recmusic.js
+++ b/src/connectors/recmusic.js
@@ -4,13 +4,15 @@ const filter = new MetadataFilter({
 	all: katakanaHanToZen,
 });
 
+const katakanaHanToZenMap = { '｡': '。', '｢': '「', '｣': '」', '､': '、', '･': '・', 'ｦ': 'ヲ', 'ｧ': 'ァ', 'ｨ': 'ィ', 'ｩ': 'ゥ', 'ｪ': 'ェ', 'ｫ': 'ォ', 'ｬ': 'ャ', 'ｭ': 'ュ', 'ｮ': 'ョ', 'ｯ': 'ッ', 'ｰ': 'ー', 'ｱ': 'ア', 'ｲ': 'イ', 'ｳ': 'ウ', 'ｴ': 'エ', 'ｵ': 'オ', 'ｶ': 'カ', 'ｷ': 'キ', 'ｸ': 'ク', 'ｹ': 'ケ', 'ｺ': 'コ', 'ｻ': 'サ', 'ｼ': 'シ', 'ｽ': 'ス', 'ｾ': 'セ', 'ｿ': 'ソ', 'ﾀ': 'タ', 'ﾁ': 'チ', 'ﾂ': 'ツ', 'ﾃ': 'テ', 'ﾄ': 'ト', 'ﾅ': 'ナ', 'ﾆ': 'ニ', 'ﾇ': 'ヌ', 'ﾈ': 'ネ', 'ﾉ': 'ノ', 'ﾊ': 'ハ', 'ﾋ': 'ヒ', 'ﾌ': 'フ', 'ﾍ': 'ヘ', 'ﾎ': 'ホ', 'ﾏ': 'マ', 'ﾐ': 'ミ', 'ﾑ': 'ム', 'ﾒ': 'メ', 'ﾓ': 'モ', 'ﾔ': 'ヤ', 'ﾕ': 'ユ', 'ﾖ': 'ヨ', 'ﾗ': 'ラ', 'ﾘ': 'リ', 'ﾙ': 'ル', 'ﾚ': 'レ', 'ﾛ': 'ロ', 'ﾜ': 'ワ', 'ﾝ': 'ン' };
+
 Connector.playerSelector = '.the-player';
 
 Connector.artistSelector = 'a.track-info-artist';
 
 Connector.albumSelector = 'a.track-info-album';
 
-Connector.getTrackArt = () => document.querySelector('.track-info-image img').style['background-image'].slice(5, -2);
+Connector.getTrackArt = () => Util.extractUrlFromCssProperty(document.querySelector('.track-info-image img').style['background-image']);
 
 Connector.currentTimeSelector = '.seekbar-duration:nth-child(2)';
 
@@ -30,8 +32,6 @@ Connector.applyFilter(filter);
  */
 
 function katakanaHanToZen(text) {
-
-	const katakanaHanToZenMap = { '｡': '。', '｢': '「', '｣': '」', '､': '、', '･': '・', 'ｦ': 'ヲ', 'ｧ': 'ァ', 'ｨ': 'ィ', 'ｩ': 'ゥ', 'ｪ': 'ェ', 'ｫ': 'ォ', 'ｬ': 'ャ', 'ｭ': 'ュ', 'ｮ': 'ョ', 'ｯ': 'ッ', 'ｰ': 'ー', 'ｱ': 'ア', 'ｲ': 'イ', 'ｳ': 'ウ', 'ｴ': 'エ', 'ｵ': 'オ', 'ｶ': 'カ', 'ｷ': 'キ', 'ｸ': 'ク', 'ｹ': 'ケ', 'ｺ': 'コ', 'ｻ': 'サ', 'ｼ': 'シ', 'ｽ': 'ス', 'ｾ': 'セ', 'ｿ': 'ソ', 'ﾀ': 'タ', 'ﾁ': 'チ', 'ﾂ': 'ツ', 'ﾃ': 'テ', 'ﾄ': 'ト', 'ﾅ': 'ナ', 'ﾆ': 'ニ', 'ﾇ': 'ヌ', 'ﾈ': 'ネ', 'ﾉ': 'ノ', 'ﾊ': 'ハ', 'ﾋ': 'ヒ', 'ﾌ': 'フ', 'ﾍ': 'ヘ', 'ﾎ': 'ホ', 'ﾏ': 'マ', 'ﾐ': 'ミ', 'ﾑ': 'ム', 'ﾒ': 'メ', 'ﾓ': 'モ', 'ﾔ': 'ヤ', 'ﾕ': 'ユ', 'ﾖ': 'ヨ', 'ﾗ': 'ラ', 'ﾘ': 'リ', 'ﾙ': 'ル', 'ﾚ': 'レ', 'ﾛ': 'ロ', 'ﾜ': 'ワ', 'ﾝ': 'ン' };
 
 	let textOutput = '';
 

--- a/src/connectors/recmusic.js
+++ b/src/connectors/recmusic.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const filter = new MetadataFilter({
+	all: katakanaHanToZen,
+});
+
+Connector.playerSelector = '.the-player';
+
+Connector.artistSelector = "a.track-info-artist";
+
+Connector.albumSelector = "a.track-info-album";
+
+Connector.getTrackArt = () => document.querySelector('.track-info-image img').style["background-image"].slice(5, -2);
+
+Connector.currentTimeSelector = ".seekbar-duration:nth-child(2)";
+
+Connector.durationSelector = ".seekbar-duration:last-child";
+
+Connector.trackSelector = "p.track-info-title";
+
+Connector.isPlaying = () => document.querySelector('.button-play').classList.contains("mk-web-icon-stop");
+
+Connector.applyFilter(filter);
+
+
+/**
+ * Replace half-width katakana with full-width katakana in the text.
+ * @param  {String} text String to be filtered
+ * @return {String} Filtered string
+ */
+
+function katakanaHanToZen(text){
+  
+  let katakanaHanToZenMap = {"｡":"。","｢":"「","｣":"」","､":"、","･":"・","ｦ":"ヲ","ｧ":"ァ","ｨ":"ィ","ｩ":"ゥ","ｪ":"ェ","ｫ":"ォ","ｬ":"ャ","ｭ":"ュ","ｮ":"ョ","ｯ":"ッ","ｰ":"ー","ｱ":"ア","ｲ":"イ","ｳ":"ウ","ｴ":"エ","ｵ":"オ","ｶ":"カ","ｷ":"キ","ｸ":"ク","ｹ":"ケ","ｺ":"コ","ｻ":"サ","ｼ":"シ","ｽ":"ス","ｾ":"セ","ｿ":"ソ","ﾀ":"タ","ﾁ":"チ","ﾂ":"ツ","ﾃ":"テ","ﾄ":"ト","ﾅ":"ナ","ﾆ":"ニ","ﾇ":"ヌ","ﾈ":"ネ","ﾉ":"ノ","ﾊ":"ハ","ﾋ":"ヒ","ﾌ":"フ","ﾍ":"ヘ","ﾎ":"ホ","ﾏ":"マ","ﾐ":"ミ","ﾑ":"ム","ﾒ":"メ","ﾓ":"モ","ﾔ":"ヤ","ﾕ":"ユ","ﾖ":"ヨ","ﾗ":"ラ","ﾘ":"リ","ﾙ":"ル","ﾚ":"レ","ﾛ":"ロ","ﾜ":"ワ","ﾝ":"ン"};
+  
+  let textOutput = "";
+  
+  for(let character of text){
+    let charCode = character.charCodeAt();
+    
+    if(charCode >= 65377 && charCode <= 65437){
+      textOutput += katakanaHanToZenMap[character];
+    }else if(charCode == 65438 || charCode == 65439){
+      let lastCharCode = textOutput[textOutput.length - 1].charCodeAt();
+      textOutput = textOutput.slice(0, -1) + String.fromCharCode(lastCharCode + charCode - 65437);
+    }else{
+      textOutput += character;
+    }
+  };
+  return textOutput;
+}

--- a/src/connectors/recmusic.js
+++ b/src/connectors/recmusic.js
@@ -18,9 +18,7 @@ Connector.durationSelector = '.seekbar-duration:last-child';
 
 Connector.trackSelector = 'p.track-info-title';
 
-Connector.pauseButtonSelector = ".button-play.mk-web-icon-stop";
-
-//Connector.isPlaying = () => document.querySelector('.button-play').classList.contains('mk-web-icon-stop');
+Connector.pauseButtonSelector = '.button-play.mk-web-icon-stop';
 
 Connector.applyFilter(filter);
 

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1618,6 +1618,6 @@ const connectors = [{
 	],
 	js: 'connectors/recmusic.js',
 	id: 'recmusic',
-},];
+}];
 
 define(() => connectors);

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1611,6 +1611,13 @@ const connectors = [{
 	],
 	js: 'connectors/radio7.js',
 	id: 'radio7lv',
-}];
+}, {
+	label: 'RecMusic',
+	matches: [
+		'*://recmusic.jp/*',
+	],
+	js: 'connectors/recmusic.js',
+	id: 'recmusic',
+},];
 
 define(() => connectors);


### PR DESCRIPTION
Adds a connector to grab metadata and scrobble off recmusic.jp

Includes a filter to convert half-width katakana to full-width katakana,
as RecMusic frequently uses half-width katakana where it is incorrect.

Examples of where this filter is necessary:
[This single and first track](https://recmusic.jp/album/?id=1011218626)
Filter correctly converts ﾚｽﾎﾟｰﾙ to レスポール
[This artist name](https://recmusic.jp/artist/?id=2001132142)
Filter correctly converts ｺﾄﾌﾙ to コトフル

This conversion will inevitably lead to some false positives.
However, false positives should be _far_ less common.