### PR TITLE
Fix maloja duplicates

### DIFF
--- a/src/core/background/scrobbler/maloja-scrobbler.js
+++ b/src/core/background/scrobbler/maloja-scrobbler.js
@@ -68,7 +68,6 @@ define((require) => {
 		/** @override */
 		async scrobble(song) {
 			const songData = this.makeTrackMetadata(song);
-			songData.time = song.metadata.startTimestamp;
 
 			return this.sendRequest(songData, this.userToken);
 		}
@@ -107,6 +106,7 @@ define((require) => {
 			const trackMeta = {
 				artist: song.getArtist(),
 				title: song.getTrack(),
+				time: song.metadata.startTimestamp,
 			};
 
 			return trackMeta;

--- a/src/core/background/scrobbler/maloja-scrobbler.js
+++ b/src/core/background/scrobbler/maloja-scrobbler.js
@@ -60,9 +60,8 @@ define((require) => {
 
 		/** @override */
 		async sendNowPlaying(song) {
-			const { sessionID } = await this.getSession();
-			const songData = this.makeTrackMetadata(song);
-			return this.sendRequest(songData, sessionID);
+			// Maloja does not support "now playing" scrobbles.
+			return ServiceCallResult.RESULT_OK
 		}
 
 		/** @override */


### PR DESCRIPTION
Send timestamp with every request for Maloja.

Maloja assigns current server timestamp to scrobbles without `time`. That creates duplicated scrobbles when time is not in sync between client and server or when the connection is slow.

See also krateng/maloja#73