### PR TITLE
Fix (fa) icons

### DIFF
--- a/src/ui/popups/info.css
+++ b/src/ui/popups/info.css
@@ -88,7 +88,7 @@ input {
 	border: none;
 	color: #495053;
 	cursor: pointer;
-	font-family: 'Font Awesome 5 Free', serif;
+	font-family: 'Font Awesome 6 Free', serif;
 	font-size: 1.1rem;
 	outline: none;
 	padding: 0;
@@ -177,7 +177,7 @@ input {
 
 .counter::before {
 	content: '\f202';
-	font-family: 'Font Awesome 5 Brands', serif;
+	font-family: 'Font Awesome 6 Brands', serif;
 }
 
 /**


### PR DESCRIPTION
**Describe the changes you made**
The icons using Font Awesome in the UI were broken following the recent upgrade to FA v6.0.0; the CSS was still using "Font Awesome 5" instead of 6. This PR fixes the two mentions of the font in info.css and fixes the icons not displaying properly.

**Additional context**
Fixes #3133 
