### PR TITLE
Update Apple Music domain matcher

### DIFF
--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1241,7 +1241,7 @@ const connectors = [{
 }, {
 	label: 'Apple Music',
 	matches: [
-		'*://music.apple.com/*',
+		'*://*music.apple.com/*',
 	],
 	js: 'connectors/apple-music.js',
 	id: 'apple-music',

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1241,7 +1241,7 @@ const connectors = [{
 }, {
 	label: 'Apple Music',
 	matches: [
-		'*://*.music.apple.com/*',
+		'*://music.apple.com/*',
 	],
 	js: 'connectors/apple-music.js',
 	id: 'apple-music',


### PR DESCRIPTION

Apple music used to live only on https://beta.music.apple.com. It can now also be accessed on https://music.apple.com. With the old matcher, `*://*.music.apple.com/*`, using Apple music at https://music.apple.com would fail to match because of the missing `.`.

This PR removes that `.` such that both `beta.music.apple.com` and `music.apple.com` matches.

