### PR TITLE
Add Radio Rock&Pop Chile connector

### DIFF
--- a/src/connectors/rockandpop.cl.js
+++ b/src/connectors/rockandpop.cl.js
@@ -1,0 +1,15 @@
+'use strict';
+
+Connector.playerSelector = '#player';
+
+Connector.artistSelector = '#top_player_TopPlayer_spanInfo3';
+
+Connector.trackSelector = '#top_player_TopPlayer_spanInfo2';
+
+Connector.playButtonSelector = '.mm_player_btn_play .fa .fa-play';
+
+Connector.trackArtSelector = '.mm_media-left img';
+
+Connector.currentTimeSelector = '.mm_current-time';
+
+Connector.durationSelector = '.mm_total-time';

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1851,6 +1851,13 @@ const connectors = [{
 	],
 	js: 'connectors/horizonte.cl.js',
 	id: 'horizontecl',
+}, {
+	label: 'Radio Rock&Pop Chile',
+	matches: [
+		'*://envivo.rockandpop.cl/*',
+	],
+	js: 'connectors/rockandpop.cl.js',
+	id: 'rockandpopcl',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
I added the connector for Rock & Pop Radio Chile.
Also added its entry in connectors.js

R&P is located at 94.1 MHz on the FM dial in Santiago, Chile.