### PR TITLE
Fix tunein connector

### DIFF
--- a/src/connectors/tunein.js
+++ b/src/connectors/tunein.js
@@ -9,9 +9,9 @@ const STATIONS_SWAP = [
 	'Cat-Country-987', '885-FM-So-Cal',
 ];
 
-const playerBar = '[class^=player-module__playerContainer___2izJC]';
+const playerBar = '[class^=player-module__playerContainer]';
 const artistTrackSelector = '#playerTitle';
-const stationNameSelector = '[class^=nowPlaying-module__link___2wDL2]';
+const stationNameSelector = '[class^=nowPlaying-module__link]';
 
 Connector.playerSelector = playerBar;
 


### PR DESCRIPTION
some  class names changed

**Describe the changes you made**
TuneIn renamed 2 of the class names used to detect the containers in which the artist - title is found. Adjuestet those to the new ones.

**Additional context**
Add any other context or screenshots here.
