### PR TITLE
Specify min-width on popup

### DIFF
--- a/src/ui/popups/info.css
+++ b/src/ui/popups/info.css
@@ -32,6 +32,7 @@ input {
 	display: grid;
 	grid-template-columns: 136px 224px;
 	min-height: 136px;
+	min-width: 360px;
 }
 
 .popup-container {


### PR DESCRIPTION
Seems to be caused by some change to how chrome handles extension popups.
Simply specified min-width as the width in my properly functioning browsers.
Other browsers, including other chromium browsers, seem to be unaffected.
Fixes #2983
Closes #2992 
Closes #2993 
Closes #2994 
Closes #2996 
Closes #3005 
It's a bit janky, but seems to function the same as it used to, without breaking anything else in chrome or other browsers.
Maybe a cleaner fix can be implemented later, but this seems pretty urgent.

edit: hopefully properly linking issues