### PR TITLE
Yandex.music: map array of artists to comma-separated string

### DIFF
--- a/src/connectors/yandex-music-dom-inject.js
+++ b/src/connectors/yandex-music-dom-inject.js
@@ -32,7 +32,7 @@ function getTrackInfo() {
 	return {
 		track, album, trackArt,
 
-		artist: trackInfo.artists[0].title,
+		artist: trackInfo.artists.map((artist) => artist.title).join(', '),
 		duration: trackInfo.duration,
 		currentTime: YandexAPI.getProgress().position,
 		uniqueID: trackInfo.link,


### PR DESCRIPTION
With this change when the track lists a set of artists it'll map it to a string of `artist-a, artist-b, artist-c`

Here are examples:
* last.fm: [My Woman by Lew Stone, The Monseigneur Band, Nat Gonella & Al Bowlly](https://www.last.fm/music/Lew+Stone,+The+Monseigneur+Band,+Nat+Gonella+&+Al+Bowlly/_/My+Woman)
* libre.fm: [My Woman by Lew Stone, The Monseigneur Band, Nat Gonella & Al Bowlly](https://libre.fm/artist/Lew+Stone%2C+The+Monseigneur+Band%2C+Nat+Gonella+%2526+Al+Bowlly/track/My+Woman)

