### PR TITLE
Fix byte.fm connector following update

### DIFF
--- a/src/connectors/byte.fm.js
+++ b/src/connectors/byte.fm.js
@@ -1,19 +1,9 @@
 'use strict';
 
-Connector.playerSelector = '#player';
+Connector.playerSelector = '.player';
 
 Connector.artistTrackSelector = '.player-current-title';
 
-Connector.getArtistTrack = () => {
-	const text = $(Connector.artistTrackSelector).text();
-	const m = text.match(/ - /g);
-	if (m && m.length === 2) {
-		const arr = text.split(' - ');
-		return { artist: arr[1], track: arr[2] };
-	}
-	return Util.splitArtistTrack(text);
-};
-
-Connector.pauseButtonSelector = '.player-pause';
+Connector.isPlaying = () => Util.getTextFromSelectors('.player-play-button') !== 'play';
 
 Connector.onReady = Connector.onStateChanged;


### PR DESCRIPTION
Updated the [byte.fm](byte.fm) connector to mirror the breaking changes made to the player. 
