### PR TITLE
Fix horizonte.cl connector

### DIFF
--- a/src/connectors/horizonte.cl.js
+++ b/src/connectors/horizonte.cl.js
@@ -6,7 +6,7 @@ Connector.artistSelector = 'p[class="line__clamp_2"]';
 
 Connector.trackSelector = 'h1[class="line__clamp_2"]';
 
-Connector.playButtonSelector = '.fa-play';
+Connector.playButtonSelector = '.button_control .fa-play';
 
 Connector.trackArtSelector = '.np__thumbnail img';
 


### PR DESCRIPTION
There are multiple elements with `.fa-play` class on the page.
To correctly detect the play button status is necessary to add a class 
to make it a unique combination.

Resolves: #2942