### PR TITLE
#2622 - Connector for Vodafone.fm

### DIFF
--- a/src/connectors/vodafone.fm.js
+++ b/src/connectors/vodafone.fm.js
@@ -1,0 +1,11 @@
+'use strict';
+
+Connector.playerSelector = '.now-playing-info';
+
+Connector.artistSelector = '#artist_name';
+
+Connector.trackSelector = '#song_name';
+
+Connector.playButtonSelector = '#play';
+
+Connector.trackArtSelector = '#cover.src';

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1393,6 +1393,13 @@ const connectors = [{
 	js: 'connectors/smoothfm.js',
 	id: 'smoothfm',
 }, {
+	label: 'Vodafone.fm',
+	matches: [
+		'*://vodafone.fm/*',
+	],
+	js: 'connectors/vodafone.fm.js',
+	id: 'vodafonefm',
+}, {
 	label: 'Relisten.net',
 	matches: [
 		'*://relisten.net/*',


### PR DESCRIPTION
### Describe the changes you made

* Added a connector for the `https://vodafone.fm/` website.

----

### Additional context

* The site is free-to-listen and doesn't require an account to test.
* Closes issue #2622
* Tested using Firefox 88.01
* Settings screenshot: 
![image](https://user-images.githubusercontent.com/1048422/119234003-74a2ae00-bb23-11eb-98c2-b76d9a9ebfd6.png)
* Seems to be working fine: 
![image](https://user-images.githubusercontent.com/1048422/119234069-d105cd80-bb23-11eb-90e0-de21ab31e44e.png)
* Unit tests are passing
```
λ npx grunt test
Running "mochacli:all" (mochacli) task
  1312 passing (1s)
Done.
```

If you have any question, feedback or suggestion, please do not hesitate to say so :)
Thank you