### PR TITLE
Add connector for hoopladigital.com

### DIFF
--- a/src/connectors/hoopladigital.js
+++ b/src/connectors/hoopladigital.js
@@ -5,16 +5,16 @@ Connector.playerSelector = '.duration-1000';
 Connector.trackSelector = '.text-current > h2';
 
 Connector.getTrackInfo = () => {
-    const artistAlbumText = Util.getTextFromSelectors('.text-current > p');
+	const artistAlbumText = Util.getTextFromSelectors('.text-current > p');
 
-    const lastSeparator = artistAlbumText.lastIndexOf(' - ');
+	const lastSeparator = artistAlbumText.lastIndexOf(' - ');
 
-    const artistAlbumInfo = {
-        album: artistAlbumText.slice(0, lastSeparator),
-        artist: artistAlbumText.slice(lastSeparator + 3)
-    };
+	const artistAlbumInfo = {
+		album: artistAlbumText.slice(0, lastSeparator),
+		artist: artistAlbumText.slice(lastSeparator + 3),
+	};
 
-    return artistAlbumInfo;
+	return artistAlbumInfo;
 };
 
 Connector.trackArtSelector = '.duration-1000 .max-w-112 > img';

--- a/src/connectors/hoopladigital.js
+++ b/src/connectors/hoopladigital.js
@@ -5,8 +5,16 @@ Connector.playerSelector = '.duration-1000';
 Connector.trackSelector = '.text-current > h2';
 
 Connector.getTrackInfo = () => {
-    const artistAlbum = Util.getTextFromSelectors('.text-current > p');
-    return Util.splitArtistAlbum(artistAlbum, [' - '], { swap: true });
+    const artistAlbumText = Util.getTextFromSelectors('.text-current > p');
+
+    const lastSeparator = artistAlbumText.lastIndexOf(' - ');
+
+    const artistAlbumInfo = {
+        artist: artistAlbumText.slice(lastSeparator + 3),
+        track: artistAlbumText.slice(0, lastSeparator)
+    };
+
+    return artistAlbumInfo;
 };
 
 Connector.trackArtSelector = '.duration-1000 .max-w-112 > img';

--- a/src/connectors/hoopladigital.js
+++ b/src/connectors/hoopladigital.js
@@ -10,8 +10,8 @@ Connector.getTrackInfo = () => {
     const lastSeparator = artistAlbumText.lastIndexOf(' - ');
 
     const artistAlbumInfo = {
-        artist: artistAlbumText.slice(lastSeparator + 3),
-        track: artistAlbumText.slice(0, lastSeparator)
+        album: artistAlbumText.slice(0, lastSeparator),
+        artist: artistAlbumText.slice(lastSeparator + 3)
     };
 
     return artistAlbumInfo;

--- a/src/connectors/hoopladigital.js
+++ b/src/connectors/hoopladigital.js
@@ -6,7 +6,7 @@ Connector.trackSelector = '.text-current > h2';
 
 Connector.getTrackInfo = () => {
     const artistAlbum = Util.getTextFromSelectors('.text-current > p');
-    return Util.splitArtistAlbum(artistAlbum, ['-'], { swap: true });
+    return Util.splitArtistAlbum(artistAlbum, [' - '], { swap: true });
 };
 
 Connector.trackArtSelector = '.duration-1000 .max-w-112 > img';

--- a/src/connectors/hoopladigital.js
+++ b/src/connectors/hoopladigital.js
@@ -1,0 +1,16 @@
+'use strict';
+
+Connector.playerSelector = '.duration-1000';
+
+Connector.trackSelector = '.text-current > h2';
+
+Connector.getTrackInfo = () => {
+    const artistAlbum = Util.getTextFromSelectors('.text-current > p');
+    return Util.splitArtistAlbum(artistAlbum, ['-'], { swap: true });
+};
+
+Connector.trackArtSelector = '.duration-1000 .max-w-112 > img';
+
+Connector.playButtonSelector = '.duration-1000 button[aria-label=Play]';
+
+Connector.durationSelector = '.duration-1000 .rounded-md.border-gray-400 button > span > span:nth-of-type(3) > span';

--- a/src/connectors/hoopladigital.js
+++ b/src/connectors/hoopladigital.js
@@ -7,11 +7,11 @@ Connector.trackSelector = '.text-current > h2';
 Connector.getTrackInfo = () => {
 	const artistAlbumText = Util.getTextFromSelectors('.text-current > p');
 
-	const lastSeparator = artistAlbumText.lastIndexOf(' - ');
+	const lastSeparatorIndex = artistAlbumText.lastIndexOf(' - ');
 
 	const artistAlbumInfo = {
-		album: artistAlbumText.slice(0, lastSeparator),
-		artist: artistAlbumText.slice(lastSeparator + 3),
+		album: artistAlbumText.slice(0, lastSeparatorIndex),
+		artist: artistAlbumText.slice(lastSeparatorIndex + 3),
 	};
 
 	return artistAlbumInfo;

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -690,6 +690,13 @@ const connectors = [{
 	js: 'connectors/freegalmusic.js',
 	id: 'freegalmusic',
 }, {
+	label: 'hoopla',
+	matches: [
+		'*://www.hoopladigital.com/*',
+	],
+	js: 'connectors/hoopladigital.js',
+	id: 'hoopladigital',
+}, {
 	label: 'Monstercat',
 	matches: [
 		'*://www.monstercat.com/*',


### PR DESCRIPTION
New connector for hoopla, a service provided by local libraries to "borrow" and stream audio. Tested with my personal account and scrobbles are successful. Screenshot below.

<img width="1252" alt="hooplascrobble" src="https://user-images.githubusercontent.com/6808988/161842090-9c10567a-f339-4066-a27a-2f6eeeabcb51.png">

Additional edit made to account for dash separator appearing in album title. Also tested with my personal account. Screenshot below.

<img width="1222" alt="hooplascrobbledash" src="https://user-images.githubusercontent.com/6808988/161896708-0c63b197-9a49-4866-9254-f9c1ac9c3aa1.png">

Resolves request in issue #1636