### PR TITLE
#2896 - Fix Live365 connector

### DIFF
--- a/src/connectors/live365.js
+++ b/src/connectors/live365.js
@@ -1,17 +1,46 @@
 'use strict';
 
-Connector.playerSelector = '.player';
-Connector.trackArtSelector = '.player-image';
-Connector.trackSelector = '.track-name';
-Connector.artistSelector = '.track-artist';
+Connector.trackArtSelector = "img[alt^='Art for']";
+
+// Due to the way the website is built, I believe we can't really define a selector to access the player directly
+// for this reason, I believe the track art to be the closest we can get to the player
+Connector.playerSelector = Connector.trackArtSelector
+
+Connector.pauseButtonSelector = '.icon--pause-circle';
+
+const artistAlbumSeparator = ' by ';
+
+Connector.getArtistTrack = () => {
+	// "Art for Layla by Derek & The Dominos"
+	const artistAndTrackUnparsed = Util.getAttrFromSelectors(Connector.trackArtSelector, 'alt');
+
+	const artistAndTrackParsed = Util.splitArtistTrack(artistAndTrackUnparsed, [artistAlbumSeparator], { swap: true });
+
+	return artistAndTrackParsed;
+};
+
+const filter = MetadataFilter.createFilter({ track: removeTrackPrefix });
+Connector.applyFilter(filter);
+
+function removeTrackPrefix(track) {
+	return track.replace('Art for ', '');
+}
 
 const LIVE_365_ARTIST = 'Live365';
-const ADWTAG = 'ADWTAG';
+const ADWTAG = 'Advert:';
 const ADBREAK = 'Ad Break';
 
-Connector.isPlaying = () => Util.hasElementClass('.playing-indicator', 'is-playing');
-
 Connector.isScrobblingAllowed = () => {
-	const artist = Connector.getArtist();
-	return artist !== LIVE_365_ARTIST && !artist.includes(ADWTAG) && !artist.includes(ADBREAK);
+	const artist = Connector.getArtistTrack().artist
+	return artist !== null 
+		&& artist !== LIVE_365_ARTIST
+		&& artist !== 'undefined'
+		&& !artist.includes(ADWTAG) 
+		&& !artist.includes(ADBREAK);
 };
+
+// By overriding this method we can work around the limitation of not being able to do a proper selector for the player
+function getObserveTarget() {
+	// By selecting the parent of the track art, we get something very close to the player, which results in an overall better behaviour
+	return document.querySelector(Connector.playerSelector).parentElement;
+}

--- a/src/connectors/live365.js
+++ b/src/connectors/live365.js
@@ -4,7 +4,7 @@ Connector.trackArtSelector = "img[alt^='Art for']";
 
 // Due to the way the website is built, I believe we can't really define a selector to access the player directly
 // for this reason, I believe the track art to be the closest we can get to the player
-Connector.playerSelector = Connector.trackArtSelector
+Connector.playerSelector = Connector.trackArtSelector;
 
 Connector.pauseButtonSelector = '.icon--pause-circle';
 
@@ -31,16 +31,16 @@ const ADWTAG = 'Advert:';
 const ADBREAK = 'Ad Break';
 
 Connector.isScrobblingAllowed = () => {
-	const artist = Connector.getArtistTrack().artist
-	return artist !== null 
+	const artist = Connector.getArtistTrack().artist;
+	return artist !== null
 		&& artist !== LIVE_365_ARTIST
 		&& artist !== 'undefined'
-		&& !artist.includes(ADWTAG) 
+		&& !artist.includes(ADWTAG)
 		&& !artist.includes(ADBREAK);
 };
 
 // By overriding this method we can work around the limitation of not being able to do a proper selector for the player
-function getObserveTarget() {
+Connector.getObserveTarget = () => {
 	// By selecting the parent of the track art, we get something very close to the player, which results in an overall better behaviour
 	return document.querySelector(Connector.playerSelector).parentElement;
-}
+};

--- a/src/core/content/starter.js
+++ b/src/core/content/starter.js
@@ -37,7 +37,7 @@
 
 		Util.debugLog('Setting up observer');
 
-		const observeTarget = document.querySelector(Connector.playerSelector);
+		const observeTarget = retrieveObserveTarget();
 		if (observeTarget !== null) {
 			setupObserver(observeTarget);
 		} else {
@@ -60,7 +60,7 @@
 
 	function setupSecondObserver() {
 		const playerObserver = new MutationObserver(() => {
-			const observeTarget = document.querySelector(Connector.playerSelector);
+			const observeTarget = retrieveObserveTarget();
 			if (observeTarget !== null) {
 				playerObserver.disconnect();
 				setupObserver(observeTarget);
@@ -72,5 +72,9 @@
 			attributes: false, characterData: false,
 		};
 		playerObserver.observe(document, playerObserverConfig);
+	}
+
+	function retrieveObserveTarget() {
+		return document.querySelector(Connector.playerSelector);
 	}
 })();


### PR DESCRIPTION
**Describe the changes you made**
* Created a new function to allow the `observeTarget` default selector behaviour to be overridden
* Fixed the connector for [Live365](https://live365.com), thus resolving the issue #2896

**Additional context**
* The website seems to have adopted a structure that makes our job more difficult. In order to tackle this, I had be a bit creative, and for this reason the whole algorithm may seem a bit _hacky_ 😕
  * This approach was necessary due to this: 
![image](https://user-images.githubusercontent.com/1048422/122685878-1fcb8380-d206-11eb-9155-4ffa4b9d7f41.png)
![image](https://user-images.githubusercontent.com/1048422/122685893-31149000-d206-11eb-9f2e-84ca76d16475.png)
  * You see, these `jss` classes are randomly generated 😕
  * So the only reliable selector that I managed to use was `img[alt^='Art for']` which proved to be useful to retrieve the artist, song title and track art.
* Tested on Chrome 91.0.4472.106 (Official Build) (64-bit): 
![image](https://user-images.githubusercontent.com/1048422/122683953-7b900f80-d1fa-11eb-9385-7beeecd9ee3f.png)
* Should also work properly if you're streaming straight from the main page: 
![image](https://user-images.githubusercontent.com/1048422/122688249-1a286a80-d213-11eb-8f47-9bb34c340afa.png)
* Required a UK VPN to test

If you have any question, feedback or suggestion, please do not hesitate to say so :)
Thank you
