### PR TITLE
Select TIDAL albums from the new table structure.

### DIFF
--- a/src/connectors/tidal.js
+++ b/src/connectors/tidal.js
@@ -20,7 +20,7 @@ Connector.getUniqueID = () => {
 
 Connector.artistSelector = `${Connector.playerSelector} span.artist-link`;
 
-Connector.albumSelector = ['#nowPlaying table[class^="infoTable--"] a[href^="/album/"]', `${Connector.playerSelector} a[href^="/album/"]`];
+Connector.albumSelector = ['#nowPlaying div.react-tabs a[href^="/album/"]', `${Connector.playerSelector} a[href^="/album/"]`];
 
 Connector.trackArtSelector = `${Connector.playerSelector} figure[data-test="current-media-imagery"] img`;
 


### PR DESCRIPTION
TIDAL recently switched from using `<table>`s in the credits to a raw-`<div>`-based
solution. This exposes an edge case which I suppose was already there before
this change: If you start by playing a song from an album, then use the Play
Queue feature, the album link will stay in the lower left, resulting in bad
albums on your scrobbles. I can't think of a good way to avoid this and it
seems like a small edge case as-is, but without the credits to fix the data,
it's a bigger problem. And in any case, this brings back the old behavior when
playing from playists etc.
