### PR TITLE
Remove unused startup messages

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -507,22 +507,6 @@
         "message": "Klick auf das Symbol in der Erweiterungsleiste und trage Titelinformationen ein.",
         "description": "Notification text"
     },
-    "startupTitle": {
-        "message": "Willkommen beim Web Scrobbler!",
-        "description": "Title for startup page"
-    },
-    "startupIntroTitle": {
-        "message": "Danke, dass du dir Web Scrobbler installiert hast.",
-        "description": "Startup intro title"
-    },
-    "startupIntroText": {
-        "message": "Bevor wir anfangen können, all deine Musik zu scrobblen, musst du zuerst unseren Datenschutzbestimmungen zustimmen (oder ablehnen).",
-        "description": "Startup intro text"
-    },
-    "startupFinished": {
-        "message": "Danke! Wenn du dich umentscheidest, kannst du dies in Einstellungen ändern.",
-        "description": "Startup finished text"
-    },
     "optIn": {
         "message": "Opt In",
         "description": "Opt in"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -599,22 +599,6 @@
     "message": "Click on the icon in the extensions bar to correct and submit track info.",
     "description": "Notification text"
   },
-  "startupTitle": {
-    "message": "Welcome to Web Scrobbler!",
-    "description": "Title for startup page"
-  },
-  "startupIntroTitle": {
-    "message": "Thanks for choosing to install Web Scrobbler!",
-    "description": "Startup intro title"
-  },
-  "startupIntroText": {
-    "message": "Before we can begin to scrobble all your music, you must first review and opt in (or out) of our privacy policy.",
-    "description": "Startup intro text"
-  },
-  "startupFinished": {
-    "message": "Thanks! If you change your mind you can change this in the options.",
-    "description": "Startup finished text"
-  },
   "optIn": {
     "message": "Opt In",
     "description": "Opt in"

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -575,22 +575,6 @@
         "message": "Haga clic en el icono en la barra de extensiones para corregir y enviar información de la pista.",
         "description": "Notification text"
     },
-    "startupTitle": {
-        "message": "Bienvenido a Web Scrobbler!",
-        "description": "Title for startup page"
-    },
-    "startupIntroTitle": {
-        "message": "Gracias por decidir instalar Web Scrobbler!",
-        "description": "Startup intro title"
-    },
-    "startupIntroText": {
-        "message": "Antes de empezar a scrobble toda tu música, primero debes revisar y optar positiva o negativamente nuestra política de privacidad",
-        "description": "Startup intro text"
-    },
-    "startupFinished": {
-        "message": "Gracias! Si cambias de parecer, puedes modificarlo desde las opciones.",
-        "description": "Startup finished text"
-    },
     "optIn": {
         "message": "Optar por sí",
         "description": "Opt in"

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -575,22 +575,6 @@
         "message": "Kliknij ikonę na pasku rozszerzeń, aby poprawić i przesłać informacje o utworze.",
         "description": "Notification text"
     },
-    "startupTitle": {
-        "message": "Witamy w Web Scrobblerze!",
-        "description": "Title for startup page"
-    },
-    "startupIntroTitle": {
-        "message": "Dzięki, że wybrałeś Web Scrobblera!",
-        "description": "Startup intro title"
-    },
-    "startupIntroText": {
-        "message": "Zanim będziemy mogli zacząć scrobblować całą twoją muzykę, musisz najpierw zapoznać się i wyrazić (albo i nie) zgodę na naszą politykę prywatności.",
-        "description": "Startup intro text"
-    },
-    "startupFinished": {
-        "message": "Dzięki! Jeśli zmienisz zdanie, zawsze możesz zmienić wybór w opcjach rozszerzenia.",
-        "description": "Startup finished text"
-    },
     "optIn": {
         "message": "Zgadzam się",
         "description": "Opt in"

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -551,22 +551,6 @@
         "message": "Clique no ícone na barra de extensões para corrigir e enviar dados da faixa.",
         "description": "Notification text"
     },
-    "startupTitle": {
-        "message": "Bem-vindo ao Web Scrobbler!",
-        "description": "Title for startup page"
-    },
-    "startupIntroTitle": {
-        "message": "Obrigado por instalar o Web Scrobbler!",
-        "description": "Startup intro title"
-    },
-    "startupIntroText": {
-        "message": "Antes de começarmos a fazer scrobble das suas músicas favoritas, primeiro você deve revisar e aceitar (ou recusar) a nossa política de privacidade.",
-        "description": "Startup intro text"
-    },
-    "startupFinished": {
-        "message": "Obrigado! Caso mude de ideia, você pode alterar a sua resposta nas opções.",
-        "description": "Startup finished text"
-    },
     "optIn": {
         "message": "Aceitar",
         "description": "Opt in"

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -575,22 +575,6 @@
         "message": "Кликните на иконку справа от адресной строки, чтобы скорректировать информацию о композиции.",
         "description": "Notification text"
     },
-    "startupTitle": {
-        "message": "Добро пожаловать в Web Scrobbler!",
-        "description": "Title for startup page"
-    },
-    "startupIntroTitle": {
-        "message": "Благодарим за установку Web Scrobbler!",
-        "description": "Startup intro title"
-    },
-    "startupIntroText": {
-        "message": "Прежде, чем мы начнём скробблить ваши композиции, вам следует ознакомиться с нашей политикой конфиденциальности и принять или отклонить её.",
-        "description": "Startup intro text"
-    },
-    "startupFinished": {
-        "message": "Спасибо! Если вы захотите изменить свой выбор, вы можете сделать это в настройках расширения.",
-        "description": "Startup finished text"
-    },
     "optIn": {
         "message": "Принять",
         "description": "Opt in"

--- a/src/_locales/sk_SK/messages.json
+++ b/src/_locales/sk_SK/messages.json
@@ -551,22 +551,6 @@
         "message": "Kliknite na ikonku v lište doplnkov a uložte správne údaje.",
         "description": "Notification text"
     },
-    "startupTitle": {
-        "message": "Vitajte vo Web Scrobbleri!",
-        "description": "Title for startup page"
-    },
-    "startupIntroTitle": {
-        "message": "Ďakujeme Vám, že ste si vybrali Web Scrobbler!",
-        "description": "Startup intro title"
-    },
-    "startupIntroText": {
-        "message": "Predtým než môžeme začať zaznamenávať vašu hudbu, je nutné si prečítať a vyjadriť súhlas/nesúhlas s našimi zásadami o ochrane osobných údajov.",
-        "description": "Startup intro text"
-    },
-    "startupFinished": {
-        "message": "Ďakujeme! V prípade že zmeníte názor, môžete zmeniť Vaše rozhodnutie v nastaveniach doplnku.",
-        "description": "Startup finished text"
-    },
     "optIn": {
         "message": "Súhlasiť",
         "description": "Opt in"

--- a/src/_locales/zh/messages.json
+++ b/src/_locales/zh/messages.json
@@ -575,22 +575,6 @@
         "message": "点击扩展列中的图标来更正和提交曲目信息。",
         "description": "Notification text"
     },
-    "startupTitle": {
-        "message": "欢迎使用 Web Scrobbler！",
-        "description": "Title for startup page"
-    },
-    "startupIntroTitle": {
-        "message": "感谢选择安装 Web Scrobbler！",
-        "description": "Startup intro title"
-    },
-    "startupIntroText": {
-        "message": "在我们开始记录您的所有音乐之前，您必须先审查并选择加入（或退出）我们的隐私政策。",
-        "description": "Startup intro text"
-    },
-    "startupFinished": {
-        "message": "感谢！如果您改变主意，可以在选项中进行更改。",
-        "description": "Startup finished text"
-    },
     "optIn": {
         "message": "选择参加",
         "description": "Opt in"


### PR DESCRIPTION
**Describe the changes you made**
Remove startup messages that are no longer user in the extension.

**Additional context**
@alexesprit mentioned the `startupIntroText` was no longer used, and I found it seems all of the `startup` messages were no longer used. There may be more in the messages file that are unused, but I figured it would be good to keep the PR small and only remove this collection for now.
