### PR TITLE
Fixed scrobbling not working due to html layout change

### DIFF
--- a/src/connectors/watch2gether.js
+++ b/src/connectors/watch2gether.js
@@ -15,7 +15,7 @@ Connector.getTrackInfo = () => {
 		return {};
 	}
 
-	const chatTextItem = chatProviderItem.nextElementSibling;
+	const chatTextItem = chatProviderItem.nextElementSibling.nextElementSibling;
 
 	const type = chatProviderItem.classList[1] || 'unknown';
 	const title = chatTextItem.textContent;


### PR DESCRIPTION
The html now has another span between the chatProviderItem and the anchor, so to get the href, we need to call nextElementSibling twice

Added another call on the watch2gether connect line 18 to nextElementSibling
