### PR TITLE
Use track URIs as unique IDs for spotify songs

### DIFF
--- a/src/connectors/spotify.js
+++ b/src/connectors/spotify.js
@@ -35,6 +35,8 @@ Connector.isScrobblingAllowed = () => isMusicPlaying() && isMainTab();
 
 Connector.isPodcast = () => isPodcastPlaying();
 
+Connector.getUniqueID = () => getTrackUri();
+
 function isMusicPlaying() {
 	return artistUrlIncludes('/artist/', '/show/') || isLocalFilePlaying();
 }
@@ -83,4 +85,19 @@ function hasMultipleSources() {
 function getActiveDeviceName() {
 	const spotifyConnectEl = document.querySelector(spotifyConnectSelector);
 	return spotifyConnectEl && spotifyConnectEl.textContent;
+}
+
+function getTrackUri() {
+	const contextLinkEl = document.querySelector('[data-testid="context-link"]');
+	if (!contextLinkEl || !contextLinkEl.href) {
+		return null;
+	}
+
+	const url = new URL(contextLinkEl);
+	const trackUri = url.searchParams.get('uri');
+	if (trackUri && trackUri.startsWith('spotify:track:')) {
+		return trackUri;
+	}
+
+	return null;
 }


### PR DESCRIPTION
**Describe the changes you made**
Spotify Track URIs (which are already guaranteed to be unique) will now be used as the unique ID for songs being played on Spotify.

**Additional context**
This should not be a breaking change, as the saved edits model will fall back to hashing the track data, which is what it's already doing for Spotify.