### PR TITLE
Fix scrobbling on Spotify by updating css selector for pauseButton

### DIFF
--- a/src/connectors/spotify.js
+++ b/src/connectors/spotify.js
@@ -27,7 +27,7 @@ Connector.currentTimeSelector = `${playerBar} [data-testid=playback-position]`;
 
 Connector.durationSelector = `${playerBar} [data-testid=playback-duration]`;
 
-Connector.pauseButtonSelector = `${playerBar} [data-testid=control-button-pause]`;
+Connector.pauseButtonSelector = `${playerBar} [data-testid=control-button-playpause] [fill=none]`;
 
 Connector.applyFilter(MetadataFilter.getSpotifyFilter());
 


### PR DESCRIPTION
Spotify changed its play/pause button which caused the web scrobbler to stop on Spotify. This fixes #3033.

The problem was, it is now a combined play/pause button that only changes in the language dependent aria-label property. So it is difficult to distinguish between play and pause button. I now select the path from the pause button to distinguish them, so we can still get the isPlaying state.