### PR TITLE
Improve YouTube Music behavior for all channels.

### DIFF
--- a/src/connectors/youtube-music.js
+++ b/src/connectors/youtube-music.js
@@ -26,9 +26,11 @@ Connector.albumSelector = [
 Connector.getArtistTrack = () => {
 	let artist; let track;
 	if (Connector.getAlbum()) {
+		Connector.resetFilter();
 		artist = Util.getTextFromSelectors(channelNameSelector);
 		track = Util.getTextFromSelectors(trackSelector);
 	} else {
+		Connector.applyFilter(MetadataFilter.getYoutubeFilter());
 		({ artist, track } = Util.processYtVideoTitle(Util.getTextFromSelectors(trackSelector)));
 		if (!artist) {
 			artist = Util.getTextFromSelectors(channelNameSelector);
@@ -44,12 +46,3 @@ Connector.isPlaying = () => {
 };
 
 Connector.isScrobblingAllowed = () => !Util.isElementVisible(adSelector);
-
-const baseStateChangedWorker = Connector.stateChangedWorker;
-Connector.stateChangedWorker = () => {
-	Connector.metadataFilter = MetadataFilter.getDefaultFilter();
-	if (! Connector.getAlbum()) {
-		Connector.applyFilter(MetadataFilter.getYoutubeFilter());
-	}
-	baseStateChangedWorker();
-};

--- a/src/connectors/youtube-music.js
+++ b/src/connectors/youtube-music.js
@@ -23,7 +23,9 @@ Connector.albumSelector = [
 	'.ytmusic-player-bar .yt-formatted-string.style-scope.yt-simple-endpoint[href*="browse/FEmusic_library_privately_owned_release_detailb_"]',
 ];
 
-const videoHasAlbum = () => !!Connector.getAlbum();
+function videoHasAlbum() {
+	return !!Connector.getAlbum();
+}
 
 Connector.getArtistTrack = () => {
 	let artist; let track;
@@ -47,7 +49,9 @@ Connector.isPlaying = () => {
 
 Connector.isScrobblingAllowed = () => !Util.isElementVisible(adSelector);
 
-const filterYoutubeIfNonAlbum = (text) => videoHasAlbum() ? text : MetadataFilter.youtube(text);
+function filterYoutubeIfNonAlbum(text) {
+	return videoHasAlbum() ? text : MetadataFilter.youtube(text);
+}
 
 const conditionalYoutubeFilter = new MetadataFilter({ track: filterYoutubeIfNonAlbum });
 

--- a/src/connectors/youtube-music.js
+++ b/src/connectors/youtube-music.js
@@ -45,4 +45,11 @@ Connector.isPlaying = () => {
 
 Connector.isScrobblingAllowed = () => !Util.isElementVisible(adSelector);
 
-Connector.applyFilter(MetadataFilter.getYoutubeFilter());
+const baseStateChangedWorker = Connector.stateChangedWorker;
+Connector.stateChangedWorker = () => {
+	Connector.metadataFilter = MetadataFilter.getDefaultFilter();
+	if (! Connector.getAlbum()) {
+		Connector.applyFilter(MetadataFilter.getYoutubeFilter());
+	}
+	baseStateChangedWorker();
+};

--- a/src/connectors/youtube-music.js
+++ b/src/connectors/youtube-music.js
@@ -2,16 +2,13 @@
 
 const playButtonSelector = '.ytmusic-player-bar.play-pause-button #icon > svg > g > path';
 const trackArtSelector = '.ytmusic-player-bar.image';
+const channelNameSelector = 'ytmusic-player-queue-item[selected] .byline';
 const trackSelector = 'ytmusic-player-queue-item[selected] .song-title';
 const adSelector = '.ytmusic-player-bar.advertisement';
 
 const playingPath = 'M6 19h4V5H6v14zm8-14v14h4V5h-4z';
 
 Connector.playerSelector = 'ytmusic-player-bar';
-
-Connector.artistSelector = 'ytmusic-player-queue-item[selected] .byline';
-
-Connector.trackSelector = trackSelector;
 
 Connector.getTrackArt = () => {
 	const trackArtUrl = Util.extractImageUrlFromSelectors(trackArtSelector);
@@ -26,6 +23,20 @@ Connector.albumSelector = [
 	'.ytmusic-player-bar .yt-formatted-string.style-scope.yt-simple-endpoint[href*="browse/FEmusic_library_privately_owned_release_detailb_"]',
 ];
 
+Connector.getArtistTrack = () => {
+	let artist; let track;
+	if (Connector.getAlbum()) {
+		artist = Util.getTextFromSelectors(channelNameSelector);
+		track = Util.getTextFromSelectors(trackSelector);
+	} else {
+		({ artist, track } = Util.processYtVideoTitle(Util.getTextFromSelectors(trackSelector)));
+		if (!artist) {
+			artist = Util.getTextFromSelectors(channelNameSelector);
+		}
+	}
+	return { artist, track };
+};
+
 Connector.timeInfoSelector = '.ytmusic-player-bar.time-info';
 
 Connector.isPlaying = () => {
@@ -33,3 +44,5 @@ Connector.isPlaying = () => {
 };
 
 Connector.isScrobblingAllowed = () => !Util.isElementVisible(adSelector);
+
+Connector.applyFilter(MetadataFilter.getYoutubeFilter());

--- a/src/connectors/youtube-music.js
+++ b/src/connectors/youtube-music.js
@@ -23,14 +23,14 @@ Connector.albumSelector = [
 	'.ytmusic-player-bar .yt-formatted-string.style-scope.yt-simple-endpoint[href*="browse/FEmusic_library_privately_owned_release_detailb_"]',
 ];
 
+const videoHasAlbum = () => !!Connector.getAlbum();
+
 Connector.getArtistTrack = () => {
 	let artist; let track;
-	if (Connector.getAlbum()) {
-		Connector.resetFilter();
+	if (videoHasAlbum()) {
 		artist = Util.getTextFromSelectors(channelNameSelector);
 		track = Util.getTextFromSelectors(trackSelector);
 	} else {
-		Connector.applyFilter(MetadataFilter.getYoutubeFilter());
 		({ artist, track } = Util.processYtVideoTitle(Util.getTextFromSelectors(trackSelector)));
 		if (!artist) {
 			artist = Util.getTextFromSelectors(channelNameSelector);
@@ -46,3 +46,9 @@ Connector.isPlaying = () => {
 };
 
 Connector.isScrobblingAllowed = () => !Util.isElementVisible(adSelector);
+
+const filterYoutubeIfNonAlbum = (text) => videoHasAlbum() ? text : MetadataFilter.youtube(text);
+
+const conditionalYoutubeFilter = new MetadataFilter({ track: filterYoutubeIfNonAlbum });
+
+Connector.applyFilter(conditionalYoutubeFilter);

--- a/src/core/content/connector.js
+++ b/src/core/content/connector.js
@@ -435,14 +435,6 @@ function BaseConnector() {
 	 */
 
 	/**
-	 * Reset the filter to default, removing any custom filters added using
-	 * applyFilter.
-	 */
-	this.resetFilter = () => {
-		metadataFilter = MetadataFilter.getDefaultFilter();
-	};
-
-	/**
 	 * Add custom filter to default one. Use this method only to apply
 	 * custom metadata filters.
 	 *

--- a/src/core/content/connector.js
+++ b/src/core/content/connector.js
@@ -435,6 +435,14 @@ function BaseConnector() {
 	 */
 
 	/**
+	 * Reset the filter to default, removing any custom filters added using
+	 * applyFilter.
+	 */
+	this.resetFilter = () => {
+		metadataFilter = MetadataFilter.getDefaultFilter();
+	};
+
+	/**
 	 * Add custom filter to default one. Use this method only to apply
 	 * custom metadata filters.
 	 *


### PR DESCRIPTION
We attempt to use a mixed solution which gives correct results for both fully
tagged music (with artist and album name properly reported by YouTube) and
videos where the artist and title are both in the video title (common in the
case of promotional channels).

Resolves #2564.
Reverts 6df5242453e4a72b71b577a9cc41f6820880d8c2.
Partially reverts 58fda0810cd2dd7163ee93ae5a9fe8ada02d1630.