### PR TITLE
Replace jQuery.ready (deprecated)

### DIFF
--- a/src/ui/.eslintrc.yml
+++ b/src/ui/.eslintrc.yml
@@ -1,2 +1,3 @@
 globals:
   $: readonly
+  jQuery: readonly

--- a/src/ui/options/index.js
+++ b/src/ui/options/index.js
@@ -58,7 +58,7 @@ require([
 		$('a#privacy-url').attr('href', privacyPolicyUrl);
 	}
 
-	$(document).ready(() => {
+	jQuery(() => {
 		initialize();
 	});
 });

--- a/src/ui/popups/info.js
+++ b/src/ui/popups/info.js
@@ -82,7 +82,7 @@ require([
 		return browser.runtime.sendMessage({ type, data });
 	}
 
-	$(document).ready(() => {
+	jQuery(() => {
 		main();
 	});
 });


### PR DESCRIPTION
Current version is 3.6.0, `ready` was deprecated in v3

Replaced as per https://api.jquery.com/ready/ but using the `jQuery` keyword instead of `$` to make it obvious where it's coming from.
