### PR TITLE
Connector for WYEP

### DIFF
--- a/src/connectors/wyep.js
+++ b/src/connectors/wyep.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const player = '.wyep-player';
+
+Connector.playerSelector = player;
+
+Connector.trackSelector = `${player} .wyep-player__title`;
+
+Connector.pauseButtonSelector = `${player}.is-playing`;
+
+Connector.getTrackInfo = () => {
+	const artistAlbum = Util.getTextFromSelectors(`${player} .wyep-player__description`);
+	return Util.splitArtistAlbum(artistAlbum, ['·']);
+};

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1858,6 +1858,13 @@ const connectors = [{
 	],
 	js: 'connectors/rockandpop.cl.js',
 	id: 'rockandpopcl',
+}, {
+	label: 'WYEP',
+	matches: [
+		'*://wyep.org/*',
+	],
+	js: 'connectors/wyep.js',
+	id: 'wyep',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
Added a connector for WYEP, a Pittsburgh-based FM radio station.

Tested on Firefox 93.0 on Debian, scrobbling against ListenBrainz. The console indicates sensible scrobbles in the case of genuine tracks:
```
Web Scrobbler: {
  "track": "The River",
  "artist": "Bruce Springsteen",
  "album": "The River",
  "albumArtist": null,
  "uniqueID": null,
  "duration": null,
  "currentTime": null,
  "isPlaying": true,
  "trackArt": null,
  "isPodcast": false,
  "originUrl": "https://wyep.org/about/mission-vision-history/"
}
```
Sometimes the player lists the current program title. In these cases, no artist/album are displayed, resulting in the scrobble:
```
Web Scrobbler: {
  "track": "The Evening Mix",
  "artist": null,
  "album": null,
  "albumArtist": null,
  "uniqueID": null,
  "duration": null,
  "currentTime": null,
  "isPlaying": true,
  "trackArt": null,
  "isPodcast": false,
  "originUrl": "https://wyep.org/"
}
```
These should be discarded, but it looks like ListenBrainz already does this for us (it requires artist to be defined).