### PR TITLE
Add Klassik Radio connector

### DIFF
--- a/src/connectors/horizonte.cl.js
+++ b/src/connectors/horizonte.cl.js
@@ -9,3 +9,7 @@ Connector.trackSelector = 'h1[class="line__clamp_2"]';
 Connector.playButtonSelector = '.button_control .fa-play';
 
 Connector.trackArtSelector = '.np__thumbnail img';
+
+Connector.currentTimeSelector = '.np__thumbnail .current_time:first-child';
+
+Connector.durationSelector = '.np__thumbnail .current_time:last-child';


### PR DESCRIPTION
Klassik Radio is a radio station in Germany. It specialises in classical 
music, Film music and Lounge music. The channel is receivable in over 
300 German cities via FM, throughout Germany via cable, and in Europe 
via satellite. It is also worldwide streamed on the internet.