### PR TITLE
Add connector override options (#2829)

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -267,6 +267,10 @@
         "message": "Anders als andere Erweiterungen enthält diese keine blinkenden Banner oder hinterhältige Werbung.",
         "description": ""
     },
+    "customPatterns": {
+        "message": "URL-Muster",
+        "description": "'URL patterns' section"
+    },
     "customPatternsHint": {
         "message": "Füge URL-Muster, für die der Verbinder gelten soll unten ein.",
         "description": "Popup hint"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -326,6 +326,10 @@
     "message": "The extension is free, and will always be free. But if you want to support development of the extension, you can use the button below.",
     "description": ""
   },
+  "customPatterns": {
+    "message": "URL patterns",
+    "description": "'URL patterns' section"
+  },
   "customPatternsHint": {
     "message": "Add URL patterns that the connector should match below.",
     "description": "Popup hint"

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -315,6 +315,10 @@
         "message": "La extensión es gratuita y siempre lo será. Pero si desea apoyar el desarrollo de la extensión, puede usar el botón a continuación.",
         "description": ""
     },
+    "customPatterns": {
+        "message": "Patrones de direcciones URL",
+        "description": "'URL patterns' section"
+    },
     "customPatternsHint": {
         "message": "Agrega patrones de direcciones URL que a continuación el conector debe hacer coincidir.",
         "description": "Popup hint"

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -315,6 +315,10 @@
         "message": "Rozszerzenie jest i pozostanie bezpłatne. Jeśli jednak chcesz wesprzeć jego dalszy rozwój, możesz skorzystać z poniższej opcji.",
         "description": ""
     },
+    "customPatterns": {
+        "message": "Wzorce adresów",
+        "description": "'URL patterns' section"
+    },
     "customPatternsHint": {
         "message": "Wprowadź poniżej wzorce adresów, dla których aktywowana ma być obsługa serwisu.",
         "description": "Popup hint"

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -291,6 +291,10 @@
         "message": "A extensão é gratuita, e sempre será. Mas, caso queira apoiar o desenvolvimento, sinta-se à vontade para usar o botão abaixo.",
         "description": ""
     },
+    "customPatterns": {
+        "message": "Padrões de URL",
+        "description": "'URL patterns' section"
+    },
     "customPatternsHint": {
         "message": "Adicione padrões de URL que o conector deva corresponder abaixo.",
         "description": "Popup hint"

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -315,6 +315,10 @@
         "message": "Расширение бесплатно, и всегда будет бесплатным. Если вы хотите поддержать разработку расширения, вы можете воспользоваться кнопкой ниже.",
         "description": ""
     },
+    "customPatterns": {
+        "message": "Шаблоны URL",
+        "description": "'URL patterns' section"
+    },
     "customPatternsHint": {
         "message": "Добавьте необходимые шаблоны URL для коннектора.",
         "description": "Popup hint"

--- a/src/_locales/sk_SK/messages.json
+++ b/src/_locales/sk_SK/messages.json
@@ -291,6 +291,10 @@
         "message": "Používanie doplnku je zadarmo, a vždy aj bude. Avšak, ak chcete podporiť vývoj doplnku, môžete použiť tlačidlo nižšie.",
         "description": ""
     },
+    "customPatterns": {
+        "message": "URL vzory",
+        "description": "'URL patterns' section"
+    },
     "customPatternsHint": {
         "message": "URL vzory ktoré má konektor brať pridajte dolu.",
         "description": "Popup hint"

--- a/src/_locales/zh/messages.json
+++ b/src/_locales/zh/messages.json
@@ -315,6 +315,10 @@
         "message": "该扩展免费并将永久免费。但是如果你想支持扩展的开发，可以使用下方按钮。",
         "description": ""
     },
+    "customPatterns": {
+        "message": "网址格式",
+        "description": "'URL patterns' section"
+    },
     "customPatternsHint": {
         "message": "在下方为接口添加匹配网址。",
         "description": "Popup hint"

--- a/src/core/background/browser/notifications.js
+++ b/src/core/background/browser/notifications.js
@@ -48,10 +48,11 @@ define((require) => {
 
 	/**
 	 * Check if notifications are allowed by user.
+	 * @param  {Object} connector Connector instance
 	 * @return {Boolean} Check result
 	 */
-	async function isAllowed() {
-		return await Options.getOption(Options.USE_NOTIFICATIONS);
+	async function isAllowed(connector) {
+		return await Options.getOption(Options.USE_NOTIFICATIONS, connector.id);
 	}
 
 	/**
@@ -124,10 +125,11 @@ define((require) => {
 	/**
 	 * Show 'Now playing' notification.
 	 * @param  {Object} song Copy of song instance
+	 * @param  {Object} connector Connector instance
 	 * @param  {Function} [onClick] Function that will be called on notification click
 	 */
-	async function showNowPlaying(song, onClick) {
-		if (!await isAllowed()) {
+	async function showNowPlaying(song, connector, onClick) {
+		if (!await isAllowed(connector)) {
 			return;
 		}
 
@@ -207,10 +209,11 @@ define((require) => {
 	/**
 	 * Show notification if song is not recognized.
 	 * @param  {Object} song Song instance
+	 * @param  {Object} connector Connector instance
 	 * @param  {Function} [onClick] Function that will be called on notification click
 	 */
-	async function showSongNotRecognized(song, onClick) {
-		if (!await Options.getOption(Options.USE_UNRECOGNIZED_SONG_NOTIFICATIONS)) {
+	async function showSongNotRecognized(song, connector, onClick) {
+		if (!await Options.getOption(Options.USE_UNRECOGNIZED_SONG_NOTIFICATIONS, connector.id)) {
 			return;
 		}
 

--- a/src/core/background/extension.js
+++ b/src/core/background/extension.js
@@ -274,7 +274,7 @@ define((require) => {
 						return;
 					}
 
-					Notifications.showNowPlaying(song, () => {
+					Notifications.showNowPlaying(song, ctrl.connector, () => {
 						openTab(ctrl.tabId);
 					});
 					break;
@@ -282,7 +282,7 @@ define((require) => {
 
 				case SongUnrecognized: {
 					const song = ctrl.getCurrentSong();
-					Notifications.showSongNotRecognized(song, () => {
+					Notifications.showSongNotRecognized(song, ctrl.connector, () => {
 						openTab(ctrl.tabId);
 					});
 					break;

--- a/src/core/background/object/controller.js
+++ b/src/core/background/object/controller.js
@@ -42,7 +42,7 @@ define((require) => {
 			this.currentSong = null;
 			this.isReplayingSong = false;
 			this.shouldScrobblePodcasts = true;
-			(async () => this.shouldScrobblePodcasts = await Options.getOption(Options.SCROBBLE_PODCASTS))();
+			(async () => this.shouldScrobblePodcasts = await Options.getOption(Options.SCROBBLE_PODCASTS, connector.id))();
 
 			this.debugLog(`Created controller for ${connector.label} connector`);
 		}
@@ -335,7 +335,7 @@ define((require) => {
 		async processSong() {
 			this.setMode(ControllerMode.Loading);
 
-			if (!await this.pipeline.process(this.currentSong)) {
+			if (!await this.pipeline.process(this.currentSong, this.connector)) {
 				return;
 			}
 
@@ -466,7 +466,7 @@ define((require) => {
 				return;
 			}
 
-			const percent = await Options.getOption(Options.SCROBBLE_PERCENT);
+			const percent = await Options.getOption(Options.SCROBBLE_PERCENT, this.connector.id);
 			const secondsToScrobble = Util.getSecondsToScrobble(duration, percent);
 
 			if (secondsToScrobble !== -1) {

--- a/src/core/background/pipeline/metadata.js
+++ b/src/core/background/pipeline/metadata.js
@@ -19,8 +19,9 @@ define((require) => {
 	/**
 	 * Load song info using ScrobblerService object.
 	 * @param  {Object} song Song instance
+	 * @param  {Object} connector Connector instance
 	 */
-	async function process(song) {
+	async function process(song, connector) {
 		if (song.isEmpty()) {
 			return;
 		}
@@ -44,7 +45,7 @@ define((require) => {
 			}
 		}
 
-		const forceRecognize = await Options.getOption(Options.FORCE_RECOGNIZE);
+		const forceRecognize = await Options.getOption(Options.FORCE_RECOGNIZE, connector.id);
 		song.flags.isValid = isSongValid || forceRecognize;
 	}
 

--- a/src/core/background/pipeline/pipeline.js
+++ b/src/core/background/pipeline/pipeline.js
@@ -17,12 +17,12 @@ define((require) => {
 			];
 		}
 
-		async process(song) {
+		async process(song, connector) {
 			// FIXME: Use another lock way
 			this.song = song;
 
 			for (const processor of this.processors) {
-				await processor.process(song);
+				await processor.process(song, connector);
 			}
 
 			// Return false if this call is not relevant, e.g. when

--- a/src/core/background/storage/browser-storage.js
+++ b/src/core/background/storage/browser-storage.js
@@ -8,10 +8,16 @@ define((require) => {
 	const SYNC = 1;
 
 	/**
-	 * This storage contains the options values.
+	 * This storage contains the connector options values.
 	 * @see DEFAULT_CONNECTOR_OPTIONS_MAP object in `config` module.
 	 */
 	const CONNECTORS_OPTIONS = 'Connectors';
+
+	/**
+	 * This storage contains the connector override options values.
+	 * @see DEFAULT_CONNECTOR_OVERRIDE_OPTIONS_MAP object in `config` module.
+	 */
+	const CONNECTORS_OVERRIDE_OPTIONS = 'ConnectorsOverrideOptions';
 
 	/**
 	 * This storage contains custom URL patterns defined by an user.
@@ -74,6 +80,7 @@ define((require) => {
 
 	const storageTypeMap = {
 		[CONNECTORS_OPTIONS]: SYNC,
+		[CONNECTORS_OVERRIDE_OPTIONS]: SYNC,
 		[CUSTOM_PATTERNS]: SYNC,
 		[NOTIFICATIONS]: SYNC,
 		[OPTIONS]: SYNC,
@@ -138,7 +145,7 @@ define((require) => {
 
 		getLocalStorage, getSyncStorage,
 
-		CONNECTORS_OPTIONS, CUSTOM_PATTERNS,
+		CONNECTORS_OPTIONS, CONNECTORS_OVERRIDE_OPTIONS, CUSTOM_PATTERNS,
 		NOTIFICATIONS, LOCAL_CACHE, OPTIONS, CORE,
 	};
 });

--- a/src/core/background/storage/options.js
+++ b/src/core/background/storage/options.js
@@ -6,6 +6,7 @@ define((require) => {
 
 	const options = BrowserStorage.getStorage(BrowserStorage.OPTIONS);
 	const connectorsOptions = BrowserStorage.getStorage(BrowserStorage.CONNECTORS_OPTIONS);
+	const connectorsOverrideOptions = BrowserStorage.getStorage(BrowserStorage.CONNECTORS_OVERRIDE_OPTIONS);
 
 	const FORCE_RECOGNIZE = 'forceRecognize';
 	const USE_NOTIFICATIONS = 'useNotifications';
@@ -97,6 +98,8 @@ define((require) => {
 		}
 		await connectorsOptions.set(data);
 		connectorsOptions.debugLog();
+
+		connectorsOverrideOptions.debugLog();
 	}
 
 	async function cleanupConfigValues() {
@@ -119,8 +122,15 @@ define((require) => {
 		}
 	}
 
-	async function getOption(key) {
+	async function getOption(key, connector) {
 		assertValidOptionKey(key);
+
+		if (connector !== undefined) {
+			const optionValue = await getConnectorOverrideOption(connector, key);
+			if (optionValue !== undefined) {
+				return optionValue;
+			}
+		}
 
 		const data = await options.get();
 		return data[key];
@@ -146,6 +156,21 @@ define((require) => {
 		data[connector][key] = value;
 
 		await connectorsOptions.set(data);
+	}
+
+	async function getConnectorOverrideOption(connector, key) {
+		const data = await connectorsOverrideOptions.get();
+		return data[connector] && data[connector][key];
+	}
+
+	async function setConnectorOverrideOption(connector, key, value) {
+		const data = await connectorsOverrideOptions.get();
+		if (!data[connector]) {
+			data[connector] = {};
+		}
+		data[connector][key] = value;
+
+		await connectorsOverrideOptions.set(data);
 	}
 
 	function assertValidOptionKey(key) {
@@ -214,6 +239,7 @@ define((require) => {
 		isConnectorEnabled, setConnectorEnabled, setAllConnectorsEnabled,
 
 		getOption, setOption, getConnectorOption, setConnectorOption,
+		getConnectorOverrideOption, setConnectorOverrideOption,
 
 		FORCE_RECOGNIZE, USE_NOTIFICATIONS,
 		SCROBBLE_PODCASTS, USE_UNRECOGNIZED_SONG_NOTIFICATIONS,

--- a/src/ui/options/dialogs.js
+++ b/src/ui/options/dialogs.js
@@ -4,17 +4,29 @@ define((require) => {
 	const browser = require('webextension-polyfill');
 	const SavedEdits = require('storage/saved-edits');
 	const CustomPatterns = require('storage/custom-patterns');
+	const Options = require('storage/options');
 
 	const { getSortedConnectors } = require('util/util-connector');
 
 	const sortedConnectors = getSortedConnectors();
 
+	/**
+	 * Object that maps options to their element IDs.
+	 * @type {Object}
+	 */
+	const OPTIONS_UI_MAP = {
+		'#conn-conf-force-recognize': Options.FORCE_RECOGNIZE,
+		'#conn-conf-use-notifications': Options.USE_NOTIFICATIONS,
+		'#conn-conf-use-unrecognized-song-notifications': Options.USE_UNRECOGNIZED_SONG_NOTIFICATIONS,
+		'#conn-conf-scrobble-podcasts': Options.SCROBBLE_PODCASTS,
+	};
+
 	function initialize() {
-		initAddPatternDialog();
+		initConnectorConfigDialog();
 		initViewEditedDialog();
 	}
 
-	function initAddPatternDialog() {
+	function initConnectorConfigDialog() {
 		$('body').on('click', 'a.conn-config', async (e) => {
 			e.preventDefault();
 
@@ -24,6 +36,16 @@ define((require) => {
 
 			modal.data('conn', index);
 			modal.find('.modal-title').text(connector.label);
+
+			for (const optionId in OPTIONS_UI_MAP) {
+				const option = OPTIONS_UI_MAP[optionId];
+
+				const optionValue = await Options.getConnectorOverrideOption(connector.id, option);
+				$(optionId).prop('checked', optionValue || false);
+				if (optionValue === undefined) {
+					$(optionId).prop('indeterminate', true);
+				}
+			}
 
 			const allPatterns = await CustomPatterns.getAllPatterns();
 			const patterns = allPatterns[connector.id] || [];
@@ -37,11 +59,19 @@ define((require) => {
 			modal.modal('show');
 		});
 
-		$('button#conn-conf-ok').click(function() {
+		$('button#conn-conf-ok').click(async function() {
 			const modal = $(this).closest('#conn-conf-modal');
 
 			const index = modal.data('conn');
 			const connector = sortedConnectors[index];
+
+			for (const optionId in OPTIONS_UI_MAP) {
+				const option = OPTIONS_UI_MAP[optionId];
+
+				if (!$(optionId).prop('indeterminate')) {
+					await Options.setConnectorOverrideOption(connector.id, option, $(optionId).is(':checked'));
+				}
+			}
 
 			const patterns = [];
 			$('#conn-conf-list').find('input:text').each(function() {
@@ -64,11 +94,17 @@ define((require) => {
 			$('#conn-conf-list').append(createNewConfigInput());
 		});
 
-		$('button#conn-conf-reset').click(function() {
+		$('button#conn-conf-reset').click(async function() {
 			const modal = $(this).closest('#conn-conf-modal');
 
 			const index = modal.data('conn');
 			const connector = sortedConnectors[index];
+
+			for (const optionId in OPTIONS_UI_MAP) {
+				const option = OPTIONS_UI_MAP[optionId];
+
+				await Options.setConnectorOverrideOption(connector.id, option, undefined);
+			}
 
 			CustomPatterns.resetPatterns(connector.id);
 

--- a/src/ui/options/index.html
+++ b/src/ui/options/index.html
@@ -308,6 +308,26 @@
 						</button>
 					</div>
 					<div class="modal-body">
+						<h6 i18n="optionsGeneral"></h6>
+						<div class="options-block">
+							<div class="form-check">
+								<input class="form-check-input" type="checkbox" id="conn-conf-use-notifications">
+								<label class="form-check-label" for="conn-conf-use-notifications" i18n="optionUseNotifications" i18n-title="optionUseNotificationsTitle"></label>
+							</div>
+							<div class="form-check">
+								<input class="form-check-input" type="checkbox" id="conn-conf-use-unrecognized-song-notifications">
+								<label class="form-check-label" for="conn-conf-use-unrecognized-song-notifications" i18n="optionUnrecognizedNotifications" i18n-title="optionUnrecognizedNotificationsTitle"></label>
+							</div>
+							<div class="form-check">
+								<input class="form-check-input" type="checkbox" id="conn-conf-force-recognize">
+								<label class="form-check-label" for="conn-conf-force-recognize" i18n="optionForceRecognize" i18n-title="optionForceRecognizeTitle"></label>
+							</div>
+							<div class="form-check">
+								<input class="form-check-input" type="checkbox" id="conn-conf-scrobble-podcasts">
+								<label class="form-check-label" for="conn-conf-scrobble-podcasts" i18n="optionScrobblePodcasts" i18n-title="optionScrobblePodcastsTitle"></label>
+							</div>
+						</div>
+						<h6 i18n="customPatterns"></h6>
 						<p i18n="customPatternsHint"></p>
 						<div class="conn-conf-patterns">
 							<ul class="list-unstyled patterns-list" id="conn-conf-list"></ul>


### PR DESCRIPTION
I added a new type of options, connector override options, which allows users to enable or disable "Use now playing notifications", "Notify if track is not recognized", "Force track recognition" and "Scrobble podcasts" on specific websites. The checkboxes are in the "indeterminate" state by default, which means they're unset and the connector uses the global/general settings. You can check or uncheck these boxes to make the connector no longer follow use global setting. The reset button will restore the checkboxes to the indeterminate state, and will make it so the connector no longer overrides the general settings.

With this feature implemented, users can now for example enable force track recognition on all websites except YouTube, or disable unrecognized track notifications on all sites except Bandcamp (see screenshot below). See #2829 for more information.

![image](https://user-images.githubusercontent.com/3918757/115738292-3764c800-a38d-11eb-864a-a6cac4df7cc2.png)