### PR TITLE
Initial support for Online Radio Box

### DIFF
--- a/src/connectors/onlineradiobox.js
+++ b/src/connectors/onlineradiobox.js
@@ -1,0 +1,9 @@
+'use strict';
+
+// Need to select also .station to cover popup where #top_player_track is 
+// outside of .player.
+Connector.playerSelector = ['.player', 'body > .station'];
+
+Connector.artistTrackSelector = '#top_player_track';
+
+Connector.playButtonSelector = '.player .b-play';

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -282,6 +282,13 @@ const connectors = [{
 	js: 'connectors/odnoklassniki.js',
 	id: 'odnoklassniki',
 }, {
+	label: 'Online Radio Box',
+	matches: [
+		'*://onlineradiobox.com/*',
+	],
+	js: 'connectors/onlineradiobox.js',
+	id: 'onlineradiobox',
+}, {
 	label: '163 Music',
 	matches: [
 		'*://music.163.com/*',


### PR DESCRIPTION
**Describe the changes you made**
This adds minimal support for Online Radio Box which is internet radio player similar to InTune. Connector supports both inline (on same page) and popup play modes.

**Additional context**
This is my first PR here, I only tested this against couple of stations I listen to.

Resolves: #2936

Signed-off-by: Ondrej Balaz <blami@blami.net>