### PR TITLE
Improve behavior with IMEs

### DIFF
--- a/src/ui/popups/info.view.js
+++ b/src/ui/popups/info.view.js
@@ -218,8 +218,8 @@ class InfoPopupView {
 			});
 		}
 
-		$(inputGenericId).off('keyup');
-		$(inputGenericId).on('keyup', (e) => {
+		$(inputGenericId).off('keydown');
+		$(inputGenericId).on('keydown', (e) => {
 			const isSubmitAction = e.which === 13;
 
 			if (isSubmitAction) {


### PR DESCRIPTION
Many IMEs, used for input of languages with multiple options for characters for same romanization (cjk languages, for instance), typically have you hit enter to confirm your selection of characters.
This triggers the keyup event and causes web scrobbler to confirm the edit, when the user may not be intending to do so yet.
This PR switches to the keydown event, which is not triggered by the enter press to confirm character selection.