### PR TITLE
Add support for La Radio du bord de l'eau

### DIFF
--- a/src/connectors/auborddeleau.radio.js
+++ b/src/connectors/auborddeleau.radio.js
@@ -13,19 +13,19 @@ function isHomePlayer() {
 }
 
 function setupHomePlayer() {
-    Connector.playerSelector = '.hero-player';
-    Connector.artistSelector = '.rk_widget_currenttrack_table>tbody:nth-child(1)>tr:nth-child(1)>td:nth-child(3)';
-    Connector.trackSelector = '.rk_widget_recenttracks_title';
-    Connector.trackArtSelector = '.rk_widget_currenttrack_table img';
-    Connector.isPlaying = () => Util.hasElementClass('.ci-soundplayer', 'playing');
+	Connector.playerSelector = '.hero-player';
+	Connector.artistSelector = '.rk_widget_currenttrack_table>tbody:nth-child(1)>tr:nth-child(1)>td:nth-child(3)';
+	Connector.trackSelector = '.rk_widget_recenttracks_title';
+	Connector.trackArtSelector = '.rk_widget_currenttrack_table img';
+	Connector.isPlaying = () => Util.hasElementClass('.ci-soundplayer', 'playing');
 }
 
 function setupOnAirPlayer() {
-    Connector.playerSelector = '#player';
-    Connector.artistSelector = '#artiste';
-    Connector.trackSelector = '#titre';
-    Connector.trackArtSelector = '#pochette img';
-    Connector.isPlaying = () => $('#btnStop').css('display') === 'inline-block';
+	Connector.playerSelector = '#player';
+	Connector.artistSelector = '#artiste';
+	Connector.trackSelector = '#titre';
+	Connector.trackArtSelector = '#pochette img';
+	Connector.isPlaying = () => $('#btnStop').css('display') === 'inline-block';
 }
 
 setupConnector();

--- a/src/connectors/auborddeleau.radio.js
+++ b/src/connectors/auborddeleau.radio.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 function setupConnector() {
 	if (isHomePlayer()) {
 		setupHomePlayer();

--- a/src/connectors/auborddeleau.radio.js
+++ b/src/connectors/auborddeleau.radio.js
@@ -1,0 +1,11 @@
+'use strict';
+
+Connector.playerSelector = '.hero-player';
+
+Connector.artistSelector = '.rk_widget_currenttrack_table > tbody:nth-child(1) > tr:nth-child(1) > td:nth-child(3)';
+
+Connector.trackSelector = '.rk_widget_recenttracks_title';
+
+Connector.trackArtSelector = '.rk_widget_currenttrack_table img';
+
+Connector.isPlaying = () => Util.hasElementClass('.ci-soundplayer', 'playing');

--- a/src/connectors/auborddeleau.radio.js
+++ b/src/connectors/auborddeleau.radio.js
@@ -1,11 +1,31 @@
 'use strict';
 
-Connector.playerSelector = '.hero-player';
+function setupConnector() {
+	if (isHomePlayer()) {
+		setupHomePlayer();
+	} else {
+		setupOnAirPlayer();
+	}
+}
 
-Connector.artistSelector = '.rk_widget_currenttrack_table > tbody:nth-child(1) > tr:nth-child(1) > td:nth-child(3)';
+function isHomePlayer() {
+	return $('body').hasClass('home');
+}
 
-Connector.trackSelector = '.rk_widget_recenttracks_title';
+function setupHomePlayer() {
+    Connector.playerSelector = '.hero-player';
+    Connector.artistSelector = '.rk_widget_currenttrack_table>tbody:nth-child(1)>tr:nth-child(1)>td:nth-child(3)';
+    Connector.trackSelector = '.rk_widget_recenttracks_title';
+    Connector.trackArtSelector = '.rk_widget_currenttrack_table img';
+    Connector.isPlaying = () => Util.hasElementClass('.ci-soundplayer', 'playing');
+}
 
-Connector.trackArtSelector = '.rk_widget_currenttrack_table img';
+function setupOnAirPlayer() {
+    Connector.playerSelector = '#player';
+    Connector.artistSelector = '#artiste';
+    Connector.trackSelector = '#titre';
+    Connector.trackArtSelector = '#pochette img';
+    Connector.isPlaying = () => $('#btnStop').css('display') === 'inline-block';
+}
 
-Connector.isPlaying = () => Util.hasElementClass('.ci-soundplayer', 'playing');
+setupConnector();

--- a/src/connectors/auborddeleau.radio.js
+++ b/src/connectors/auborddeleau.radio.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 function setupConnector() {
 	if (isHomePlayer()) {
 		setupHomePlayer();

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1895,6 +1895,13 @@ const connectors = [{
 	matches: ['*://listen.refnet.fm/*'],
 	js: 'connectors/refnet.js',
 	id: 'refnet',
+}, {
+	label: "La Radio du bord de l'eau",
+	matches: [
+		'*://*auborddeleau.radio/*',
+	],
+	js: 'connectors/auborddeleau.radio.js',
+	id: 'auborddeleau.radio',
 }];
 
 define(() => connectors);

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1902,6 +1902,7 @@ const connectors = [{
 	],
 	js: 'connectors/auborddeleau.radio.js',
 	id: 'auborddeleau.radio',
+	allFrames: true,
 }];
 
 define(() => connectors);


### PR DESCRIPTION
**Describe the changes you made**
Adds support for auborddeleau.radio ~~(main/home page only)~~ for both the player on the main page and the one on the "on air" page. Both players support cover/artwork.

**Additional context**
1. Had to use double quote symbol (") instead of single quote (') to get the label right; I hope that's ok.
2. ~~The "OnAir" page player seems to be using an iframe, and I have not gotten it to work yet.~~