### PR TITLE
Fix for bug with Youtube artist parsing from chapter

### DIFF
--- a/src/connectors/youtube.js
+++ b/src/connectors/youtube.js
@@ -251,10 +251,10 @@ function getTrackInfoFromChapters() {
 	if (!artistTrack.track) {
 		artistTrack.track = chapterName;
 	}
-	//fix for when Youtube has artist name like '<div class="ytp-chapter-title-content">20..<Artist> - <Song></div>' (notice '..')
-	//which then causes parser to parse artist as '.Artist' instead of just 'Artist'
+	// fix for when Youtube has artist name like '<div class="ytp-chapter-title-content">20..<Artist> - <Song></div>' (notice '..')
+	// which then causes parser to parse artist as '.Artist' instead of just 'Artist'
 	if (artistTrack.artist && (new RegExp('[0-9][\\.]{2}.*')).test(artistTrack.artist)) {
-		artistTrack.artist = artistTrack.artist.replace("..", ".");
+		artistTrack.artist = artistTrack.artist.replace('..', '.');
 	}
 	return artistTrack;
 }

--- a/src/connectors/youtube.js
+++ b/src/connectors/youtube.js
@@ -251,6 +251,11 @@ function getTrackInfoFromChapters() {
 	if (!artistTrack.track) {
 		artistTrack.track = chapterName;
 	}
+	//fix for when Youtube has artist name like '<div class="ytp-chapter-title-content">20..<Artist> - <Song></div>' (notice '..')
+	//which then causes parser to parse artist as '.Artist' instead of just 'Artist'
+	if (artistTrack.artist && (new RegExp('[0-9][\\.]{2}.*')).test(artistTrack.artist)) {
+		artistTrack.artist = artistTrack.artist.replace("..", ".");
+	}
 	return artistTrack;
 }
 


### PR DESCRIPTION
**Describe the changes you made**
Fix for when parsing track artist from Youtube chapter the format in html is `ytp-chapter-title-content">20..<Artist> - <Song></div>` (notice `..`) which then gets artist name parsed as `.Artist` instead of just `Artist`

**Additional context**
Here's an example of the bug https://imgur.com/a/XKbfv7c
Also, it seems it's video related, so it's not for every video, example for which it's bugged: https://www.youtube.com/watch?v=rF2HrVGtTgE
