### PR TITLE
#2809 - Connector for JBFM radio

### DIFF
--- a/src/connectors/jb.fm.js
+++ b/src/connectors/jb.fm.js
@@ -1,0 +1,11 @@
+'use strict';
+
+Connector.playerSelector = '.musica-info';
+
+Connector.artistSelector = '#nome-artista';
+
+Connector.trackSelector = '#nome-musica';
+
+Connector.trackArtSelector = '#capa-album';
+
+Connector.isPlaying = () => Util.hasElementClass('#botao-play', 'tocando');

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1435,7 +1435,7 @@ const connectors = [{
 	],
 	js: 'connectors/jb.fm.js',
 	id: 'jbfm',
-} ,{
+}, {
 	label: 'SECTOR Radio',
 	matches: [
 		'*://sectorradio.ru/*',

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1429,6 +1429,13 @@ const connectors = [{
 	js: 'connectors/shuffleone.js',
 	id: 'shuffleone',
 }, {
+	label: 'JB FM',
+	matches: [
+		'*://jb.fm/player/*',
+	],
+	js: 'connectors/jb.fm.js',
+	id: 'jbfm',
+} ,{
 	label: 'SECTOR Radio',
 	matches: [
 		'*://sectorradio.ru/*',


### PR DESCRIPTION
### Describe the changes you made

* Added a connector for the https://jb.fm/player/ website.

----

### Additional context

* The site is free-to-listen and doesn't require an account to test
* Closes issue #2809
* Tested using Firefox 88.01
* Settings screenshot: 
![image](https://user-images.githubusercontent.com/1048422/119243656-a423db80-bb60-11eb-97d1-bc1441f61875.png)
* Seems to be working fine: 
![image](https://user-images.githubusercontent.com/1048422/119243637-85254980-bb60-11eb-90a8-d1c527c22e42.png)
* Unit tests are passing
```
λ npx grunt test
Running "mochacli:all" (mochacli) task
  1312 passing (1s)
Done.
```

If you have any question, feedback or suggestion, please do not hesitate to say so :)
Thank you