### PR TITLE
Update plex.js - necessary as selector for Pause Button had changed

### DIFF
--- a/src/connectors/plex.js
+++ b/src/connectors/plex.js
@@ -25,7 +25,7 @@ Connector.trackArtSelector = [
 // @endif
 
 Connector.pauseButtonSelector = [
-	`${Connector.playerSelector} [data-qa-id="pauseButton"]`,
+	`${Connector.playerSelector} [data-testid="pauseButton"]`,
 	`${Connector.playerSelector} [class^=plex-icon-player-pause]`,
 ];
 


### PR DESCRIPTION
**Describe the changes you made**
Very small change to selector for the pause button

**Additional context**
Plex connector has not been working for a while now - this appears to fix it. Tested on both Firefox and Chrome
