### PR TITLE
Fix scrobbling on Spotify by updating css selector for artist

### DIFF
--- a/src/connectors/spotify.js
+++ b/src/connectors/spotify.js
@@ -2,7 +2,7 @@
 
 const playerBar = '.Root__now-playing-bar';
 
-const artistSelector = `${playerBar} [dir="auto"]:last-child a`;
+const artistSelector = `${playerBar} [data-testid="context-item-info-artist"]`;
 const spotifyConnectSelector = `${playerBar} [aria-live="polite"]`;
 
 Connector.useMediaSessionApi();


### PR DESCRIPTION
Spotify changed its website, which causes the web scrobbler to stop working on Spotify, this fixes #3019, #3020 and #3021.
I changed the CSS selector for artists and tested the build locally, where it seemed to be sufficient to get web scrobbler working again on spotify.