### PR TITLE
#2808 - Connector for horizonte.cl

### DIFF
--- a/src/connectors/horizonte.cl.js
+++ b/src/connectors/horizonte.cl.js
@@ -1,0 +1,15 @@
+'use strict';
+
+Connector.playerSelector = '.np__details';
+
+Connector.artistSelector = 'p[class="line__clamp_2"]';
+
+Connector.trackSelector = 'h1[class="line__clamp_2"]';
+
+Connector.playButtonSelector = '.fa-play';
+
+Connector.trackArtSelector = '.np__thumbnail img';
+
+Connector.currentTimeSelector = '.np__thumbnail .current_time:first-child';
+
+Connector.durationSelector = '.np__thumbnail .current_time:last-child';

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1846,6 +1846,13 @@ const connectors = [{
 	],
 	js: 'connectors/kkbox-legacy.js',
 	id: 'kkbox-legacy',
+}, {
+	label: 'Radio Horizonte',
+	matches: [
+		'*://*horizonte.cl/*',
+	],
+	js: 'connectors/horizonte.cl.js',
+	id: 'horizontecl',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
**Describe the changes you made**
* Added a connector for [Radio Horizonte](https://www.horizonte.cl)

**Additional context**
* Resolves issue #2808
* The site is free-to-listen and doesn't require an account to test
* Tested on Chrome 91.0.4472.106 (Official Build) (64-bit): 
  * ![image](https://user-images.githubusercontent.com/1048422/122691006-dcccd880-d224-11eb-8e7a-f661bd2da293.png)
  *  settings: 
![image](https://user-images.githubusercontent.com/1048422/122691036-f79f4d00-d224-11eb-8bfa-270183c04486.png)

If you have any question, feedback or suggestion, please do not hesitate to say so :)
Thank you