### PR TITLE
Don't remove trailing MV/PV when part of word

### DIFF
--- a/src/core/content/util.js
+++ b/src/core/content/util.js
@@ -587,7 +587,7 @@ const Util = {
 
 		// MV/PV if followed by an opening/closing bracket
 		title = title.replace(/(MV|PV)([「【『』】」])/i, '$2');
-		
+
 		// MV/PV if ending and with whitespace in front
 		title = title.replace(/\s+(MV|PV)$/i, '');
 

--- a/src/core/content/util.js
+++ b/src/core/content/util.js
@@ -585,8 +585,11 @@ const Util = {
 		// 【/(東方/オリジナル*】/)
 		title = title.replace(/[(【]((オリジナル)|(東方)).*?[】)]/, '');
 
-		// MV/PV if not followed by an opening/closing bracket or if ending
-		title = title.replace(/(MV|PV)([「【『』】」]|$)/i, '$2');
+		// MV/PV if followed by an opening/closing bracket
+		title = title.replace(/(MV|PV)([「【『』】」])/i, '$2');
+		
+		// MV/PV if ending and with whitespace in front
+		title = title.replace(/\s+(MV|PV)$/i, '');
 
 		// Try to match one of the regexps
 		for (const regExp of this.ytTitleRegExps) {

--- a/tests/content/util.js
+++ b/tests/content/util.js
@@ -369,9 +369,13 @@ const PROCESS_YT_VIDEO_TITLE_DATA = [{
 	args: ['Artist - Track(MV)'],
 	expected: { artist: 'Artist', track: 'Track' },
 }, {
-	description: 'should remove "MV" string',
-	args: ['Artist - TrackMV'],
+	description: 'should remove trailing " MV" string',
+	args: ['Artist - Track MV'],
 	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should not remove trailing "MV" string',
+	args: ['Artist - TrackMV'],
+	expected: { artist: 'Artist', track: 'TrackMV' },
 }, {
 	description: 'should not remove "MV" in string',
 	args: ['Artist - Omvei'],
@@ -397,9 +401,13 @@ const PROCESS_YT_VIDEO_TITLE_DATA = [{
 	args: ['Artist『TrackMV』'],
 	expected: { artist: 'Artist', track: 'Track' },
 }, {
-	description: 'should remove "PV" string',
-	args: ['Artist - TrackPV'],
+	description: 'should remove trailing " PV" string',
+	args: ['Artist - Track PV'],
 	expected: { artist: 'Artist', track: 'Track' },
+}, {
+	description: 'should not remove trailing "PV" string',
+	args: ['Artist - TrackPV'],
+	expected: { artist: 'Artist', track: 'TrackPV' },
 }, {
 	description: 'should not remove "PV" in string',
 	args: ['Artist - Oppvakt'],


### PR DESCRIPTION
Fixes #2858 while maintaining most of intended functionality