### PR TITLE
#2910 - Fix Primephonic connector

### DIFF
--- a/src/connectors/primephonic.js
+++ b/src/connectors/primephonic.js
@@ -2,11 +2,11 @@
 
 Connector.playerSelector = '.player';
 
-Connector.trackArtSelector = '.cover .loaded';
+Connector.trackArtSelector = '.player-section .cover .loaded';
 
 Connector.artistSelector = '.composer';
 
-Connector.trackSelector = '.movement-text';
+Connector.trackSelector = '.track-title';
 
 Connector.albumSelector = '.work';
 


### PR DESCRIPTION
**Describe the changes you made**
* Fixed the connector for [Primephonic](https://play.primephonic.com/radio)

**Additional context**
* Tested on Chrome 91.0.4472.106 (Official Build) (64-bit): 
![image](https://user-images.githubusercontent.com/1048422/122679810-3365f280-d1e4-11eb-95fe-90230bd45ba8.png)
* Fixes issue #2910
* As this is a paid radio service, I've used a free trial account for development purposes. In case you'd like to test is as well, it was: fehota3084 at 0ranges.com (the password is the same as the email).
* Unit tests are passing:
```
npx grunt test        
Running "mochacli:all" (mochacli) task
  1316 passing (905ms)
```

If you have any question, feedback or suggestion, please do not hesitate to say so :)
Thank you