### PR TITLE
Update detection of "various artists" albums in bandcamp connector

### DIFF
--- a/src/connectors/bandcamp.js
+++ b/src/connectors/bandcamp.js
@@ -227,11 +227,22 @@ function isArtistVarious(artist, track) {
 	 */
 	if (isAlbumPage()) {
 		const trackNodes = document.querySelectorAll('.track_list .track-title');
+		const artists = [];
 		for (const trackNode of trackNodes) {
 			const trackName = trackNode.textContent;
 			if (!Util.findSeparator(trackName, SEPARATORS)) {
 				return false;
 			}
+			const { artist } = Util.splitArtistTrack(trackName, SEPARATORS);
+			artists.push(artist);
+		}
+		/*
+		 * Return false if every detected artist on the album has a very short name.
+		 * It is probably not artist names but disc sides or some kind of numbers.
+		 * Example: https://teenagemenopause.bandcamp.com/album/viens-mourir
+		 */
+		if (artists.every((artist) => artist.length <= 2)) {
+			return false;
 		}
 
 		return true;


### PR DESCRIPTION
Hi! 👋 

The bandcamp connector currently has false positives when deciding if an album is from various artists.

Examples (these are wrongly detected as "various artists albums" because of how the tracks are named):

https://teenagemenopause.bandcamp.com/album/viens-mourir
https://standard-in-fi.bandcamp.com/album/quattro

In this change I introduced a new rule: if every detected artist of an album has a name shorter than 3 characters, then we decide that those are not artist names.

This should cover the majority of current false positives with extremely few false negatives (if every artist in an album has a name shorter than 3 characters, it wont count as "various artists")