### PR TITLE
Update thecurrent.org connector for new redesign

### DIFF
--- a/src/connectors/thecurrent.js
+++ b/src/connectors/thecurrent.js
@@ -15,10 +15,10 @@ Connector.applyFilter(filter);
 
 function cleanupTrack(track) {
 	// Extract a track title from a `Track by Artist` string.
-	return track.replace(/^(.*?)\s(by)\s(.*?)$/s, '$1');
+	return track.replace(/^(.*?)\s(by)\s(.*?)$/, '$1');
 }
 
 function cleanupArtist(artist) {
 	// Extract the artist from a `Track by Artist` string.
-	return artist.replace(/^(.*?)\s(by)\s(.*?)$/s, '$3');
+	return artist.replace(/^(.*?)\s(by)\s(.*?)$/, '$3');
 }


### PR DESCRIPTION
**Describe the changes you made**
thecurrent.org just pushed a new website redesign that broke the existing connector. I believe I was able to get this connector working again with these changes. It seems they no longer have the album title available as data that can be pulled, so I've removed the album info functionality. 

**Additional context**
I can't recall if the additional streaming channels on the site worked before, but they seem to work pretty seamlessly for me with this connector update.
![image](https://user-images.githubusercontent.com/2962327/138716473-e6a679b0-cf12-4614-8812-fcd92f74b03a.png)



