### PR TITLE
Improve Idagio connector

### DIFF
--- a/src/connectors/idagio.js
+++ b/src/connectors/idagio.js
@@ -17,11 +17,16 @@ Connector.isPlaying = () => Util.getTextFromSelectors('.player-PlayerControls__b
 Connector.isScrobblingAllowed = () => Util.getTextFromSelectors('.player-PlayerInfo__recordingInfo--15VMv') !== 'Sponsor message';
 
 function getCurrentTrack() {
-  return Util.getTextFromSelectors(".player-PlayerInfo__infoEl--2jhHY").split(" – ").slice(1).join(" - ").replace(" op. ", ", op. ");
+	return Util.getTextFromSelectors('.player-PlayerInfo__infoEl--2jhHY').split(' – ').slice(1).join(' - ');
 }
 
 function getCurrentSymphony() {
-	const symphonyShort = Util.getTextFromSelectors('.player-PlayerInfo__infoEl--2jhHY span:nth-child(3) span').split(/ in [A-G]/)[0];
-	const director = Util.getTextFromSelectors('.player-PlayerInfo__recordingInfo--15VMv>span:first-child span');
-	return `${symphonyShort} (${director})`;
+	const symphonyShort = Util.getTextFromSelectors('.player-PlayerInfo__infoEl--2jhHY span:nth-child(3) span:first-child').split(/ in [A-G]/)[0].split(/ op. [0-9]/)[0].split(/ KV [0-9]/)[0];
+	const commonName = Util.getTextFromSelectors('.player-PlayerInfo__infoEl--2jhHY span:nth-child(3) span:nth-child(2)') || '';
+	const director = removeParenthesis(Util.getTextFromSelectors('.player-PlayerInfo__recordingInfo--15VMv>span:first-child span'));
+	return `${symphonyShort}${commonName} (${director})`;
+}
+
+function removeParenthesis(text) {
+	return text.replace(/\s*\(.*?\)\s*/g, '');
 }

--- a/src/connectors/idagio.js
+++ b/src/connectors/idagio.js
@@ -1,5 +1,11 @@
 'use strict';
 
+const symphonySelector = '.player-PlayerInfo__infoEl--2jhHY span:nth-child(3) span:first-child';
+const commonNameSelector = '.player-PlayerInfo__infoEl--2jhHY span:nth-child(3) span:nth-child(2)';
+const directorSelector = '.player-PlayerInfo__recordingInfo--15VMv>span:first-child span';
+const trackSelector = '.player-PlayerInfo__infoEl--2jhHY';
+const pauseButtonSelector = '.player-PlayerControls__btn--1r-vy:nth-child(2) .util-IconLabel__component--3Uitr span';
+
 Connector.playerSelector = '.player-PlayerBar__bar--2yos_';
 
 Connector.artistSelector = '.player-PlayerInfo__infoEl--2jhHY span:first-child';
@@ -12,18 +18,18 @@ Connector.currentTimeSelector = '.player-PlayerProgress__progress--2F0qB>span';
 
 Connector.durationSelector = '.player-PlayerProgress__timeTotal--3aHlj span';
 
-Connector.isPlaying = () => Util.getTextFromSelectors('.player-PlayerControls__btn--1r-vy:nth-child(2) .util-IconLabel__component--3Uitr span') === 'Pause';
+Connector.isPlaying = () => Util.getTextFromSelectors(pauseButtonSelector) === 'Pause';
 
 Connector.isScrobblingAllowed = () => Util.getTextFromSelectors('.player-PlayerInfo__recordingInfo--15VMv') !== 'Sponsor message';
 
 function getCurrentTrack() {
-	return Util.getTextFromSelectors('.player-PlayerInfo__infoEl--2jhHY').split(' – ').slice(1).join(': ');
+	return Util.getTextFromSelectors(trackSelector).split(' – ').slice(1).join(': ');
 }
 
 function getCurrentSymphony() {
-	const symphonyShort = Util.getTextFromSelectors('.player-PlayerInfo__infoEl--2jhHY span:nth-child(3) span:first-child').split(/ in [A-G]| op. [0-9]| KV [0-9]/)[0];
-	const commonName = Util.getTextFromSelectors('.player-PlayerInfo__infoEl--2jhHY span:nth-child(3) span:nth-child(2)') || '';
-	const director = removeParenthesis(Util.getTextFromSelectors('.player-PlayerInfo__recordingInfo--15VMv>span:first-child span'));
+	const symphonyShort = Util.getTextFromSelectors(symphonySelector).split(/ in [A-G]| op. [0-9]| KV [0-9]/)[0];
+	const commonName = Util.getTextFromSelectors(commonNameSelector) || '';
+	const director = removeParenthesis(Util.getTextFromSelectors(directorSelector));
 	return `${symphonyShort}${commonName} (${director})`;
 }
 

--- a/src/connectors/idagio.js
+++ b/src/connectors/idagio.js
@@ -17,7 +17,7 @@ Connector.isPlaying = () => Util.getTextFromSelectors('.player-PlayerControls__b
 Connector.isScrobblingAllowed = () => Util.getTextFromSelectors('.player-PlayerInfo__recordingInfo--15VMv') !== 'Sponsor message';
 
 function getCurrentTrack() {
-	return Util.getTextFromSelectors('.player-PlayerInfo__infoEl--2jhHY').split(' – ').slice(1).join(' - ');
+	return Util.getTextFromSelectors('.player-PlayerInfo__infoEl--2jhHY').split(' – ').slice(1).join(': ');
 }
 
 function getCurrentSymphony() {

--- a/src/connectors/idagio.js
+++ b/src/connectors/idagio.js
@@ -1,35 +1,27 @@
 'use strict';
 
-const symphonySelector = '.player-PlayerInfo__infoEl--2jhHY span:nth-child(3) span';
-const movementSelector = '.player-PlayerInfo__infoEl--2jhHY span span span';
-const directorSelector = '.player-PlayerInfo__recordingInfo--15VMv>span:first-child span';
-const recordingInfoSelector = '.player-PlayerInfo__recordingInfo--15VMv';
-const pauseButtonSelector = '.player-PlayerControls__btn--1r-vy:nth-child(2) .util-IconLabel__component--3Uitr span';
-
 Connector.playerSelector = '.player-PlayerBar__bar--2yos_';
 
 Connector.artistSelector = '.player-PlayerInfo__infoEl--2jhHY span:first-child';
 
-Connector.getTrack = getCurrentTrack;
+Connector.getTrack = () => getCurrentTrack();
 
-Connector.getAlbum = getCurrentSymphony;
+Connector.getAlbum = () => getCurrentSymphony();
 
 Connector.currentTimeSelector = '.player-PlayerProgress__progress--2F0qB>span';
 
 Connector.durationSelector = '.player-PlayerProgress__timeTotal--3aHlj span';
 
-Connector.isPlaying = () => Util.getTextFromSelectors(pauseButtonSelector) === 'Pause';
+Connector.isPlaying = () => Util.getTextFromSelectors('.player-PlayerControls__btn--1r-vy:nth-child(2) .util-IconLabel__component--3Uitr span') === 'Pause';
 
-Connector.isScrobblingAllowed = () => Util.getTextFromSelectors(recordingInfoSelector) !== 'Sponsor message';
+Connector.isScrobblingAllowed = () => Util.getTextFromSelectors('.player-PlayerInfo__recordingInfo--15VMv') !== 'Sponsor message';
 
 function getCurrentTrack() {
-	const symphony = Util.getTextFromSelectors(symphonySelector);
-	const movement = Util.getTextFromSelectors(movementSelector);
-	return `${symphony}: ${movement}`;
+  return Util.getTextFromSelectors(".player-PlayerInfo__infoEl--2jhHY").split(" – ").slice(1).join(" - ").replace(" op. ", ", op. ");
 }
 
 function getCurrentSymphony() {
-	const symphonyShort = Util.getTextFromSelectors(symphonySelector).split(/ in [A-G]/)[0];
-	const director = Util.getTextFromSelectors(directorSelector);
+	const symphonyShort = Util.getTextFromSelectors('.player-PlayerInfo__infoEl--2jhHY span:nth-child(3) span').split(/ in [A-G]/)[0];
+	const director = Util.getTextFromSelectors('.player-PlayerInfo__recordingInfo--15VMv>span:first-child span');
 	return `${symphonyShort} (${director})`;
 }

--- a/src/connectors/idagio.js
+++ b/src/connectors/idagio.js
@@ -4,9 +4,9 @@ Connector.playerSelector = '.player-PlayerBar__bar--2yos_';
 
 Connector.artistSelector = '.player-PlayerInfo__infoEl--2jhHY span:first-child';
 
-Connector.getTrack = () => getCurrentTrack();
+Connector.getTrack = getCurrentTrack;
 
-Connector.getAlbum = () => getCurrentSymphony();
+Connector.getAlbum = getCurrentSymphony;
 
 Connector.currentTimeSelector = '.player-PlayerProgress__progress--2F0qB>span';
 

--- a/src/connectors/idagio.js
+++ b/src/connectors/idagio.js
@@ -21,7 +21,7 @@ function getCurrentTrack() {
 }
 
 function getCurrentSymphony() {
-	const symphonyShort = Util.getTextFromSelectors('.player-PlayerInfo__infoEl--2jhHY span:nth-child(3) span:first-child').split(/ in [A-G]/)[0].split(/ op. [0-9]/)[0].split(/ KV [0-9]/)[0];
+	const symphonyShort = Util.getTextFromSelectors('.player-PlayerInfo__infoEl--2jhHY span:nth-child(3) span:first-child').split(/ in [A-G]| op. [0-9]| KV [0-9]/)[0];
 	const commonName = Util.getTextFromSelectors('.player-PlayerInfo__infoEl--2jhHY span:nth-child(3) span:nth-child(2)') || '';
 	const director = removeParenthesis(Util.getTextFromSelectors('.player-PlayerInfo__recordingInfo--15VMv>span:first-child span'));
 	return `${symphonyShort}${commonName} (${director})`;


### PR DESCRIPTION
Had a discussion with a friend and ended up changing some things

- The symphony name shortener used for album tag is more reliable
- If there is a "common name", it is at least sometimes put in album tag
- Remove credit type for primary contributor, leaving only name

Some examples:

Old:
Bagatelle for Piano in A minor WoO 59 “Für Elise”: Poco moto
Ludwig van Beethoven
Bagatelle for Piano (Anatol Ugorski (Piano))

New:
Bagatelle for Piano in A minor WoO 59 “Für Elise”: Poco moto
Ludwig van Beethoven
Bagatelle for Piano “Für Elise” (Anatol Ugorski)


Old:
Préludes op. 28: 15. Prelude in D flat major 'Raindrop'. Sostenuto
Frédéric Chopin
Préludes op. 28 (Martha Argerich (piano))

New:
Préludes op. 28: 15. Prelude in D flat major 'Raindrop'. Sostenuto
Frédéric Chopin
Préludes (Martha Argerich)

Also features some general restructuring of the code