### PR TITLE
Fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The detailed build instruction is available [here][BuildInstructions].
 ### Develop connectors
 
 Check the [wiki page][WikiDev] to understand development of connectors. Please
-also read our[contributions guidelines][Contributing].
+also read our [contribution guidelines][Contributing].
 
 ### Translations
 


### PR DESCRIPTION
Dunno if this is the correct way to submit this but here goes
Adds a space and removes an s from one of the links in readme.
The s may not be a typo but it is the more common way to write it anyway
Space is definitely a typo.