### PR TITLE
Eggspand Eggs connector to include youtube embeds

### DIFF
--- a/src/connectors/eggs-dom-inject.js
+++ b/src/connectors/eggs-dom-inject.js
@@ -54,6 +54,11 @@ function placeYoutubeVideo() {
 		height: '290',
 		width: '500',
 		videoId,
+		playerVars: {
+			origin: 'https://eggs.mu/',
+			wmode: 'transparent',
+			rel: 0,
+		},
 		events: {
 			'onStateChange': youtubeStateChange,
 		},

--- a/src/connectors/eggs-dom-inject.js
+++ b/src/connectors/eggs-dom-inject.js
@@ -1,0 +1,80 @@
+'use strict';
+
+/*
+ * This script runs in non-isolated environment(eggs.mu itself)
+ * for accessing window variables
+ */
+
+const isArtistPage = window.location.href.includes('/artist/');
+
+let videoId = '';
+
+if (isArtistPage) {
+	const observer = new MutationObserver(toggleExternalPlayer);
+
+	observer.observe(document.body, { childList: true });
+} else {
+
+	window.player.addEventListener('onStateChange', youtubeStateChange);
+
+}
+
+function toggleExternalPlayer(mutationList) {
+
+	const removedList = mutationList[0].removedNodes;
+
+	if (removedList.length) {
+
+		// external player has been started
+		if (removedList[0].id === 'fancybox-loading') {
+
+			replaceYoutubeVideo();
+
+		}
+	}
+}
+
+function replaceYoutubeVideo() {
+
+	const iframeParent = document.querySelector('.fancybox-inner');
+	videoId = iframeParent.querySelector('iframe').src.split('/').pop().split('?')[0];
+
+	iframeParent.innerHTML = '';
+
+	const videoDiv = document.createElement('div');
+	videoDiv.id = 'webscrobblerPlayer';
+	iframeParent.append(videoDiv);
+
+	placeYoutubeVideo();
+
+}
+
+function placeYoutubeVideo() {
+	new window.YT.Player('webscrobblerPlayer', {
+		height: '290',
+		width: '500',
+		videoId,
+		events: {
+			'onStateChange': youtubeStateChange,
+		},
+	});
+}
+
+function youtubeStateChange(event) {
+
+	const parentElmt = (document.querySelector(`a[href*="${videoId}"]`) && document.querySelector(`a[href*="${videoId}"]`).closest('li')) || document;
+
+	window.postMessage({
+		sender: 'web-scrobbler',
+		playerType: `youtube${(event.data === -1) ? 'start' : ''}`,
+		isPlaying: event.data === 1,
+		timeInfo: {
+			currentTime: event.target.getCurrentTime(),
+			duration: event.target.getDuration(),
+		},
+		trackInfo: {
+			artist: parentElmt.querySelector(`.artist_name${(isArtistPage) ? '' : ' a'}`).innerText,
+			track: parentElmt.querySelector(`.product_name${(isArtistPage) ? ' a' : ' p'}`).innerText,
+		},
+	}, '*');
+}

--- a/src/connectors/eggs-dom-inject.js
+++ b/src/connectors/eggs-dom-inject.js
@@ -14,28 +14,21 @@ if (isArtistPage) {
 
 	observer.observe(document.body, { childList: true });
 } else {
-
-	window.player.addEventListener('onStateChange', youtubeStateChange);
-
+	window.player.addEventListener('onStateChange', onYoutubeStateChange);
 }
 
 function toggleExternalPlayer(mutationList) {
-
 	const removedList = mutationList[0].removedNodes;
 
 	if (removedList.length) {
-
 		// external player has been started
 		if (removedList[0].id === 'fancybox-loading') {
-
 			replaceYoutubeVideo();
-
 		}
 	}
 }
 
 function replaceYoutubeVideo() {
-
 	const iframeParent = document.querySelector('.fancybox-inner');
 	videoId = iframeParent.querySelector('iframe').src.split('/').pop().split('?')[0];
 
@@ -60,18 +53,19 @@ function placeYoutubeVideo() {
 			rel: 0,
 		},
 		events: {
-			'onStateChange': youtubeStateChange,
+			'onStateChange': onYoutubeStateChange,
 		},
 	});
 }
 
-function youtubeStateChange(event) {
-
-	const parentElmt = (document.querySelector(`a[href*="${videoId}"]`) && document.querySelector(`a[href*="${videoId}"]`).closest('li')) || document;
+function onYoutubeStateChange(event) {
+	const currentPlayer = document.querySelector(`a[href*="${videoId}"]`);
+	const parentElmt = (currentPlayer && currentPlayer.closest('li')) || document;
+	const playerTypeSuffix = (event.data === -1) ? 'start' : '';
 
 	window.postMessage({
 		sender: 'web-scrobbler',
-		playerType: `youtube${(event.data === -1) ? 'start' : ''}`,
+		playerType: `youtube${playerTypeSuffix}`,
 		isPlaying: event.data === 1,
 		timeInfo: {
 			currentTime: event.target.getCurrentTime(),

--- a/src/connectors/eggs.js
+++ b/src/connectors/eggs.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const filter = new MetadataFilter({
+	track: removeMV,
+});
+
 let trackInfo = {};
 let timeInfo = {};
 let isPlaying = false;
@@ -10,6 +14,8 @@ Connector.getTimeInfo = () => {
 };
 
 Connector.playerSelector = '.m-upload-list';
+
+Connector.applyFilter(filter);
 
 Connector.injectScript('connectors/eggs-dom-inject.js');
 
@@ -101,3 +107,7 @@ Connector.onScriptEvent = (event) => {
 
 	}
 };
+
+function removeMV(text){
+  return text.replace(/(\(MV\)|MV)$/, '');
+}

--- a/src/connectors/eggs.js
+++ b/src/connectors/eggs.js
@@ -108,6 +108,6 @@ Connector.onScriptEvent = (event) => {
 	}
 };
 
-function removeMV(text){
-  return text.replace(/(\(MV\)|MV)$/, '');
+function removeMV(text) {
+	return text.replace(/(\(MV\)|MV)$/, '');
 }

--- a/src/connectors/eggs.js
+++ b/src/connectors/eggs.js
@@ -26,17 +26,14 @@ if (window.location.href.includes('/artist/')) {
 }
 
 function setupYoutubePlayer() {
-
 	Connector.getTrackInfo = () => trackInfo;
 
 	Connector.isPlaying = () => isPlaying;
 
 	Connector.getTimeInfo = () => timeInfo;
-
 }
 
 function setupArtistPlayer() {
-
 	const youtubeScript = document.createElement('script');
 	youtubeScript.src = 'https://www.youtube.com/iframe_api';
 	document.head.append(youtubeScript);
@@ -49,7 +46,6 @@ function setupArtistPlayer() {
 }
 
 function setArtistConnector() {
-
 	Connector.getTrackInfo = () => {
 		const parentLi = document.querySelector('.pause[style*="display: block"]').closest('li');
 
@@ -65,11 +61,9 @@ function setArtistConnector() {
 	Connector.isPlaying = () => {
 		document.querySelectorAll('.pause[style*="display: block;"]').length;
 	};
-
 }
 
 function setupSongPlayer() {
-
 	Connector.trackArtSelector = '.img-album img';
 
 	Connector.artistSelector = '.artist_name a';
@@ -94,17 +88,12 @@ function checkToggleArtist(mutationList) {
 }
 
 Connector.onScriptEvent = (event) => {
-
 	({ trackInfo, isPlaying, timeInfo } = event.data);
 
 	if (event.data.playerType === 'youtube') {
-
 		Connector.onStateChanged();
-
 	} else if (event.data.playerType === 'youtubestart') {
-
 		setupYoutubePlayer();
-
 	}
 };
 

--- a/src/connectors/eggs.js
+++ b/src/connectors/eggs.js
@@ -109,5 +109,5 @@ Connector.onScriptEvent = (event) => {
 };
 
 function removeMV(text) {
-	return text.replace(/(\(MV\)|MV)$/, '');
+	return text.replace(/(\(MV\)|【MV】|MV)$/, '');
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,6 +15,7 @@
 
   "web_accessible_resources": [
     "connectors/deezer-dom-inject.js",
+    "connectors/eggs-dom-inject.js",
     "connectors/musickit-dom-inject.js",
     "connectors/vk-dom-inject.js",
     "connectors/yandex-music-dom-inject.js",


### PR DESCRIPTION
Uses an injected script to scrobble youtube embeds on Eggs.mu.

Indicators for using injected script vs allframes:

- eggs.mu/artist adds/removes youtube iframe to/from DOM dynamically.
- Also makes it easy for it to work alongside the normal scrobbling.
- It also allows usage of the eggs.mu tags, not having to rely on parsing.

Therefore, I chose to use an injected script with a mutation observer.

Replaces the youtube iframes on eggs.mu/artist with ones made through
youtube embed api, to be able to interact with it and get playing status.

As for eggs.mu/song, youtube embed api is already used, so the script
simply adds an event listener to the existing player variable.

I could use allframes for eggs.mu/song, but its just reusing code from
eggs.mu/artist scrobbler anyway, so it seems like a worse approach.

Also added a simple filter to remove MV suffix as well as (MV) and【MV】
as these denote "music video".

Will probably require some back and forth.