### PR TITLE
Filter out record side names from Bandcamp

### DIFF
--- a/src/connectors/bandcamp.js
+++ b/src/connectors/bandcamp.js
@@ -65,11 +65,15 @@ function initGenericProperties() {
 
 	Connector.getArtistTrack = () => {
 		const artist = Util.getTextFromSelectors(Connector.artistSelector);
-		const track = parseTrackTitle(Util.getTextFromSelectors(Connector.trackSelector));
+		let track = Util.getTextFromSelectors(Connector.trackSelector);
 
 		if (isArtistVarious(artist, track)) {
 			return Util.splitArtistTrack(track, SEPARATORS);
 		}
+		if (trackContainsRecordSide()) {
+			track = Util.removeRecordSide(track);
+		}
+
 		return { artist, track };
 	};
 
@@ -258,18 +262,24 @@ function isArtistVarious(artist, track) {
 	return false;
 }
 
-function getPageType() {
-	return Util.getAttrFromSelectors('meta[property="og:type"]', 'content');
-}
-
-function parseTrackTitle(trackTitle) {
+function trackContainsRecordSide() {
 	const RECORD_SIDE_REGEX = /^[A-Z][1-9]\.? /;
-	let title = trackTitle;
-	if (title.substring(0, 3).match(RECORD_SIDE_REGEX) || title.substring(0, 4).match(RECORD_SIDE_REGEX)) {
-		title = trackTitle.replace(RECORD_SIDE_REGEX, '');
+	const trackNodes = document.querySelectorAll('.track_list .track-title');
+	let numTracksWithRecordSide = 0;
+
+	for (const trackNode of trackNodes) {
+		const trackName = trackNode.textContent;
+		if (trackName.substring(0, 3).match(RECORD_SIDE_REGEX) || trackName.substring(0, 4).match(RECORD_SIDE_REGEX)) {
+			numTracksWithRecordSide++;
+		}
 	}
 
-	return title;
+	// return true if all tracks on the album page contain a record side
+	return numTracksWithRecordSide === trackNodes.length;
+}
+
+function getPageType() {
+	return Util.getAttrFromSelectors('meta[property="og:type"]', 'content');
 }
 
 function initEventListeners() {

--- a/src/connectors/bandcamp.js
+++ b/src/connectors/bandcamp.js
@@ -263,13 +263,12 @@ function isArtistVarious(artist, track) {
 }
 
 function trackContainsRecordSide() {
-	const RECORD_SIDE_REGEX = /^[A-Z][1-9]\.? /;
 	const trackNodes = document.querySelectorAll('.track_list .track-title');
 	let numTracksWithRecordSide = 0;
 
 	for (const trackNode of trackNodes) {
 		const trackName = trackNode.textContent;
-		if (trackName.substring(0, 3).match(RECORD_SIDE_REGEX) || trackName.substring(0, 4).match(RECORD_SIDE_REGEX)) {
+		if (trackName.substring(0, 3).match(Util.RECORD_SIDE_REGEX) || trackName.substring(0, 4).match(Util.RECORD_SIDE_REGEX)) {
 			numTracksWithRecordSide++;
 		}
 	}

--- a/src/connectors/bandcamp.js
+++ b/src/connectors/bandcamp.js
@@ -65,7 +65,7 @@ function initGenericProperties() {
 
 	Connector.getArtistTrack = () => {
 		const artist = Util.getTextFromSelectors(Connector.artistSelector);
-		const track = Util.getTextFromSelectors(Connector.trackSelector);
+		const track = parseTrackTitle(Util.getTextFromSelectors(Connector.trackSelector));
 
 		if (isArtistVarious(artist, track)) {
 			return Util.splitArtistTrack(track, SEPARATORS);
@@ -260,6 +260,16 @@ function isArtistVarious(artist, track) {
 
 function getPageType() {
 	return Util.getAttrFromSelectors('meta[property="og:type"]', 'content');
+}
+
+function parseTrackTitle(trackTitle) {
+	const RECORD_SIDE_REGEX = /^[A-Z][1-9]\.? /;
+	let title = trackTitle;
+	if (title.substring(0, 3).match(RECORD_SIDE_REGEX) || title.substring(0, 4).match(RECORD_SIDE_REGEX)) {
+		title = trackTitle.replace(RECORD_SIDE_REGEX, '');
+	}
+
+	return title;
 }
 
 function initEventListeners() {

--- a/src/core/content/util.js
+++ b/src/core/content/util.js
@@ -111,13 +111,21 @@ const Util = {
 	},
 
 	/**
+	 * Regular Expression to detect record side in track title
+	 * @type { RegExp }
+	 */
+	RECORD_SIDE_REGEX: /^[A-Z][1-9]\.? /,
+
+	/**
 	 * Remove record side from track title.
 	 * @param {String} str String contains track title
 	 * @return {String} String contains track title without record side
 	 */
 	removeRecordSide(str) {
-		const RECORD_SIDE_REGEX = /^[A-Z][1-9]\.? /;
-		return str.replace(RECORD_SIDE_REGEX, '');
+		if (str !== null) {
+			return str.replace(Util.RECORD_SIDE_REGEX, '');
+		}
+		return null;
 	},
 
 	/**

--- a/src/core/content/util.js
+++ b/src/core/content/util.js
@@ -111,6 +111,16 @@ const Util = {
 	},
 
 	/**
+	 * Remove record side from track title.
+	 * @param {String} str String contains track title
+	 * @return {String} String contains track title without record side
+	 */
+	removeRecordSide(str) {
+		const RECORD_SIDE_REGEX = /^[A-Z][1-9]\.? /;
+		return str.replace(RECORD_SIDE_REGEX, '');
+	},
+
+	/**
 	 * Split string to artist and album.
 	 * @param  {String} str String contains artist and track
 	 * @param  {Array} [separators] Array of separators

--- a/tests/content/util.js
+++ b/tests/content/util.js
@@ -85,6 +85,36 @@ const SPLIT_ARTIST_ALBUM_DATA = [{
 }];
 
 /**
+ * Test data for testing 'Util.removeRecordSide' function.
+ * @type {Array}
+ */
+const REMOVE_RECORD_SIDE_DATA = [{
+	description: 'should not modify string without record side',
+	args: ['track'],
+	expected: 'track',
+}, {
+	description: 'should return null for null input',
+	args: [null],
+	expected: null,
+}, {
+	description: 'should return empty result for empty input',
+	args: [''],
+	expected: '',
+}, {
+	description: 'should return string without record side',
+	args: ['A1. track'],
+	expected: 'track',
+}, {
+	description: 'should not modify string with invalid record side',
+	args: ['Z0. track'],
+	expected: 'Z0. track',
+}, {
+	description: 'should not modify string that is "record side-like" ',
+	args: ['V0.1D track'],
+	expected: 'V0.1D track',
+}];
+
+/**
  * Test data for testing 'Util.escapeBadTimeValues' function.
  * @type {Array}
  */
@@ -797,6 +827,9 @@ const testData = [{
 }, {
 	func: Util.splitArtistTrack,
 	data: SPLIT_ARTIST_TRACK_DATA,
+}, {
+	func: Util.removeRecordSide,
+	data: REMOVE_RECORD_SIDE_DATA,
 }, {
 	func: Util.splitArtistAlbum,
 	data: SPLIT_ARTIST_ALBUM_DATA,


### PR DESCRIPTION
**Describe the changes you made**
Checks for a record side prefix in the track title on the album page of the Bandcamp connector. If the prefix exists, it's filtered out of the track title string. This allows for more accurate scrobbles of Bandcamp tracks

**Additional context**
Closes #3093 
