### PR TITLE
Prefer YouTube video IDs on YouTube Music

### DIFF
--- a/src/connectors/youtube-music.js
+++ b/src/connectors/youtube-music.js
@@ -98,6 +98,14 @@ Connector.isPlaying = () => {
 	return Util.getAttrFromSelectors(playButtonSelector, 'd') === playingPath;
 };
 
+Connector.getUniqueID = () => {
+	const videoUrl = Util.getAttrFromSelectors('.yt-uix-sessionlink', 'href');
+
+	if (videoUrl) {
+		return Util.getYtVideoIdFromUrl(videoUrl);
+	}
+};
+
 Connector.isScrobblingAllowed = () => !Util.isElementVisible(adSelector);
 
 function getArtists() {


### PR DESCRIPTION
**Describe the changes you made**

Prefers using video IDs instead of track metadata on YouTube music, as some videos (incorrectly) have the same metadata, which makes it impossible to locally store the correct metadata instead.

**Additional context**

As far as I'm aware this is not a breaking change, as the saved edits model also looks up saved information using metadata from the page if it can't be found right away, however I was unsure whether this should also include a check with all four base fields Song has, meaning I've left the file untouched for now.
https://github.com/web-scrobbler/web-scrobbler/blob/f5007fe38e1472b7f2074454761f8ccbe26a9cf9/src/core/background/storage/saved-edits.model.js#L23-L32
