### PR TITLE
Organize option labels and titles, fix indentation

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -52,7 +52,7 @@
         "description": "Option title"
     },
     "optionYtDesc": {
-        "message": "Wenn du beide Optionen deaktivierst, wird die Erweiterung YouTubevideos aus allen Kategorien scrobblen.",
+        "message": "Wenn du beide Optionen deaktivierst, wird die Erweiterung YouTube videos aus allen Kategorien scrobblen.",
         "description": "Description of YouTube options"
     },
     "optionYtMusicOnly": {

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -33,15 +33,27 @@
     },
     "optionScrobblePodcasts": {
         "message": "Scrobble podcasts",
-        "description": "Option title"
+        "description": "Option label"
     },
     "optionScrobblePodcastsTitle": {
         "message": "Scrobble podcast episodes",
-        "description": "Option label"
+        "description": "Option title"
+    },
+    "optionsHidden": {
+        "message": "Versteckt",
+        "description": "'Hidden' section"
+    },
+    "optionScrobblePercent": {
+        "message": "Scrobble bei",
+        "description": "Option title"
+    },
+    "optionScrobblePercentSuffix": {
+        "message": "der Songlänge",
+        "description": "Option title"
     },
     "optionYtDesc": {
-        "message": "Wenn du beide Optionen deaktivierst, wird die Erweiterung Youtubevideos aus allen Kategorien scrobblen.",
-        "description": "Description of Youtube options"
+        "message": "Wenn du beide Optionen deaktivierst, wird die Erweiterung YouTubevideos aus allen Kategorien scrobblen.",
+        "description": "Description of YouTube options"
     },
     "optionYtMusicOnly": {
         "message": "Videos aus der Kategorie \"Musik\" scrobblen",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,611 +1,611 @@
 {
-  "extDescription": {
-    "message": "Scrobble music all around the web!",
-    "description": "Description of the extension"
-  },
+    "extDescription": {
+        "message": "Scrobble music all around the web!",
+        "description": "Description of the extension"
+    },
 
-  "optionsTitle": {
-    "message": "Web Scrobbler options",
-    "description": "Title of options page"
-  },
-  "optionsGeneral": {
-    "message": "General",
-    "description": "'General' section"
-  },
-  "optionUseNotifications": {
-    "message": "Use now playing notifications",
-    "description": "Option label"
-  },
-  "optionUseNotificationsTitle": {
-    "message": "Show now playing notifications for all supported websites",
-    "description": "Option title"
-  },
-  "optionUnrecognizedNotifications": {
-    "message": "Notify if track is not recognized",
-    "description": "Option label"
-  },
-  "optionUnrecognizedNotificationsTitle": {
-    "message": "Show notification if track is not recognized by the extension",
-    "description": "Option title"
-  },
-  "optionForceRecognize": {
-    "message": "Force track recognition",
-    "description": "Option label"
-  },
-  "optionForceRecognizeTitle": {
-    "message": "Force recognition of unknown tracks",
-    "description": "Option title"
-  },
-  "optionScrobblePodcasts" : {
-    "message": "Scrobble podcasts",
-    "description": "Option title"
-  },
-  "optionsHidden": {
-    "message": "Hidden",
-    "description": "'Hidden' section"
-  },
-  "optionScrobblePercent" : {
-    "message": "Scrobble at",
-    "description": "Option title"
-  },
-  "optionScrobblePercentSuffix" : {
-    "message": "of song duration",
-    "description": "Option title"
-  },
-  "optionScrobblePodcastsTitle" : {
-    "message": "Scrobble podcast episodes",
-    "description": "Option label"
-  },
-  "optionYtDesc": {
-    "message": "If you turn off both options, the extension will scrobble Youtube videos from all categories.",
-    "description": "Description of Youtube options"
-  },
-  "optionPercentDesc": {
-    "message": "Note that a track will be scrobbled anyway, if it has been played for 4 minutes, regardless of the option value.",
-    "description": "Description of scrobble percent option"
-  },
-  "optionYtMusicOnly": {
-    "message": "Scrobble videos from \"Music\" category",
-    "description": "Option title"
-  },
-  "optionYtMusicOnlyTitle": {
-    "message": "Ignore videos that are not in Music category",
-    "description": "Option label"
-  },
-  "optionYtEntertainmentOnly": {
-    "message": "Scrobble videos from \"Entertainment\" category",
-    "description": "Option label"
-  },
-  "optionYtEntertainmentOnlyTitle": {
-    "message": "Ignore videos that are not in Entertainment category",
-    "description": "Option title"
-  },
+    "optionsTitle": {
+        "message": "Web Scrobbler options",
+        "description": "Title of options page"
+    },
+    "optionsGeneral": {
+        "message": "General",
+        "description": "'General' section"
+    },
+    "optionUseNotifications": {
+        "message": "Use now playing notifications",
+        "description": "Option label"
+    },
+    "optionUseNotificationsTitle": {
+        "message": "Show now playing notifications for all supported websites",
+        "description": "Option title"
+    },
+    "optionUnrecognizedNotifications": {
+        "message": "Notify if track is not recognized",
+        "description": "Option label"
+    },
+    "optionUnrecognizedNotificationsTitle": {
+        "message": "Show notification if track is not recognized by the extension",
+        "description": "Option title"
+    },
+    "optionForceRecognize": {
+        "message": "Force track recognition",
+        "description": "Option label"
+    },
+    "optionForceRecognizeTitle": {
+        "message": "Force recognition of unknown tracks",
+        "description": "Option title"
+    },
+    "optionScrobblePodcasts": {
+        "message": "Scrobble podcasts",
+        "description": "Option label"
+    },
+    "optionScrobblePodcastsTitle": {
+        "message": "Scrobble podcast episodes",
+        "description": "Option title"
+    },
+    "optionsHidden": {
+        "message": "Hidden",
+        "description": "'Hidden' section"
+    },
+    "optionScrobblePercent": {
+        "message": "Scrobble at",
+        "description": "Option title"
+    },
+    "optionScrobblePercentSuffix": {
+        "message": "of song duration",
+        "description": "Option title"
+    },
+    "optionYtDesc": {
+        "message": "If you turn off both options, the extension will scrobble YouTube videos from all categories.",
+        "description": "Description of YouTube options"
+    },
+    "optionPercentDesc": {
+        "message": "Note that a track will be scrobbled anyway, if it has been played for 4 minutes, regardless of the option value.",
+        "description": "Description of scrobble percent option"
+    },
+    "optionYtMusicOnly": {
+        "message": "Scrobble videos from \"Music\" category",
+        "description": "Option title"
+    },
+    "optionYtMusicOnlyTitle": {
+        "message": "Ignore videos that are not in Music category",
+        "description": "Option label"
+    },
+    "optionYtEntertainmentOnly": {
+        "message": "Scrobble videos from \"Entertainment\" category",
+        "description": "Option label"
+    },
+    "optionYtEntertainmentOnlyTitle": {
+        "message": "Ignore videos that are not in Entertainment category",
+        "description": "Option title"
+    },
 
-  "optionsAccounts": {
-    "message": "Accounts",
-    "description": "'Accounts' section"
-  },
-  "accountsSignedInAs": {
-    "message": "You are signed in as $1.",
-    "description": "'Signed in' label"
-  },
-  "accountsNotSignedIn": {
-    "message": "You are not signed in.",
-    "description": "'Signed in' label"
-  },
-  "accountsProfile": {
-    "message": "Profile",
-    "description": "'Signed in' label"
-  },
-  "accountsSignOut": {
-    "message": "Sign out",
-    "description": "Button label"
-  },
-  "accountsSignIn": {
-    "message": "Sign in",
-    "description": "Button label"
-  },
-  "accountsScrobblerProps": {
-    "message": "Properties",
-    "description": "Button label"
-  },
-  "accountsScrobblerPropsTitle": {
-    "message": "$1 properties",
-    "description": "Button label"
-  },
-  "accountsUserApiUrl": {
-    "message": "API URL",
-    "description": "Input label"
-  },
-  "accountsUserApiUrlPlaceholder": {
-    "message": "Custom API URL",
-    "description": "Input label"
-  },
-  "accountsUserToken": {
-    "message": "Token",
-    "description": "Input label"
-  },
-  "accountsUserTokenPlaceholder": {
-    "message": "Custom token",
-    "description": "Input label"
-  },
+    "optionsAccounts": {
+        "message": "Accounts",
+        "description": "'Accounts' section"
+    },
+    "accountsSignedInAs": {
+        "message": "You are signed in as $1.",
+        "description": "'Signed in' label"
+    },
+    "accountsNotSignedIn": {
+        "message": "You are not signed in.",
+        "description": "'Signed in' label"
+    },
+    "accountsProfile": {
+        "message": "Profile",
+        "description": "'Signed in' label"
+    },
+    "accountsSignOut": {
+        "message": "Sign out",
+        "description": "Button label"
+    },
+    "accountsSignIn": {
+        "message": "Sign in",
+        "description": "Button label"
+    },
+    "accountsScrobblerProps": {
+        "message": "Properties",
+        "description": "Button label"
+    },
+    "accountsScrobblerPropsTitle": {
+        "message": "$1 properties",
+        "description": "Button label"
+    },
+    "accountsUserApiUrl": {
+        "message": "API URL",
+        "description": "Input label"
+    },
+    "accountsUserApiUrlPlaceholder": {
+        "message": "Custom API URL",
+        "description": "Input label"
+    },
+    "accountsUserToken": {
+        "message": "Token",
+        "description": "Input label"
+    },
+    "accountsUserTokenPlaceholder": {
+        "message": "Custom token",
+        "description": "Input label"
+    },
 
-  "optionsOptions": {
-    "message": "Options",
-    "description": "'Options' section"
-  },
-  "optionsEditedTracks": {
-    "message": "Edited tracks",
-    "description": "'Edited tracks' header"
-  },
-  "optionsEditedTracksDesc": {
-    "message": "This extension stores edited tracks.",
-    "description": "Description of edited tracks"
-  },
-  "optionsEditedTracksPopupTitle": {
-    "message": "$1 edited tracks",
-    "description": "'Edited tracks' header"
-  },
-  "optionsViewEdited": {
-    "message": "View",
-    "description": "Button to view edited tracks"
-  },
-  "optionsExportEdited": {
-    "message": "Export",
-    "description": "Button to export edited tracks"
-  },
-  "optionsImportEdited": {
-    "message": "Import",
-    "description": "Button to import edited tracks"
-  },
-  "optionsEnableDisableHint": {
-    "message": "Click on the checkbox to enable/disable connectors.",
-    "description": "Enable/disable hint"
-  },
-  "optionsCustomPatternsHint": {
-    "message": "Click on the gear icon to configure custom URL patterns for connectors.",
-    "description": "Description of how to configure custom URL patterns"
-  },
-  "optionsSupportedWebsites": {
-    "message": "Supported websites",
-    "description": "'Supported websites' header"
-  },
-  "optionsToggle": {
-    "message": "Toggle",
-    "description": "Label of toggle button"
-  },
+    "optionsOptions": {
+        "message": "Options",
+        "description": "'Options' section"
+    },
+    "optionsEditedTracks": {
+        "message": "Edited tracks",
+        "description": "'Edited tracks' header"
+    },
+    "optionsEditedTracksDesc": {
+        "message": "This extension stores edited tracks.",
+        "description": "Description of edited tracks"
+    },
+    "optionsEditedTracksPopupTitle": {
+        "message": "$1 edited tracks",
+        "description": "'Edited tracks' header"
+    },
+    "optionsViewEdited": {
+        "message": "View",
+        "description": "Button to view edited tracks"
+    },
+    "optionsExportEdited": {
+        "message": "Export",
+        "description": "Button to export edited tracks"
+    },
+    "optionsImportEdited": {
+        "message": "Import",
+        "description": "Button to import edited tracks"
+    },
+    "optionsEnableDisableHint": {
+        "message": "Click on the checkbox to enable/disable connectors.",
+        "description": "Enable/disable hint"
+    },
+    "optionsCustomPatternsHint": {
+        "message": "Click on the gear icon to configure custom URL patterns for connectors.",
+        "description": "Description of how to configure custom URL patterns"
+    },
+    "optionsSupportedWebsites": {
+        "message": "Supported websites",
+        "description": "'Supported websites' header"
+    },
+    "optionsToggle": {
+        "message": "Toggle",
+        "description": "Label of toggle button"
+    },
 
-  "learnMoreLabel": {
-    "message": "Learn more",
-    "description": "Learn more label"
-  },
+    "learnMoreLabel": {
+        "message": "Learn more",
+        "description": "Learn more label"
+    },
 
-  "contactTitle": {
-    "message": "Contact",
-    "description": "'Contact' section"
-  },
-  "contactGitHubDesc": {
-    "message": "Report an issue and contribute",
-    "description": "Description for GitHub section"
-  },
-  "contactTwitterDesc": {
-    "message": "Keep up with the updates and for quick chat",
-    "description": "Description for Twitter section"
-  },
-  "contactPrivacyPolicyDesc": {
-    "message": "View the privacy policy",
-    "description": "Description for privacy section"
-  },
+    "contactTitle": {
+        "message": "Contact",
+        "description": "'Contact' section"
+    },
+    "contactGitHubDesc": {
+        "message": "Report an issue and contribute",
+        "description": "Description for GitHub section"
+    },
+    "contactTwitterDesc": {
+        "message": "Keep up with the updates and for quick chat",
+        "description": "Description for Twitter section"
+    },
+    "contactPrivacyPolicyDesc": {
+        "message": "View the privacy policy",
+        "description": "Description for privacy section"
+    },
 
-  "faqTitle": {
-    "message": "FAQ",
-    "description": "'FAQ' section"
-  },
-  "faqQuestion1": {
-    "message": "How can I start using the extension?",
-    "description": "Question #1"
-  },
-  "faqAnswer1a": {
-    "message": "You should click on a notification that is shown when the extension is loaded the first time. Then, you should grant access to your accounts.",
-    "description": "Answer #1"
-  },
-  "faqAnswer1b": {
-    "message": "Note: In some cases, the notification won't be shown, e.g. on Mac OS if Chrome is running in full-screen mode; the extension will open a tab where you can grant access to your accounts.",
-    "description": "Answer #1"
-  },
-  "faqQuestion2": {
-    "message": "How do I temporarily disable scrobbling?",
-    "description": "Question #2"
-  },
-  "faqAnswer2a": {
-    "message": "You can do that by right-clicking on the green extension icon in the extension bar. Using the context menu you can disable the connector for the current web service.",
-    "description": "Answer #2"
-  },
-  "faqAnswer2b": {
-    "message": "Use the checkboxes on the options page to disable certain connectors, or the \"Toggle\" checkbox to disable scrobbling globally.",
-    "description": "Answer #2"
-  },
-  "faqQuestion3": {
-    "message": "The track was not recognized! Can you fix it?",
-    "description": "Question #3"
-  },
-  "faqAnswer3a": {
-    "message": "When a track cannot be recognized, a gray icon with question mark appears in the extension bar. You can click on this icon and input correct data in the opened popup window.",
-    "description": "Answer #3"
-  },
-  "faqAnswer3b": {
-    "message": "Also, there's an option called \"Force track recognition\" that makes the extension force scrobbling the track even if the track is not validated by Last.fm.",
-    "description": "Answer #3"
-  },
-  "faqQuestion4": {
-    "message": "Some music on Bandcamp cannot be scrobbled. Is it possible to fix this?",
-    "description": "Question #4"
-  },
-  "faqAnswer4a": {
-    "message": "Looks like the music is hosted on a custom domain and the extension cannot detect whether it’s Bandcamp or not.",
-    "description": "Answer #4"
-  },
-  "faqAnswer4b": {
-    "message": "As a workaround, configure the extension to work with custom domains as follows:",
-    "description": "Answer #4"
-  },
-  "faqAnswer4b1": {
-    "message": "Open the extension setting page and expand the “Options” section.",
-    "description": "Answer #4"
-  },
-  "faqAnswer4b2": {
-    "message": "Find the Bandcamp connector in the list of supported services.",
-    "description": "Answer #4"
-  },
-  "faqAnswer4b3": {
-    "message": "Click on the gear icon near the connector label.",
-    "description": "Answer #4"
-  },
-  "faqAnswer4b4": {
-    "message": "Add URL pattern that matches the Bandcamp custom domain URL and apply the changes.",
-    "description": "Answer #4"
-  },
-  "faqAnswer4c": {
-    "message": "You can learn more about the custom URL patterns <a target='_blank' href='https://github.com/web-scrobbler/web-scrobbler/wiki/Custom-URL-patterns'>here</a>.",
-    "description": "Answer #4"
-  },
-  "faqQuestion5": {
-    "message": "Will you add support for scrobbling at ____ ?",
-    "description": "Question #5"
-  },
-  "faqAnswer5": {
-    "message": "Open a <a href=\"https://github.com/web-scrobbler/web-scrobbler/issues\" target=\"_blank\">new issue</a> on GitHub with your request, and we'll tell you if we can add support for the website or not. Also, you can add support for the website by forking the <a href=\"http://github.com/web-scrobbler/web-scrobbler\">GitHub repository</a> and sending us a pull request.",
-    "description": "Answer #5"
-  },
-  "faqQuestion6": {
-    "message": "Will you add ____ functionality?",
-    "description": "Question #6"
-  },
-  "faqAnswer6": {
-    "message": "Possibly, if it makes sense. But if you want me to add some not-that-useful-but-really-cool functions, you'll probably get disappointed.",
-    "description": "Answer #6"
-  },
-  "faqQuestion7": {
-    "message": "Who is the author?",
-    "description": "Question #7"
-  },
-  "faqAnswer7": {
-    "message": "The original author of this extension is David Šabata. Now this extension is developed and maintained by the Web Scrobbler Team.",
-    "description": "Answer #7"
-  },
+    "faqTitle": {
+        "message": "FAQ",
+        "description": "'FAQ' section"
+    },
+    "faqQuestion1": {
+        "message": "How can I start using the extension?",
+        "description": "Question #1"
+    },
+    "faqAnswer1a": {
+        "message": "You should click on a notification that is shown when the extension is loaded the first time. Then, you should grant access to your accounts.",
+        "description": "Answer #1"
+    },
+    "faqAnswer1b": {
+        "message": "Note: In some cases, the notification won't be shown, e.g. on Mac OS if Chrome is running in full-screen mode; the extension will open a tab where you can grant access to your accounts.",
+        "description": "Answer #1"
+    },
+    "faqQuestion2": {
+        "message": "How do I temporarily disable scrobbling?",
+        "description": "Question #2"
+    },
+    "faqAnswer2a": {
+        "message": "You can do that by right-clicking on the green extension icon in the extension bar. Using the context menu you can disable the connector for the current web service.",
+        "description": "Answer #2"
+    },
+    "faqAnswer2b": {
+        "message": "Use the checkboxes on the options page to disable certain connectors, or the \"Toggle\" checkbox to disable scrobbling globally.",
+        "description": "Answer #2"
+    },
+    "faqQuestion3": {
+        "message": "The track was not recognized! Can you fix it?",
+        "description": "Question #3"
+    },
+    "faqAnswer3a": {
+        "message": "When a track cannot be recognized, a gray icon with question mark appears in the extension bar. You can click on this icon and input correct data in the opened popup window.",
+        "description": "Answer #3"
+    },
+    "faqAnswer3b": {
+        "message": "Also, there's an option called \"Force track recognition\" that makes the extension force scrobbling the track even if the track is not validated by Last.fm.",
+        "description": "Answer #3"
+    },
+    "faqQuestion4": {
+        "message": "Some music on Bandcamp cannot be scrobbled. Is it possible to fix this?",
+        "description": "Question #4"
+    },
+    "faqAnswer4a": {
+        "message": "Looks like the music is hosted on a custom domain and the extension cannot detect whether it’s Bandcamp or not.",
+        "description": "Answer #4"
+    },
+    "faqAnswer4b": {
+        "message": "As a workaround, configure the extension to work with custom domains as follows:",
+        "description": "Answer #4"
+    },
+    "faqAnswer4b1": {
+        "message": "Open the extension setting page and expand the “Options” section.",
+        "description": "Answer #4"
+    },
+    "faqAnswer4b2": {
+        "message": "Find the Bandcamp connector in the list of supported services.",
+        "description": "Answer #4"
+    },
+    "faqAnswer4b3": {
+        "message": "Click on the gear icon near the connector label.",
+        "description": "Answer #4"
+    },
+    "faqAnswer4b4": {
+        "message": "Add URL pattern that matches the Bandcamp custom domain URL and apply the changes.",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c": {
+        "message": "You can learn more about the custom URL patterns <a target='_blank' href='https://github.com/web-scrobbler/web-scrobbler/wiki/Custom-URL-patterns'>here</a>.",
+        "description": "Answer #4"
+    },
+    "faqQuestion5": {
+        "message": "Will you add support for scrobbling at ____ ?",
+        "description": "Question #5"
+    },
+    "faqAnswer5": {
+        "message": "Open a <a href=\"https://github.com/web-scrobbler/web-scrobbler/issues\" target=\"_blank\">new issue</a> on GitHub with your request, and we'll tell you if we can add support for the website or not. Also, you can add support for the website by forking the <a href=\"http://github.com/web-scrobbler/web-scrobbler\">GitHub repository</a> and sending us a pull request.",
+        "description": "Answer #5"
+    },
+    "faqQuestion6": {
+        "message": "Will you add ____ functionality?",
+        "description": "Question #6"
+    },
+    "faqAnswer6": {
+        "message": "Possibly, if it makes sense. But if you want me to add some not-that-useful-but-really-cool functions, you'll probably get disappointed.",
+        "description": "Answer #6"
+    },
+    "faqQuestion7": {
+        "message": "Who is the author?",
+        "description": "Question #7"
+    },
+    "faqAnswer7": {
+        "message": "The original author of this extension is David Šabata. Now this extension is developed and maintained by the Web Scrobbler Team.",
+        "description": "Answer #7"
+    },
 
-  "optionsAbout": {
-    "message": "About",
-    "description": "'About' section"
-  },
-  "aboutChangelog": {
-    "message": "The changelog of current version is available <a id='latest-release' target='_blank' href='#'>here</a>. For the full changelog please visit <a target='_blank' href='https://github.com/web-scrobbler/web-scrobbler/releases'>this page</a>.",
-    "description": "'About' section text"
-  },
-  "aboutExtensionDesc": {
-    "message": "Web Scrobbler is a browser extension created for people who listen to music online through their browser, and would like to keep an updated playback history using scrobbling services, such as Last.fm, Libre.fm and ListenBrainz.",
-    "description": "'About' section text"
-  },
-  "contributorsTitle": {
-    "message": "Contributors",
-    "description": "'Contributors' header"
-  },
-  "contributorsText": {
-    "message": "You can find the list of contributors <a href=\"https://github.com/web-scrobbler/web-scrobbler/graphs/contributors\">right on the GitHub</a>",
-    "description": "'About' section text"
-  },
-  "showSomeLoveTitle": {
-    "message": "Show some love",
-    "description": "'Show some love' section"
-  },
-  "showSomeLoveText1": {
-    "message": "Unlike other extensions, this one does not contain any flashing banners or sneaky ads.",
-    "description": ""
-  },
-  "showSomeLoveText2": {
-    "message": "The extension is free, and will always be free. But if you want to support development of the extension, you can use the button below.",
-    "description": ""
-  },
-  "customPatterns": {
-    "message": "URL patterns",
-    "description": "'URL patterns' section"
-  },
-  "customPatternsHint": {
-    "message": "Add URL patterns that the connector should match below.",
-    "description": "Popup hint"
-  },
-  "customPatternsAdd": {
-    "message": "Add pattern",
-    "description": "Add button"
-  },
-  "albumTooltip": {
-    "message": "From \"$1\" album",
-    "description": "Tooltip text"
-  },
-  "buttonOk": {
-    "message": "OK",
-    "description": "OK button label"
-  },
-  "buttonCancel": {
-    "message": "Cancel",
-    "description": "Cancel button label"
-  },
-  "buttonReset": {
-    "message": "Reset",
-    "description": "Reset button label"
-  },
-  "buttonClear": {
-    "message": "Clear",
-    "description": "Clear button label"
-  },
-  "noItemsInCache": {
-    "message": "No items in cache.",
-    "description": "Popup hint"
-  },
-
-
-  "getStartedHeader": {
-    "message": "Play some music to get started",
-    "description": "The header of 'Get started' popup"
-  },
-  "getStartedSubheader": {
-    "message": "Is it already playing?",
-    "description": "The subheader of 'Get started' popup"
-  },
-  "getStartedSiteChanged": {
-    "message": "In most cases this means the site has changed somehow. The change does not have to be visible to user, but means a lot to the extension.",
-    "description": "Description of why track is not recognized"
-  },
-  "getStartedSubmitIssue": {
-    "message": "The connector code for this specific website needs to be updated. You can navigate to the <a href=\"https://github.com/web-scrobbler/web-scrobbler/issues\" target=\"_blank\">list of issues</a> and see if this website is already reported. If it is not, you can submit a new issue describing what's wrong, what's expected behavior and what's happening instead.",
-    "description": "Description of how to submit new issue"
-  },
+    "optionsAbout": {
+        "message": "About",
+        "description": "'About' section"
+    },
+    "aboutChangelog": {
+        "message": "The changelog of current version is available <a id='latest-release' target='_blank' href='#'>here</a>. For the full changelog please visit <a target='_blank' href='https://github.com/web-scrobbler/web-scrobbler/releases'>this page</a>.",
+        "description": "'About' section text"
+    },
+    "aboutExtensionDesc": {
+        "message": "Web Scrobbler is a browser extension created for people who listen to music online through their browser, and would like to keep an updated playback history using scrobbling services, such as Last.fm, Libre.fm and ListenBrainz.",
+        "description": "'About' section text"
+    },
+    "contributorsTitle": {
+        "message": "Contributors",
+        "description": "'Contributors' header"
+    },
+    "contributorsText": {
+        "message": "You can find the list of contributors <a href=\"https://github.com/web-scrobbler/web-scrobbler/graphs/contributors\">right on the GitHub</a>",
+        "description": "'About' section text"
+    },
+    "showSomeLoveTitle": {
+        "message": "Show some love",
+        "description": "'Show some love' section"
+    },
+    "showSomeLoveText1": {
+        "message": "Unlike other extensions, this one does not contain any flashing banners or sneaky ads.",
+        "description": ""
+    },
+    "showSomeLoveText2": {
+        "message": "The extension is free, and will always be free. But if you want to support development of the extension, you can use the button below.",
+        "description": ""
+    },
+    "customPatterns": {
+        "message": "URL patterns",
+        "description": "'URL patterns' section"
+    },
+    "customPatternsHint": {
+        "message": "Add URL patterns that the connector should match below.",
+        "description": "Popup hint"
+    },
+    "customPatternsAdd": {
+        "message": "Add pattern",
+        "description": "Add button"
+    },
+    "albumTooltip": {
+        "message": "From \"$1\" album",
+        "description": "Tooltip text"
+    },
+    "buttonOk": {
+        "message": "OK",
+        "description": "OK button label"
+    },
+    "buttonCancel": {
+        "message": "Cancel",
+        "description": "Cancel button label"
+    },
+    "buttonReset": {
+        "message": "Reset",
+        "description": "Reset button label"
+    },
+    "buttonClear": {
+        "message": "Clear",
+        "description": "Clear button label"
+    },
+    "noItemsInCache": {
+        "message": "No items in cache.",
+        "description": "Popup hint"
+    },
 
 
-  "serviceErrorHeader": {
-    "message": "Service error",
-    "description": "The header of 'error' popup"
-  },
-  "serviceErrorDesc": {
-    "message": "Looks like something went wrong while scrobbling the music. Please open the options page and try to reauthenticate with services. If reauthentication doesn't help, and you still see this message, please create <a href=\"https://github.com/web-scrobbler/web-scrobbler/issues\" target=\"_blank\">a new issue</a> at the GitHub project page.",
-    "description": "The description of service error"
-  },
-
-  "disabledSiteHeader": {
-    "message": "This website is turned off",
-    "description": "The header of 'disabled' popup"
-  },
-  "disabledSiteDesc": {
-    "message": "The extension won't scrobble music from this website until you turn it on in the extension options.",
-    "description": "The description of 'disabled' popup"
-  },
-  "disabledSiteButton": {
-    "message": "Open options page",
-    "description": "Button label"
-  },
-
-  "unsupportedWebsiteHeader": {
-    "message": "This website is not supported",
-    "description": "The header of 'unsupported' popup"
-  },
-  "unsupportedWebsiteDesc": {
-    "message": "Web Scrobbler does not support scrobbling from this website.",
-    "description": "The description of 'unsupported' popup"
-  },
-  "unsupportedWebsiteDesc2": {
-    "message": "Some Google websites supported by the extension (e.g. Google Play Music, YouTube) can be blocked due to an ExtensionSettings policy.",
-    "description": "The description of 'unsupported' popup"
-  },
-
-  "infoLove": {
-    "message": "Love track",
-    "description": "Label of love/unlove button"
-  },
-  "infoUnlove": {
-    "message": "Unlove track",
-    "description": "Label of love/unlove button"
-  },
-  "infoEditTitle": {
-    "message": "Edit track metadata",
-    "description": "Title of edit button"
-  },
-  "infoEditUnableTitle": {
-    "message": "You cannot edit this track",
-    "description": "Title of edit button"
-  },
-  "infoSwapTitle": {
-    "message": "Swap title and artist",
-    "description": "Title of swap button"
-  },
-  "infoSwapUnableTitle": {
-    "message": "You cannot swap empty track info",
-    "description": "Title of swap button"
-  },
-  "infoSubmitTitle": {
-    "message": "Submit changes",
-    "description": "Title of submit button"
-  },
-  "infoSubmitUnableTitle": {
-    "message": "You cannot submit empty track info",
-    "description": "Title of submit button"
-  },
-  "infoRevertTitle": {
-    "message": "Revert changes",
-    "description": "Title of revert button"
-  },
-  "infoRevertUnableTitle": {
-    "message": "You cannot revert this track",
-    "description": "Title of revert button"
-  },
-  "infoSkipTitle": {
-    "message": "Don't scrobble current track",
-    "description": "Title of skip button"
-  },
-  "infoSkipUnableTitle": {
-    "message": "You cannot skip this track",
-    "description": "Title of skip button"
-  },
-  "infoSkippedTitle": {
-    "message": "You skipped this track",
-    "description": "Title of unskip button"
-  },
-  "infoOpenAlbumArt": {
-    "message": "Open album art in new tab",
-    "description": "Title of album image"
-  },
-  "infoArtistPlaceholder": {
-    "message": "Artist",
-    "description": "Placeholder of artist input"
-  },
-  "infoTrackPlaceholder": {
-    "message": "Track",
-    "description": "Placeholder of track input"
-  },
-  "infoAlbumPlaceholder": {
-    "message": "Album (optional)",
-    "description": "Placeholder of album input"
-  },
-  "infoAlbumArtistPlaceholder": {
-    "message": "Album artist (optional)",
-    "description": "Placeholder of album artist input"
-  },
-  "infoViewArtistPage": {
-    "message": "View artist page: $1",
-    "description": "Placeholder of album input"
-  },
-  "infoViewAlbumPage": {
-    "message": "View album page: $1",
-    "description": "Placeholder of album input"
-  },
-  "infoViewTrackPage": {
-    "message": "View track page: $1",
-    "description": "Placeholder of album input"
-  },
-  "infoYourScrobbles": {
-    "message": "Your scrobbles: $1",
-    "description": "Label for user play count"
-  },
+    "getStartedHeader": {
+        "message": "Play some music to get started",
+        "description": "The header of 'Get started' popup"
+    },
+    "getStartedSubheader": {
+        "message": "Is it already playing?",
+        "description": "The subheader of 'Get started' popup"
+    },
+    "getStartedSiteChanged": {
+        "message": "In most cases this means the site has changed somehow. The change does not have to be visible to user, but means a lot to the extension.",
+        "description": "Description of why track is not recognized"
+    },
+    "getStartedSubmitIssue": {
+        "message": "The connector code for this specific website needs to be updated. You can navigate to the <a href=\"https://github.com/web-scrobbler/web-scrobbler/issues\" target=\"_blank\">list of issues</a> and see if this website is already reported. If it is not, you can submit a new issue describing what's wrong, what's expected behavior and what's happening instead.",
+        "description": "Description of how to submit new issue"
+    },
 
 
-  "pageActionBase": {
-    "message": "This site is supported for scrobbling",
-    "description": "`base` page action title"
-  },
-  "pageActionLoading": {
-    "message": "Looking up $1",
-    "description": "`loading` page action title"
-  },
-  "pageActionRecognized": {
-    "message": "Now playing $1",
-    "description": "`recognized` page action title"
-  },
-  "pageActionScrobbled": {
-    "message": "Scrobbled $1",
-    "description": "`scrobbled` page action title"
-  },
-  "pageActionSkipped": {
-    "message": "Skipped $1",
-    "description": "`skipped` page action title"
-  },
-  "pageActionIgnored": {
-    "message": "Ignored $1",
-    "description": "`ignored` page action title"
-  },
-  "pageActionDisabled": {
-    "message": "This site is supported for scrobbling, but you disabled it",
-    "description": "`disabled` page action title"
-  },
-  "pageActionUnknown": {
-    "message": "The track is not recognized. Click to submit correct info.",
-    "description": "`unknown` page action title"
-  },
-  "pageActionError": {
-    "message": "A service error occurred. Click for more information.",
-    "description": "`loading` page action title"
-  },
-  "pageActionUnsupported": {
-    "message": "Web Scrobbler does not support this website.",
-    "description": "`unsupported` page action title"
-  },
-  "pageActionLoved": {
-    "message": "You loved $1",
-    "description": "`unsupported` page action title"
-  },
-  "pageActionUnloved": {
-    "message": "You unloved $1",
-    "description": "`unsupported` page action title"
-  },
+    "serviceErrorHeader": {
+        "message": "Service error",
+        "description": "The header of 'error' popup"
+    },
+    "serviceErrorDesc": {
+        "message": "Looks like something went wrong while scrobbling the music. Please open the options page and try to reauthenticate with services. If reauthentication doesn't help, and you still see this message, please create <a href=\"https://github.com/web-scrobbler/web-scrobbler/issues\" target=\"_blank\">a new issue</a> at the GitHub project page.",
+        "description": "The description of service error"
+    },
+
+    "disabledSiteHeader": {
+        "message": "This website is turned off",
+        "description": "The header of 'disabled' popup"
+    },
+    "disabledSiteDesc": {
+        "message": "The extension won't scrobble music from this website until you turn it on in the extension options.",
+        "description": "The description of 'disabled' popup"
+    },
+    "disabledSiteButton": {
+        "message": "Open options page",
+        "description": "Button label"
+    },
+
+    "unsupportedWebsiteHeader": {
+        "message": "This website is not supported",
+        "description": "The header of 'unsupported' popup"
+    },
+    "unsupportedWebsiteDesc": {
+        "message": "Web Scrobbler does not support scrobbling from this website.",
+        "description": "The description of 'unsupported' popup"
+    },
+    "unsupportedWebsiteDesc2": {
+        "message": "Some Google websites supported by the extension (e.g. Google Play Music, YouTube) can be blocked due to an ExtensionSettings policy.",
+        "description": "The description of 'unsupported' popup"
+    },
+
+    "infoLove": {
+        "message": "Love track",
+        "description": "Label of love/unlove button"
+    },
+    "infoUnlove": {
+        "message": "Unlove track",
+        "description": "Label of love/unlove button"
+    },
+    "infoEditTitle": {
+        "message": "Edit track metadata",
+        "description": "Title of edit button"
+    },
+    "infoEditUnableTitle": {
+        "message": "You cannot edit this track",
+        "description": "Title of edit button"
+    },
+    "infoSwapTitle": {
+        "message": "Swap title and artist",
+        "description": "Title of swap button"
+    },
+    "infoSwapUnableTitle": {
+        "message": "You cannot swap empty track info",
+        "description": "Title of swap button"
+    },
+    "infoSubmitTitle": {
+        "message": "Submit changes",
+        "description": "Title of submit button"
+    },
+    "infoSubmitUnableTitle": {
+        "message": "You cannot submit empty track info",
+        "description": "Title of submit button"
+    },
+    "infoRevertTitle": {
+        "message": "Revert changes",
+        "description": "Title of revert button"
+    },
+    "infoRevertUnableTitle": {
+        "message": "You cannot revert this track",
+        "description": "Title of revert button"
+    },
+    "infoSkipTitle": {
+        "message": "Don't scrobble current track",
+        "description": "Title of skip button"
+    },
+    "infoSkipUnableTitle": {
+        "message": "You cannot skip this track",
+        "description": "Title of skip button"
+    },
+    "infoSkippedTitle": {
+        "message": "You skipped this track",
+        "description": "Title of unskip button"
+    },
+    "infoOpenAlbumArt": {
+        "message": "Open album art in new tab",
+        "description": "Title of album image"
+    },
+    "infoArtistPlaceholder": {
+        "message": "Artist",
+        "description": "Placeholder of artist input"
+    },
+    "infoTrackPlaceholder": {
+        "message": "Track",
+        "description": "Placeholder of track input"
+    },
+    "infoAlbumPlaceholder": {
+        "message": "Album (optional)",
+        "description": "Placeholder of album input"
+    },
+    "infoAlbumArtistPlaceholder": {
+        "message": "Album artist (optional)",
+        "description": "Placeholder of album artist input"
+    },
+    "infoViewArtistPage": {
+        "message": "View artist page: $1",
+        "description": "Placeholder of album input"
+    },
+    "infoViewAlbumPage": {
+        "message": "View album page: $1",
+        "description": "Placeholder of album input"
+    },
+    "infoViewTrackPage": {
+        "message": "View track page: $1",
+        "description": "Placeholder of album input"
+    },
+    "infoYourScrobbles": {
+        "message": "Your scrobbles: $1",
+        "description": "Label for user play count"
+    },
 
 
-  "menuDisableConnector": {
-    "message": "Disable $1 connector",
-    "description": "Context menu item"
-  },
-  "menuEnableConnector": {
-    "message": "Enable $1 connector",
-    "description": "Context menu item"
-  },
-  "menuDisableUntilTabClosed": {
-    "message": "Disable $1 connector until tab is closed",
-    "description": "Context menu item"
-  },
+    "pageActionBase": {
+        "message": "This site is supported for scrobbling",
+        "description": "`base` page action title"
+    },
+    "pageActionLoading": {
+        "message": "Looking up $1",
+        "description": "`loading` page action title"
+    },
+    "pageActionRecognized": {
+        "message": "Now playing $1",
+        "description": "`recognized` page action title"
+    },
+    "pageActionScrobbled": {
+        "message": "Scrobbled $1",
+        "description": "`scrobbled` page action title"
+    },
+    "pageActionSkipped": {
+        "message": "Skipped $1",
+        "description": "`skipped` page action title"
+    },
+    "pageActionIgnored": {
+        "message": "Ignored $1",
+        "description": "`ignored` page action title"
+    },
+    "pageActionDisabled": {
+        "message": "This site is supported for scrobbling, but you disabled it",
+        "description": "`disabled` page action title"
+    },
+    "pageActionUnknown": {
+        "message": "The track is not recognized. Click to submit correct info.",
+        "description": "`unknown` page action title"
+    },
+    "pageActionError": {
+        "message": "A service error occurred. Click for more information.",
+        "description": "`loading` page action title"
+    },
+    "pageActionUnsupported": {
+        "message": "Web Scrobbler does not support this website.",
+        "description": "`unsupported` page action title"
+    },
+    "pageActionLoved": {
+        "message": "You loved $1",
+        "description": "`unsupported` page action title"
+    },
+    "pageActionUnloved": {
+        "message": "You unloved $1",
+        "description": "`unsupported` page action title"
+    },
 
 
-  "notificationConnectAccounts": {
-    "message": "Connect your accounts",
-    "description": "Notification title"
-  },
-  "notificationConnectAccountsText": {
-    "message": "Click the notification to connect your accounts.",
-    "description": "Notification text"
-  },
-  "notificationAuthError": {
-    "message": "Authentication error",
-    "description": "Notification title"
-  },
-  "notificationUnableSignIn": {
-    "message": "Unable to sign in to $1. Please try later.",
-    "description": "Notification text"
-  },
-  "notificationNotRecognized": {
-    "message": "The track is not recognized",
-    "description": "Notification title"
-  },
-  "notificationNotRecognizedText": {
-    "message": "Click on the icon in the extensions bar to correct and submit track info.",
-    "description": "Notification text"
-  },
+    "menuDisableConnector": {
+        "message": "Disable $1 connector",
+        "description": "Context menu item"
+    },
+    "menuEnableConnector": {
+        "message": "Enable $1 connector",
+        "description": "Context menu item"
+    },
+    "menuDisableUntilTabClosed": {
+        "message": "Disable $1 connector until tab is closed",
+        "description": "Context menu item"
+    },
 
-  "hotkeyToggleConnector": {
-    "message": "Toggle scrobbling for current website",
-    "description": "Hotkey label"
-  },
-  "hotkeyLoveSong": {
-    "message": "Love now playing song",
-    "description": "Hotkey label"
-  },
-  "hotkeyUnloveSong": {
-    "message": "Unlove now playing song",
-    "description": "Hotkey label"
-  }
+
+    "notificationConnectAccounts": {
+        "message": "Connect your accounts",
+        "description": "Notification title"
+    },
+    "notificationConnectAccountsText": {
+        "message": "Click the notification to connect your accounts.",
+        "description": "Notification text"
+    },
+    "notificationAuthError": {
+        "message": "Authentication error",
+        "description": "Notification title"
+    },
+    "notificationUnableSignIn": {
+        "message": "Unable to sign in to $1. Please try later.",
+        "description": "Notification text"
+    },
+    "notificationNotRecognized": {
+        "message": "The track is not recognized",
+        "description": "Notification title"
+    },
+    "notificationNotRecognizedText": {
+        "message": "Click on the icon in the extensions bar to correct and submit track info.",
+        "description": "Notification text"
+    },
+
+    "hotkeyToggleConnector": {
+        "message": "Toggle scrobbling for current website",
+        "description": "Hotkey label"
+    },
+    "hotkeyLoveSong": {
+        "message": "Love now playing song",
+        "description": "Hotkey label"
+    },
+    "hotkeyUnloveSong": {
+        "message": "Unlove now playing song",
+        "description": "Hotkey label"
+    }
 }

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -33,6 +33,10 @@
     },
     "optionScrobblePodcasts": {
         "message": "Scrobble podcasts",
+        "description": "Option label"
+    },
+    "optionScrobblePodcastsTitle": {
+        "message": "Scrobble episodios del podcast",
         "description": "Option title"
     },
     "optionsHidden": {
@@ -47,13 +51,9 @@
         "message": "de duración de la canción",
         "description": "Option title"
     },
-    "optionScrobblePodcastsTitle": {
-        "message": "Scrobble episodios del podcast",
-        "description": "Option label"
-    },
     "optionYtDesc": {
-        "message": "Si desactiva ambas opciones, la extensión hará scrobbles de los videos de Youtube en todas las categorías.",
-        "description": "Description of Youtube options"
+        "message": "Si desactiva ambas opciones, la extensión hará scrobbles de los videos de YouTube en todas las categorías.",
+        "description": "Description of YouTube options"
     },
     "optionPercentDesc": {
         "message": "Tenga en cuenta que una pista será scrobbled de todos modos, si se ha ejecutado durante 4 minutos, independientemente del valor de la opción.",

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -33,6 +33,10 @@
     },
     "optionScrobblePodcasts": {
         "message": "Scrobbluj podcasty",
+        "description": "Option label"
+    },
+    "optionScrobblePodcastsTitle": {
+        "message": "Scrobbluj odcinki podcastów",
         "description": "Option title"
     },
     "optionsHidden": {
@@ -47,13 +51,9 @@
         "message": "czasu trwania utworu",
         "description": "Option title"
     },
-    "optionScrobblePodcastsTitle": {
-        "message": "Scrobbluj odcinki podcastów",
-        "description": "Option label"
-    },
     "optionYtDesc": {
-        "message": "Jeśli wyłączysz obie opcje, rozszerzenie będzie scrobblować filmy na Youtube niezależnie od kategorii.",
-        "description": "Description of Youtube options"
+        "message": "Jeśli wyłączysz obie opcje, rozszerzenie będzie scrobblować filmy na YouTube niezależnie od kategorii.",
+        "description": "Description of YouTube options"
     },
     "optionPercentDesc": {
         "message": "Niezależnie od ustawionej wartości, utwór zostanie przescrobblowany jeśli będzie odtwarzany dłużej niż 4 minuty.",

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -33,6 +33,10 @@
     },
     "optionScrobblePodcasts": {
         "message": "Efetuar scrobble de podcasts",
+        "description": "Option label"
+    },
+    "optionScrobblePodcastsTitle": {
+        "message": "Efetuar scrobble de episódios de podcasts",
         "description": "Option title"
     },
     "optionsHidden": {
@@ -47,13 +51,9 @@
         "message": "da duração total da música",
         "description": "Option title"
     },
-    "optionScrobblePodcastsTitle": {
-        "message": "Efetuar scrobble de episódios de podcasts",
-        "description": "Option label"
-    },
     "optionYtDesc": {
-        "message": "Caso desative ambas as opções, a extensão efetuará scrobble de vídeos do Youtube de todas as categorias.",
-        "description": "Description of Youtube options"
+        "message": "Caso desative ambas as opções, a extensão efetuará scrobble de vídeos do YouTube de todas as categorias.",
+        "description": "Description of YouTube options"
     },
     "optionPercentDesc": {
         "message": "Observe que o scrobble será feito em faixas que estejam em reprodução por mais de 4 minutos independentemente do valor informado.",

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -33,6 +33,10 @@
     },
     "optionScrobblePodcasts": {
         "message": "Скробблить подкасты",
+        "description": "Option label"
+    },
+    "optionScrobblePodcastsTitle": {
+        "message": "Разрешить приложению скробблить подкасты",
         "description": "Option title"
     },
     "optionsHidden": {
@@ -47,13 +51,9 @@
         "message": "композиции",
         "description": "Option title"
     },
-    "optionScrobblePodcastsTitle": {
-        "message": "Разрешить приложению скробблить подкасты",
-        "description": "Option label"
-    },
     "optionYtDesc": {
         "message": "Если вы отключите обе настройки, расширение будет скробблить видео из всех категорий.",
-        "description": "Description of Youtube options"
+        "description": "Description of YouTube options"
     },
     "optionPercentDesc": {
         "message": "Примечание: композиция будет заскробблена, если она играет более 4 минут, независимо от значения данной настройки.",

--- a/src/_locales/sk_SK/messages.json
+++ b/src/_locales/sk_SK/messages.json
@@ -33,6 +33,10 @@
     },
     "optionScrobblePodcasts": {
         "message": "Zaznamenávať podcasty",
+        "description": "Option label"
+    },
+    "optionScrobblePodcastsTitle": {
+        "message": "Zaznamenáva diely podcastov",
         "description": "Option title"
     },
     "optionsHidden": {
@@ -47,13 +51,9 @@
         "message": "dĺžky skladby",
         "description": "Option title"
     },
-    "optionScrobblePodcastsTitle": {
-        "message": "Zaznamenáva diely podcastov",
-        "description": "Option label"
-    },
     "optionYtDesc": {
         "message": "Ak vypnete obe možnosti, doplnok bude zaznamenávať youtube videá zo všetkých kategórii.",
-        "description": "Description of Youtube options"
+        "description": "Description of YouTube options"
     },
     "optionPercentDesc": {
         "message": "Ak skladba hrala aspoň 4 minúty, tak bude zaznamenaná bezohľadu na nastavenú hodnotu.",
@@ -372,7 +372,7 @@
         "description": "The description of 'unsupported' popup"
     },
     "unsupportedWebsiteDesc2": {
-        "message": "Niektoré Google stránky podporované doplnkom (napr. Google Play Hudba, Youtube) môžu byť zablokované kvôli politike nastavení doplnku.",
+        "message": "Niektoré Google stránky podporované doplnkom (napr. Google Play Hudba, YouTube) môžu byť zablokované kvôli politike nastavení doplnku.",
         "description": "The description of 'unsupported' popup"
     },
     "infoLove": {

--- a/src/_locales/zh/messages.json
+++ b/src/_locales/zh/messages.json
@@ -33,6 +33,10 @@
     },
     "optionScrobblePodcasts": {
         "message": "记录播客",
+        "description": "Option label"
+    },
+    "optionScrobblePodcastsTitle": {
+        "message": "记录播客节目",
         "description": "Option title"
     },
     "optionsHidden": {
@@ -47,13 +51,9 @@
         "message": "曲目长度",
         "description": "Option title"
     },
-    "optionScrobblePodcastsTitle": {
-        "message": "记录播客节目",
-        "description": "Option label"
-    },
     "optionYtDesc": {
-        "message": "如果您关闭了这两个选项，该扩展程序将会对所有类别的 Youtube 视频追踪播放记录。",
-        "description": "Description of Youtube options"
+        "message": "如果您关闭了这两个选项，该扩展程序将会对所有类别的 YouTube 视频追踪播放记录。",
+        "description": "Description of YouTube options"
     },
     "optionPercentDesc": {
         "message": "请注意，如果一个曲目已播放了4分钟，无论选项值如何，它都将被记录。",


### PR DESCRIPTION
While working on a feature that isn't ready yet, I noticed the labels and titles used for options were a bit unorganized.

- German translations for `optionsHidden`, `optionScrobblePercent` and `optionScrobblePercentSuffix` were missing;
- The descriptions for `optionScrobblePodcasts` and `optionScrobblePodcastsTitle` were swapped;
- `optionScrobblePodcastsTitle` was not immediately after `optionScrobblePodcasts`.

I also fixed the indentation of the English messages.json file, it was the only file that did not yet use 4 spaces for indentation.

Lastly, I capitalized the T in YouTube.

