### PR TITLE
open.fm-connector: remove year from album name (issue #3060)

### DIFF
--- a/src/connectors/openfm.js
+++ b/src/connectors/openfm.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const openfmFilter = MetadataFilter.createFilter({
+	album: removeYearFromAlbum,
+});
+
 Connector.playerSelector = '#openfm-player';
 
 Connector.artistSelector = '#station-view .station-details > h3';
@@ -9,3 +13,9 @@ Connector.trackSelector = '#station-view .station-details > h2';
 Connector.albumSelector = '#station-view .station-details > h4';
 
 Connector.pauseButtonSelector = '.controls-con > .stop-btn';
+
+Connector.applyFilter(openfmFilter);
+
+function removeYearFromAlbum(text) {
+	return text.replace(/ \[\d*\]$/, '');
+}


### PR DESCRIPTION
**Describe the changes you made**
open.fm provides the release year within every album name. This change adds an album filter to the corresponding connector, which removes the trailing year.

**Additional context**
The bug was reported with issue #3060.
