### PR TITLE
Beetle connector

### DIFF
--- a/src/connectors/beetle.js
+++ b/src/connectors/beetle.js
@@ -1,0 +1,23 @@
+'use strict';
+
+Connector.playerSelector = '#player';
+
+Connector.trackSelector = '.current .title a';
+
+Connector.artistSelector = '.current .artist a';
+
+Connector.getAlbum = () => Util.getAttrFromSelectors('.current .album a', 'title');
+
+Connector.trackArtSelector = '.current .album img';
+
+Connector.playButtonSelector = '.control .play';
+
+Connector.isPlaying = () => {
+	return Util.getTextFromSelectors('.control .play title') === 'pause';
+}
+
+Connector.getUniqueID = () => {
+  return Util.getAttrFromSelectors('.current .title a', 'href');
+}
+
+Connector.durationSelector = '.current .duration';

--- a/src/connectors/beetle.js
+++ b/src/connectors/beetle.js
@@ -13,11 +13,11 @@ Connector.trackArtSelector = '.current .album img';
 Connector.playButtonSelector = '.control .play';
 
 Connector.isPlaying = () => {
-	return Util.getTextFromSelectors('.control .play title') === 'pause';
-}
+  return Util.getTextFromSelectors('.control .play title') === 'pause';
+};
 
 Connector.getUniqueID = () => {
   return Util.getAttrFromSelectors('.current .title a', 'href');
-}
+};
 
 Connector.durationSelector = '.current .duration';

--- a/src/connectors/beetle.js
+++ b/src/connectors/beetle.js
@@ -13,11 +13,11 @@ Connector.trackArtSelector = '.current .album img';
 Connector.playButtonSelector = '.control .play';
 
 Connector.isPlaying = () => {
-  return Util.getTextFromSelectors('.control .play title') === 'pause';
+	return Util.getTextFromSelectors('.control .play title') === 'pause';
 };
 
 Connector.getUniqueID = () => {
-  return Util.getAttrFromSelectors('.current .title a', 'href');
+	return Util.getAttrFromSelectors('.current .title a', 'href');
 };
 
 Connector.durationSelector = '.current .duration';

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1879,6 +1879,10 @@ const connectors = [{
 	],
 	js: 'connectors/klassikradio.de.js',
 	id: 'klassikradio',
+}, {
+	label: 'Beetle',
+	js: 'connectors/beetle.js',
+	id: 'beetle',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
[Beetle](https://gitlab.com/maxburon/beetle) a web interface for the music manager [beets](https://github.com/beetbox/beets). 
The following changes introduces a connector for Beetle. Beetle has no default instance, so it is the reason why there is no given `matches`.