### PR TITLE
Add SoundCloud Premiere Filters

### DIFF
--- a/src/connectors/soundcloud.js
+++ b/src/connectors/soundcloud.js
@@ -41,7 +41,27 @@ Connector.getRemainingTime = () => {
 
 Connector.isPlaying = () => $('.playControl').hasClass('playing');
 
-Connector.applyFilter(MetadataFilter.getYoutubeFilter());
+const filterArtistPremiereRules = [
+	{ source: /^\s*Premiere.*:\s*/i, target: '' },
+	{ source: /^\s*\*\*Premiere\*\*\s*/i, target: '' },
+];
+
+const filterTrackPRemiereRules = [
+	{ source: /\[.*Premiere.*\]/i, target: '' },
+];
+
+function filterArtistPremiere(text) {
+	return MetadataFilter.filterWithFilterRules(text, filterArtistPremiereRules);
+}
+
+function filterTrackPremiere(text) {
+	return MetadataFilter.filterWithFilterRules(text, filterTrackPRemiereRules);
+}
+
+Connector.applyFilter(MetadataFilter.getYoutubeFilter().append({
+	artist: filterArtistPremiere,
+	track: filterTrackPremiere,
+}));
 
 function getDurationOrRemainingTime() {
 	return Util.getSecondsFromSelectors(durationSelector);

--- a/src/connectors/soundcloud.js
+++ b/src/connectors/soundcloud.js
@@ -46,7 +46,7 @@ const filterArtistPremiereRules = [
 	{ source: /^\s*\*\*Premiere\*\*\s*/i, target: '' },
 ];
 
-const filterTrackPRemiereRules = [
+const filterTrackPremiereRules = [
 	{ source: /\[.*Premiere.*\]/i, target: '' },
 ];
 
@@ -55,7 +55,7 @@ function filterArtistPremiere(text) {
 }
 
 function filterTrackPremiere(text) {
-	return MetadataFilter.filterWithFilterRules(text, filterTrackPRemiereRules);
+	return MetadataFilter.filterWithFilterRules(text, filterTrackPremiereRules);
 }
 
 Connector.applyFilter(MetadataFilter.getYoutubeFilter().append({


### PR DESCRIPTION
**Describe the changes you made**
Implements filtering of "Premiere" text on Artist & Track strings as requested by @sc113 in #2537.

**Additional context**
It handles the cases like these:
```
PREMIERE:Funderground feat. Mutado Pintado
PREMIERE : St Theodore - Machine Learning
PREMIERE: Funderground feat. Mutado Pintado - The Fun Begins
AVSTIN JAMES - Bad Bonfire (Childish Gambino X Axel Thesleff) [YouKnowWhatsGood Premiere]
Datsik & Zack the Lad - Feel Good [Thissongissick.com Premiere]
```
The first 3 contain the premiere string as part of the artist and the rest as part of the track string.