### PR TITLE
Qobuz - select only album as album

### DIFF
--- a/src/connectors/qobuz.js
+++ b/src/connectors/qobuz.js
@@ -7,7 +7,7 @@ Connector.playerSelector = '.player';
 
 Connector.trackSelector = '.player__track-title';
 
-Connector.albumSelector = '.player__track-album';
+Connector.albumSelector = '.player__track-album > a:nth-of-type(2)';
 
 Connector.trackArtSelector = '.player__track-cover img';
 


### PR DESCRIPTION
**Describe the changes you made**
Qobuz seems to have made a change that results in a DOM that includes multiple textual components inside of the `.player__track-album` element. The key components are all included as `a` tags, and the second `a` tag is always the album (with the first being the artist, and the optional third being the playlist if present).

This commit makes a change to always select the second `a` tag within `.player__track-album` to ensure only the album is selected (till further changes are made on the Qobuz end).

**Additional context**
Resolves web-scrobbler/web-scrobbler#3095
