### PR TITLE
Implement URL pattern match blacklisting feature

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -346,6 +346,10 @@
     "message": "Add URL patterns that the connector should match below.",
     "description": "Popup hint"
   },
+  "customBlacklistPatternsHint": {
+    "message": "Add URL patterns that the connector should ignore below.",
+    "description": "Popup hint"
+  },
   "customPatternsAdd": {
     "message": "Add pattern",
     "description": "Add button"

--- a/src/core/background/storage/browser-storage.js
+++ b/src/core/background/storage/browser-storage.js
@@ -16,9 +16,18 @@ define((require) => {
 	/**
 	 * This storage contains custom URL patterns defined by an user.
 	 *
+	 * Each pattern is a dictionary containing the pattern and a boolean
+	 * indicating if it should be used to blacklist instead.
+	 *
 	 * The format of storage data is following:
 	 * {
-	 *     connector_id: [URL_pattern_1, URL_pattern_2, ...],
+	 *     connector_id: [
+	 *         {
+	 *             isBlacklist: false,
+	 *             pattern: 'URL_pattern',
+	 *         }
+	 *         ...
+	 *     ],
 	 *     ...
 	 * }
 	 */

--- a/src/core/background/util/util-connector.js
+++ b/src/core/background/util/util-connector.js
@@ -9,14 +9,25 @@ define((require) => {
 	async function getConnectorByUrl(url) {
 		const customPatterns = await getAllPatterns();
 		for (const connector of connectors) {
-			const patterns = connector.matches || [];
+			const patterns = connector.matches.map(
+				(match) => ({
+					pattern: match,
+					isBlacklist: false,
+				})
+			) || [];
 
 			if (customPatterns[connector.id]) {
 				patterns.push(...customPatterns[connector.id]);
 			}
 
 			for (const pattern of patterns) {
-				if (UrlMatch.test(url, pattern)) {
+				if (UrlMatch.test(url, pattern['pattern']) && pattern['isBlacklist']) {
+					return null;
+				}
+			}
+
+			for (const pattern of patterns) {
+				if (UrlMatch.test(url, pattern['pattern'])) {
 					return connector;
 				}
 			}

--- a/src/ui/options/dialogs.js
+++ b/src/ui/options/dialogs.js
@@ -29,11 +29,18 @@ define((require) => {
 			const patterns = allPatterns[connector.id] || [];
 
 			const inputs = $('<ul class="list-unstyled patterns-list" id="conn-conf-list"></ul>');
+			const blacklistInputs = $('<ul class="list-unstyled patterns-list" id="conn-conf-blacklist-list"></ul>');
 			for (const value of patterns) {
-				inputs.append(createNewConfigInput(value));
+				if (value['isBlacklist']) {
+					blacklistInputs.append(createNewConfigInput(value['pattern']));
+				} else {
+					inputs.append(createNewConfigInput(value['pattern']));
+				}
 			}
 
 			modal.find('.conn-conf-patterns').html(inputs);
+			modal.modal('show');
+			modal.find('.conn-conf-blacklist-patterns').html(blacklistInputs);
 			modal.modal('show');
 		});
 
@@ -47,7 +54,13 @@ define((require) => {
 			$('#conn-conf-list').find('input:text').each(function() {
 				const pattern = $(this).val();
 				if (pattern.length > 0) {
-					patterns.push(pattern);
+					patterns.push({ pattern, isBlacklist: false });
+				}
+			});
+			$('#conn-conf-blacklist-list').find('input:text').each(function() {
+				const pattern = $(this).val();
+				if (pattern.length > 0) {
+					patterns.push({ pattern, isBlacklist: true });
 				}
 			});
 
@@ -62,6 +75,10 @@ define((require) => {
 
 		$('button#add-pattern').click(() => {
 			$('#conn-conf-list').append(createNewConfigInput());
+		});
+
+		$('button#add-blacklist-pattern').click(() => {
+			$('#conn-conf-blacklist-list').append(createNewConfigInput());
 		});
 
 		$('button#conn-conf-reset').click(function() {

--- a/src/ui/options/index.html
+++ b/src/ui/options/index.html
@@ -324,6 +324,11 @@
 						<div class="conn-conf-patterns"></div>
 						<button type="button" id="add-pattern" class="btn btn-primary" i18n="customPatternsAdd"></button>
 					</div>
+					<div class="modal-body">
+						<p i18n="customBlacklistPatternsHint"></p>
+						<div class="conn-conf-blacklist-patterns"></div>
+						<button type="button" id="add-blacklist-pattern" class="btn btn-primary" i18n="customPatternsAdd"></button>
+					</div>
 					<div class="modal-footer">
 						<button type="button" class="btn btn-secondary" data-dismiss="modal" i18n="buttonCancel"></button>
 						<button type="button" class="btn btn-secondary" id="conn-conf-reset" i18n="buttonReset"></button>


### PR DESCRIPTION
Implements #2557 and partially addresses #2443 (see note 3).

**Describe the changes you made**

Extends the existing custom patterns feature by marking each pattern in the `customPatterns` storage entry with a flag. When retrieving a connector based on the URL, this flag is used to check if the URL should be ignored.

The user-facing component includes a new body in the connector options modal dialogue, mirroring the existing pattern input. 

**Notes**
1. Blacklist entries take precedent over regular entries.
2. For the prompt, a new string is added to `messages.json` which will need to be translated.
3. To fully address #2443 requires a userscript which retrieves the channel ID of the playing YouTube video and appends it to the URL. The channel ID can then be added to the blacklist to blacklist all videos from that channel. Here is a link to a userscript that can be used with Tamper/Violentmonkey: https://github.com/fishstik/youtube-channel-in-url/
4. Blacklisting URLs in this way will have the extension icon show the `...does not support this website` tooltip and popup. For UI clarity, when a URL is blacklisted, it should show the `... is supported ... but you disabled it` tooltip and perhaps a new popup with something like `This URL is ignored` (since the existing `This website is turned off` popup wouldn't be accurate).


**Additional context**

Connector options UI update. This particular entry blacklists https://www.youtube.com/watch?v=dQw4w9WgXcQ
![image](https://user-images.githubusercontent.com/4278123/102732659-4f5a0b80-4309-11eb-9fd8-1daae05214e0.png)

Contents of browser storage after submitting the above:
![image](https://user-images.githubusercontent.com/4278123/102732715-7284bb00-4309-11eb-886f-53c4d14a36ef.png)