### PR TITLE
Fix time before scrobbling issue on horizonte.cl

### DIFF
--- a/src/connectors/horizonte.cl.js
+++ b/src/connectors/horizonte.cl.js
@@ -9,7 +9,3 @@ Connector.trackSelector = 'h1[class="line__clamp_2"]';
 Connector.playButtonSelector = '.button_control .fa-play';
 
 Connector.trackArtSelector = '.np__thumbnail img';
-
-Connector.currentTimeSelector = '.np__thumbnail .current_time:first-child';
-
-Connector.durationSelector = '.np__thumbnail .current_time:last-child';


### PR DESCRIPTION
It is better to delete the parameters `.currentTimeSelector` and
`.durationSelector`. The radio reports the duration of the show and not
the duration of the song (e.g. a show lasts 1 or 2 hours, 3600 or 7200
seconds), so all songs will be sent at 240 seconds, the default maximum
time. This affects songs that are less than 4 minutes long (many cases).