### PR TITLE
Add short name selector as default for Tidal.

### DIFF
--- a/src/connectors/tidal.js
+++ b/src/connectors/tidal.js
@@ -8,7 +8,7 @@ Connector.pauseButtonSelector = `${Connector.playerSelector} button[data-test="p
 
 Connector.isScrobblingAllowed = () => !!$(Connector.playButtonSelector);
 
-Connector.trackSelector = `${Connector.playerSelector} div[data-test="footer-track-title"]`;
+Connector.trackSelector = ['#nowPlaying .react-tabs__tab-panel--selected > div > div:nth-child(1) > div:nth-child(1) > span:nth-child(2)', `${Connector.playerSelector} div[data-test="footer-track-title"]`];
 
 Connector.getUniqueID = () => {
 	const trackUrl = $(`${Connector.trackSelector} a`).attr('href');

--- a/src/connectors/tidal.js
+++ b/src/connectors/tidal.js
@@ -8,7 +8,7 @@ Connector.pauseButtonSelector = `${Connector.playerSelector} button[data-test="p
 
 Connector.isScrobblingAllowed = () => !!$(Connector.playButtonSelector);
 
-Connector.trackSelector = ['#nowPlaying .react-tabs__tab-panel--selected > div > div:nth-child(1) > div:nth-child(1) > span:nth-child(2)', `${Connector.playerSelector} div[data-test="footer-track-title"]`];
+Connector.trackSelector = ['#nowPlaying div.react-tabs__tab-panel--selected > div > div:nth-child(1) > div:nth-child(1) > span:nth-child(2)', `${Connector.playerSelector} div[data-test="footer-track-title"]`];
 
 Connector.getUniqueID = () => {
 	const trackUrl = $(`${Connector.trackSelector} a`).attr('href');


### PR DESCRIPTION
In #2789, the track selector was simplified to reflect Tidal's redesign. Now the variance in track names is back (long in the footer, short in the table). Instead of adding the option back, preserve the current behavior as far as possible. That is, use the title in the table if the correct tab is open, falling back to the footer. Annoyingly, the tab state is inconsistent between songs with lyrics and those without. The details tab is either `react-tabs-5` or `react-tabs-7`. That's the reason for the `#nowPlaying .react-tabs__tab-panel--selected` hack.
