### PR TITLE
Improve Japanese youtube title parsing

### DIFF
--- a/src/core/content/util.js
+++ b/src/core/content/util.js
@@ -526,7 +526,7 @@ const Util = {
 		},
 		// Artist「Track」 (Japanese tracks)
 		{
-			pattern: /(.+?)[『「](.+?)[」』]/,
+			pattern: /(.+?)[『「【](.+?)[」』】]/,
 			groups: { artist: 1, track: 2 },
 		},
 		// Track (... by Artist)

--- a/src/core/content/util.js
+++ b/src/core/content/util.js
@@ -588,9 +588,6 @@ const Util = {
 		// MV/PV if not followed by an opening/closing bracket or if ending
 		title = title.replace(/(MV|PV)([「【『』】」]|$)/i, '$2');
 
-		// Music video in japanese brackets
-		title = title.replace(/[(【)](of+icial\s*)?(music\s*)?(video|audio)[)】]/i, '');
-
 		// Try to match one of the regexps
 		for (const regExp of this.ytTitleRegExps) {
 			const artistTrack = title.match(regExp.pattern);

--- a/src/core/content/util.js
+++ b/src/core/content/util.js
@@ -18,8 +18,21 @@ const Util = {
 	 * @type {Array}
 	 */
 	separators: [
-		' -- ', '--', ' ~ ', ' \u002d ', ' \u2013 ', ' \u2014 ',
-		' // ', '\u002d', '\u2013', '\u2014', ':', '|', '///', '/', '~',
+		' -- ',
+		'--',
+		' ~ ',
+		' \u002d ',
+		' \u2013 ',
+		' \u2014 ',
+		' // ',
+		'\u002d',
+		'\u2013',
+		'\u2014',
+		':',
+		'|',
+		'///',
+		'/',
+		'~',
 	],
 
 	/**
@@ -36,12 +49,13 @@ const Util = {
 		const negativeExpression = /-/g;
 		const digitsExpression = /\d{1,2}/g;
 
-		const seconds = str.match(digitsExpression)
+		const seconds = str
+			.match(digitsExpression)
 			.reverse()
 			.map((current) => parseInt(current, 10))
 			.reduce((total, current, i) => total + current * Math.pow(60, i));
 
-		return (negativeExpression.test(str)) ? -seconds : seconds;
+		return negativeExpression.test(str) ? -seconds : seconds;
 	},
 
 	/**
@@ -77,9 +91,11 @@ const Util = {
 			return null;
 		}
 
-		return artists.map((artist) => {
-			return artist.textContent;
-		}).join(this.ARTIST_SEPARATOR);
+		return artists
+			.map((artist) => {
+				return artist.textContent;
+			})
+			.join(this.ARTIST_SEPARATOR);
 	},
 
 	/**
@@ -114,7 +130,9 @@ const Util = {
 	 * @return {Object} Array ontains 'currentTime' and 'duration' fields
 	 */
 	splitTimeInfo(str, separator = '/', { swap = false } = {}) {
-		let [currentTime, duration] = this.splitString(str, [separator], { swap });
+		let [currentTime, duration] = this.splitString(str, [separator], {
+			swap,
+		});
 		if (currentTime) {
 			currentTime = this.stringToSeconds(currentTime);
 		}
@@ -358,9 +376,7 @@ const Util = {
 	 */
 	/* istanbul ignore next */
 	getSecondsFromSelectors(selectors) {
-		return Util.stringToSeconds(
-			Util.getTextFromSelectors(selectors)
-		);
+		return Util.stringToSeconds(Util.getTextFromSelectors(selectors));
 	},
 
 	/**
@@ -432,7 +448,9 @@ const Util = {
 		}
 
 		if (!Array.isArray(selectors)) {
-			throw new TypeError(`Unknown type of selector: ${typeof selectors}`);
+			throw new TypeError(
+				`Unknown type of selector: ${typeof selectors}`
+			);
 		}
 
 		for (const selector of selectors) {
@@ -526,7 +544,7 @@ const Util = {
 		},
 		// Artist「Track」 (Japanese tracks)
 		{
-			pattern: /(.+?)[『「【](.+?)[」』】]/,
+			pattern: /(.+?)[『｢「](.+?)[」｣』]/,
 			groups: { artist: 1, track: 2 },
 		},
 		// Track (... by Artist)
@@ -550,10 +568,28 @@ const Util = {
 		}
 
 		// Remove [genre] or 【genre】 from the beginning of the title
-		let title = videoTitle.replace(/^((\[[^\]]+])|(【[^】]+】))\s*-*\s*/i, '');
+		let title = videoTitle.replace(
+			/^((\[[^\]]+])|(【[^】]+】))\s*-*\s*/i,
+			''
+		);
 
 		// Remove track (CD and vinyl) numbers from the beginning of the title
 		title = title.replace(/^\s*([a-zA-Z]{1,2}|[0-9]{1,2})[1-9]?\.\s+/i, '');
+
+		// Remove - preceding opening bracket
+		title = title.replace(/-\s*([「【『])/, '$1');
+
+		// 【/(*Music Video/MV/PV*】/)
+		title = title.replace(/[(【].*?((MV)|(PV)).*?[】)]/i, '');
+
+		// 【/(東方/オリジナル*】/)
+		title = title.replace(/[(【]((オリジナル)|(東方)).*?[】)]/, '');
+
+		// MV/PV if not followed by an opening/closing bracket or if ending
+		title = title.replace(/(MV|PV)([「【『』】」]|$)/i, '$2');
+
+		// Music video in japanese brackets
+		title = title.replace(/[(【)](of+icial\s*)?(music\s*)?(video|audio)[)】]/i, '');
 
 		// Try to match one of the regexps
 		for (const regExp of this.ytTitleRegExps) {
@@ -570,6 +606,15 @@ const Util = {
 			({ artist, track } = this.splitArtistTrack(title));
 		}
 
+		// No match? Check for 【】
+		if (this.isArtistTrackEmpty({ artist, track })) {
+			const artistTrack = title.match(/(.+?)【(.+?)】/);
+			if (artistTrack) {
+				artist = artistTrack[1];
+				track = artistTrack[2];
+			}
+		}
+
 		if (this.isArtistTrackEmpty({ artist, track })) {
 			track = title;
 		}
@@ -578,9 +623,10 @@ const Util = {
 	},
 
 	isYtVideoDescriptionValid(desc) {
-		return desc && (
-			desc.startsWith(this.ytDescFirstLine) ||
-			desc.endsWith(this.ytDescLastLine)
+		return (
+			desc &&
+			(desc.startsWith(this.ytDescFirstLine) ||
+				desc.endsWith(this.ytDescLastLine))
 		);
 	},
 
@@ -589,11 +635,14 @@ const Util = {
 			return null;
 		}
 
-		const lines = desc.split('\n').filter((line) => {
-			return line.length > 0;
-		}).filter((line) => {
-			return !line.startsWith(this.ytDescFirstLine);
-		});
+		const lines = desc
+			.split('\n')
+			.filter((line) => {
+				return line.length > 0;
+			})
+			.filter((line) => {
+				return !line.startsWith(this.ytDescFirstLine);
+			});
 
 		const firstLine = lines[0];
 		const secondLine = lines[1];

--- a/tests/content/util.js
+++ b/tests/content/util.js
@@ -353,10 +353,6 @@ const PROCESS_YT_VIDEO_TITLE_DATA = [{
 	args: ['Track Name'],
 	expected: { artist: null, track: 'Track Name' },
 }, {
-	description: 'should remove "【Music Video】" string',
-	args: ['Artist - Track【Music Video】'],
-	expected: { artist: 'Artist', track: 'Track' },
-}, {
 	description: 'should remove "【MV】" string',
 	args: ['Artist - Track【MV】'],
 	expected: { artist: 'Artist', track: 'Track' },
@@ -485,9 +481,9 @@ const PROCESS_YT_VIDEO_TITLE_DATA = [{
 	args: ['Artist -【Track】'],
 	expected: { artist: 'Artist ', track: 'Track' },
 }, {
-	description: 'should remove 【Official Video】string (yonige moment)',
+	description: 'should prioritize dashes over 【】',
 	args: ['Artist -Track-【Official Video】'],
-	expected: { artist: 'Artist ', track: 'Track' },
+	expected: { artist: 'Artist ', track: 'Track【Official Video】' },
 }, {
 	description: 'should prioritize other brackets over 【】',
 	args: ['Artist「Track」【stuff】'],

--- a/tests/content/util.js
+++ b/tests/content/util.js
@@ -352,6 +352,146 @@ const PROCESS_YT_VIDEO_TITLE_DATA = [{
 	description: 'should use title as track title',
 	args: ['Track Name'],
 	expected: { artist: null, track: 'Track Name' },
+}, {
+	description: 'should remove "【Music Video】" string',
+	args: ['Artist - Track【Music Video】'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "【MV】" string',
+	args: ['Artist - Track【MV】'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "【Whatever MV】" string',
+	args: ['Artist「Track」【Whatever MV】'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "【MV Whatever】" string',
+	args: ['Artist - Track【MV Whatever】'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "(MV)" string',
+	args: ['Artist - Track(MV)'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "MV" string',
+	args: ['Artist - TrackMV'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should not remove "MV" in string',
+	args: ['Artist - Omvei'],
+	expected: { artist: 'Artist', track: 'Omvei' },
+}, {
+	description: 'should remove "MV" in string if before 「',
+	args: ['ArtistMV「Track」'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "MV" in string if before 【',
+	args: ['ArtistMV【Track】'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "MV" in string if before 『',
+	args: ['ArtistMV『Track』'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "MV" in string if before 」',
+	args: ['Artist「TrackMV」'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "MV" in string if before 』',
+	args: ['Artist『TrackMV』'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "PV" string',
+	args: ['Artist - TrackPV'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should not remove "PV" in string',
+	args: ['Artist - Oppvakt'],
+	expected: { artist: 'Artist', track: 'Oppvakt' },
+}, {
+	description: 'should remove "PV" in string if before 「',
+	args: ['ArtistPV「Track」'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "PV" in string if before 『',
+	args: ['ArtistPV『Track』'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "PV" in string if before 」',
+	args: ['Artist「TrackPV」'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "PV" in string if before 』',
+	args: ['Artist『TrackPV』'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "【PV】" string',
+	args: ['Artist - Track【PV】'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "【Whatever PV】" string',
+	args: ['Artist - Track【Whatever PV】'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "【PV Whatever】" string',
+	args: ['Artist - Track【PV Whatever】'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "(PV)" string',
+	args: ['Artist - Track (PV)'],
+	expected: { artist: 'Artist', track: 'Track ' },
+}, {
+	description: 'should remove "(Whatever PV)" string',
+	args: ['Artist - Track(Whatever PV)'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "(PV Whatever)" string',
+	args: ['Artist - Track(PV Whatever)'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "(Whatever MV)" string',
+	args: ['Artist - Track(Whatever MV)'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "(MV Whatever)" string',
+	args: ['Artist - Track (MV Whatever)'],
+	expected: { artist: 'Artist', track: 'Track ' },
+}, {
+	description: 'should remove "【オリジナル】" string',
+	args: ['Artist - Track【オリジナル】'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "【オリジナルWhatever】" string',
+	args: ['Artist【Track】【オリジナルWhatever】'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "【東方】" string',
+	args: ['Artist - Track【東方】'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove "【東方Whatever】" string',
+	args: ['Artist「Track」【東方Whatever】'],
+	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should remove dash from "-「" string',
+	args: ['Artist - 「Track」'],
+	expected: { artist: 'Artist ', track: 'Track' },
+}, {
+	description: 'should remove dash from "-『" string',
+	args: ['Artist -『Track』'],
+	expected: { artist: 'Artist ', track: 'Track' },
+}, {
+	description: 'should remove dash from "-【" string',
+	args: ['Artist -【Track】'],
+	expected: { artist: 'Artist ', track: 'Track' },
+}, {
+	description: 'should remove 【Official Video】string (yonige moment)',
+	args: ['Artist -Track-【Official Video】'],
+	expected: { artist: 'Artist ', track: 'Track' },
+}, {
+	description: 'should prioritize other brackets over 【】',
+	args: ['Artist「Track」【stuff】'],
+	expected: { artist: 'Artist', track: 'Track' },
 }];
 
 /**


### PR DESCRIPTION
This should fix parsing of thousands of Japanese videos, including but not limited to:
https://youtu.be/2BAdG-1AT-Q
https://youtu.be/fP2dH0hXQXY
https://youtu.be/6tHAM8m8XrY
https://youtu.be/MScO5NsmII0
https://youtu.be/R4xgeGinzUY (once metadata filter is updated)