### PR TITLE
Include field values in tooltips to expose any overflow text

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -408,15 +408,15 @@
         "description": "Placeholder of album artist input"
     },
     "infoViewArtistPage": {
-        "message": "Künstlerseite ansehen",
+        "message": "Künstlerseite ansehen: $1",
         "description": "Placeholder of album input"
     },
     "infoViewAlbumPage": {
-        "message": "Albumseite ansehen",
+        "message": "Albumseite ansehen: $1",
         "description": "Placeholder of album input"
     },
     "infoViewTrackPage": {
-        "message": "Titelseite ansehen",
+        "message": "Titelseite ansehen: $1",
         "description": "Placeholder of album input"
     },
     "pageActionBase": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -490,15 +490,15 @@
     "description": "Placeholder of album artist input"
   },
   "infoViewArtistPage": {
-    "message": "View artist page",
+    "message": "View artist page: $1",
     "description": "Placeholder of album input"
   },
   "infoViewAlbumPage": {
-    "message": "View album page",
+    "message": "View album page: $1",
     "description": "Placeholder of album input"
   },
   "infoViewTrackPage": {
-    "message": "View track page",
+    "message": "View track page: $1",
     "description": "Placeholder of album input"
   },
   "infoYourScrobbles": {

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -472,15 +472,15 @@
         "description": "Placeholder of album artist input"
     },
     "infoViewArtistPage": {
-        "message": "Ver página del artista",
+        "message": "Ver página del artista: $1",
         "description": "Placeholder of album input"
     },
     "infoViewAlbumPage": {
-        "message": "Ver página del álbum",
+        "message": "Ver página del álbum: $1",
         "description": "Placeholder of album input"
     },
     "infoViewTrackPage": {
-        "message": "Ver página de la canción",
+        "message": "Ver página de la canción: $1",
         "description": "Placeholder of album input"
     },
     "infoYourScrobbles": {

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -472,15 +472,15 @@
         "description": "Placeholder of album artist input"
     },
     "infoViewArtistPage": {
-        "message": "Zobacz stronę wykonawcy",
+        "message": "Zobacz stronę wykonawcy: $1",
         "description": "Placeholder of album input"
     },
     "infoViewAlbumPage": {
-        "message": "Zobacz stronę albumu",
+        "message": "Zobacz stronę albumu: $1",
         "description": "Placeholder of album input"
     },
     "infoViewTrackPage": {
-        "message": "Zobacz stronę utworu",
+        "message": "Zobacz stronę utworu: $1",
         "description": "Placeholder of album input"
     },
     "infoYourScrobbles": {

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -448,15 +448,15 @@
         "description": "Placeholder of album artist input"
     },
     "infoViewArtistPage": {
-        "message": "Ver página do artista",
+        "message": "Ver página do artista: $1",
         "description": "Placeholder of album input"
     },
     "infoViewAlbumPage": {
-        "message": "Ver página do álbum",
+        "message": "Ver página do álbum: $1",
         "description": "Placeholder of album input"
     },
     "infoViewTrackPage": {
-        "message": "Ver página da faixa",
+        "message": "Ver página da faixa: $1",
         "description": "Placeholder of album input"
     },
     "infoYourScrobbles": {

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -472,15 +472,15 @@
         "description": "Placeholder of album artist input"
     },
     "infoViewArtistPage": {
-        "message": "Посмотреть страницу исполнителя",
+        "message": "Посмотреть страницу исполнителя: $1",
         "description": "Placeholder of album input"
     },
     "infoViewAlbumPage": {
-        "message": "Посмотреть страницу альбома",
+        "message": "Посмотреть страницу альбома: $1",
         "description": "Placeholder of album input"
     },
     "infoViewTrackPage": {
-        "message": "Посмотреть страницу композиции",
+        "message": "Посмотреть страницу композиции: $1",
         "description": "Placeholder of album input"
     },
     "infoYourScrobbles": {

--- a/src/_locales/sk_SK/messages.json
+++ b/src/_locales/sk_SK/messages.json
@@ -448,15 +448,15 @@
         "description": "Placeholder of album artist input"
     },
     "infoViewArtistPage": {
-        "message": "Otvoriť stránku interpreta",
+        "message": "Otvoriť stránku interpreta: $1",
         "description": "Placeholder of album input"
     },
     "infoViewAlbumPage": {
-        "message": "Otvoriť stránku albumu",
+        "message": "Otvoriť stránku albumu: $1",
         "description": "Placeholder of album input"
     },
     "infoViewTrackPage": {
-        "message": "Otvoriť stránku skladby",
+        "message": "Otvoriť stránku skladby: $1",
         "description": "Placeholder of album input"
     },
     "infoYourScrobbles": {

--- a/src/_locales/zh/messages.json
+++ b/src/_locales/zh/messages.json
@@ -472,15 +472,15 @@
         "description": "Placeholder of album artist input"
     },
     "infoViewArtistPage": {
-        "message": "查看艺术家页面",
+        "message": "查看艺术家页面：$1",
         "description": "Placeholder of album input"
     },
     "infoViewAlbumPage": {
-        "message": "查看专辑页面",
+        "message": "查看专辑页面：$1",
         "description": "Placeholder of album input"
     },
     "infoViewTrackPage": {
-        "message": "查看曲目页面",
+        "message": "查看曲目页面：$1",
         "description": "Placeholder of album input"
     },
     "infoYourScrobbles": {

--- a/src/ui/popups/info.popup.js
+++ b/src/ui/popups/info.popup.js
@@ -56,7 +56,7 @@ class InfoPopup {
 
 			this.view.setFieldValue(field, fieldValue);
 			if (fieldUrl) {
-				this.view.setFieldUrl(field, fieldUrl);
+				this.view.setFieldUrl(field, fieldUrl, fieldValue);
 			} else {
 				this.view.removeFieldUrl(field);
 			}

--- a/src/ui/popups/info.view.js
+++ b/src/ui/popups/info.view.js
@@ -191,12 +191,12 @@ class InfoPopupView {
 		$(selector).val(value);
 	}
 
-	setFieldUrl(field, url) {
+	setFieldUrl(field, url, title) {
 		const selector = InfoPopupView.getFieldSelector(field);
 		const fieldTitleId = fieldTitleMap[field];
 
 		$(selector).attr('href', url);
-		$(selector).attr('title', this.i18n(fieldTitleId));
+		$(selector).attr('title', this.i18n(fieldTitleId, title));
 	}
 
 	removeFieldUrl(field) {


### PR DESCRIPTION
This PR changes info popup field tooltips to include the value of the field, so that you can see the full value of track/artist/album names that are too long to fit in the popup.

Note that this only affects fields with a URL, because otherwise there is no tooltip currently.  It would be nice if a tooltip were shown even if there is no URL, but that isn't addressed in this PR.

Example of a tooltip before this change:

![web-scrobbler-tooltip-before](https://user-images.githubusercontent.com/19522030/119434383-b24b3680-bcdd-11eb-93de-4a45fea2ade4.jpg)

Example of a tooltip after this change:

![web-scrobbler-tooltip-after](https://user-images.githubusercontent.com/19522030/119434384-b24b3680-bcdd-11eb-8a28-88216abd88d6.jpg)
