### PR TITLE
Naxos Music Library connector

### DIFF
--- a/src/connectors/naxosmusiclibrary.js
+++ b/src/connectors/naxosmusiclibrary.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const playerBar = '#music';
+
+function getCatalogID() {
+	return Util.getTextFromSelectors(`${playerBar} .u-album`);
+}
+
+Connector.useMediaSessionApi();
+
+Connector.playerSelector = '.u-control.u-process';
+
+Connector.artistSelector = `${playerBar} .u-artist`;
+
+Connector.trackSelector = `${playerBar} .u-music-title`;
+
+Connector.getAlbum = () => {
+	const catalogID = getCatalogID();
+	const albumHeader = Util.queryElements(`.eps._playAlbum[data-catalogueid="${catalogID}"]`);
+	if (albumHeader.length > 0) {
+		return albumHeader[0].textContent;
+	}
+	return null;
+};
+
+Connector.currentTimeSelector = `${playerBar} .u-control.u-surplusTime`;
+
+Connector.durationSelector = `${playerBar} .u-control .u-time`;
+
+Connector.playButtonSelector = `${playerBar} .u-play-btn.ctrl-play.paused`;
+
+Connector.trackArtSelector = `${playerBar} .u-cover img`;
+
+Connector.getUniqueID = () => {
+	const catalogID = getCatalogID();
+	// Remark: NML starts counting track numbers from 0
+	const trackNum = Util.getAttrFromSelectors(`${playerBar} span.u-album`, 'data-tracknum');
+	return `${catalogID}+${trackNum}`;
+};

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1872,6 +1872,13 @@ const connectors = [{
 	],
 	js: 'connectors/zeno.js',
 	id: 'zeno',
+}, {
+	label: 'Naxos Music Library',
+	matches: [
+		'*://*.naxosmusiclibrary.com/*',
+	],
+	js: 'connectors/naxosmusiclibrary.js',
+	id: 'naxosmusiclibrary',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
**Describe the changes you made**

Add a connector for Naxos Music Library. Tested and seems to be working:

```
Web Scrobbler: {
  "track": "Glinka: Zhizn' za tsarya (A Life for the Tsar), Op. 4: Act I: Cavatina and Rondo: Akh, ti, polye, polye ti moyo (Ah, you, my field) (Antonida)",
  "artist": "Orchestre National du Bolchoi, L'; Barannikov, A.",
  "album": "GLINKA, M.I.: Zhizn' za tsarya (A Life for the Tsar) [Opera] (Barannikov)",
  "albumArtist": null,
  "uniqueID": "3700403528770+2",
  "duration": null,
  "currentTime": null,
  "isPlaying": false,
  "trackArt": "https://cdn.naxos.com/SharedFiles/images/cds/others/3700403528770.gif",
  "isPodcast": false,
  "originUrl": "https://cmu-naxosmusiclibrary-com.cmu.idm.oclc.org/catalogue/item.asp?cid=3700403528770"
}
```