### PR TITLE
Fix Spotify's pause button selector.

### DIFF
--- a/src/connectors/spotify.js
+++ b/src/connectors/spotify.js
@@ -27,7 +27,7 @@ Connector.currentTimeSelector = `${playerBar} [data-testid=playback-position]`;
 
 Connector.durationSelector = `${playerBar} [data-testid=playback-duration]`;
 
-Connector.pauseButtonSelector = `${playerBar} [data-testid=control-button-playpause] [fill=none]`;
+Connector.pauseButtonSelector = `${playerBar} [data-testid=control-button-playpause] > svg > path[d="M2.7 1a.7.7 0 00-.7.7v12.6a.7.7 0 00.7.7h2.6a.7.7 0 00.7-.7V1.7a.7.7 0 00-.7-.7H2.7zm8 0a.7.7 0 00-.7.7v12.6a.7.7 0 00.7.7h2.6a.7.7 0 00.7-.7V1.7a.7.7 0 00-.7-.7h-2.6z"]`;
 
 Connector.applyFilter(MetadataFilter.getSpotifyFilter());
 

--- a/src/connectors/spotify.js
+++ b/src/connectors/spotify.js
@@ -3,6 +3,7 @@
 const playerBar = '.Root__now-playing-bar';
 
 const artistSelector = `${playerBar} [data-testid="context-item-info-artist"]`;
+const playingPath = 'M2.7 1a.7.7 0 00-.7.7v12.6a.7.7 0 00.7.7h2.6a.7.7 0 00.7-.7V1.7a.7.7 0 00-.7-.7H2.7zm8 0a.7.7 0 00-.7.7v12.6a.7.7 0 00.7.7h2.6a.7.7 0 00.7-.7V1.7a.7.7 0 00-.7-.7h-2.6z';
 const spotifyConnectSelector = `${playerBar} [aria-live="polite"]`;
 
 Connector.useMediaSessionApi();
@@ -27,7 +28,7 @@ Connector.currentTimeSelector = `${playerBar} [data-testid=playback-position]`;
 
 Connector.durationSelector = `${playerBar} [data-testid=playback-duration]`;
 
-Connector.pauseButtonSelector = `${playerBar} [data-testid=control-button-playpause] > svg > path[d="M2.7 1a.7.7 0 00-.7.7v12.6a.7.7 0 00.7.7h2.6a.7.7 0 00.7-.7V1.7a.7.7 0 00-.7-.7H2.7zm8 0a.7.7 0 00-.7.7v12.6a.7.7 0 00.7.7h2.6a.7.7 0 00.7-.7V1.7a.7.7 0 00-.7-.7h-2.6z"]`;
+Connector.pauseButtonSelector = `${playerBar} [data-testid=control-button-playpause] > svg > path[d="${playingPath}"]`;
 
 Connector.applyFilter(MetadataFilter.getSpotifyFilter());
 


### PR DESCRIPTION
Fixes #3105.

In #3035, the selector was changed to reflect a change in Spotify's UI which
combined the play and pause buttons. As far as I can tell, the SVG under that
button now varies only with regard to its `path`, so the `fill` selector no
longer works. The
shuffle.one (https://github.com/web-scrobbler/web-scrobbler/blob/db9bf606b52483bb13f16dc684e58f479f3373a3/src/connectors/shuffleone.js#L12)
and YouTube
Music (https://github.com/web-scrobbler/web-scrobbler/blob/db9bf606b52483bb13f16dc684e58f479f3373a3/src/connectors/youtube-music.js#L54)
connectors embed SVG paths, but end up using them in a custom `isPlaying`
implementation. Here, we embed the path to maintain the static
`pauseButtonSelector`.