### PR TITLE
Add connector for burntable.com

### DIFF
--- a/src/connectors/burntable.js
+++ b/src/connectors/burntable.js
@@ -1,0 +1,41 @@
+'use strict';
+
+// only works on mixes via https://burntable.com/listen or user playlists; album playback limited to 60-second increments
+
+Connector.playerSelector = '.universal-player';
+
+Connector.getTrackInfo = () => {
+	let albumText;
+	let artistText;
+	let trackText;
+
+	const artistAlbumText = Util.getTextFromSelectors('.universal-player .magic-marquee .magic-marquee-content > span > span:last-of-type');
+
+	if (artistAlbumText !== null) { // ensure text captured
+		const artistAlbumSplit = artistAlbumText.split(' \u2013 '); // en dash separator
+		albumText = artistAlbumSplit[1];
+		artistText = artistAlbumSplit[0];
+	}
+
+	const trackTextElement = document.querySelector('.universal-player .magic-marquee .magic-marquee-content > span');
+
+	if (trackTextElement !== null) { // ensure element loaded
+		trackText = trackTextElement.childNodes[1].textContent; // get text without span siblings
+	}
+
+	return {
+		album: albumText,
+		artist: artistText,
+		track: trackText,
+	};
+};
+
+const filter = MetadataFilter.createFilter({
+	album: (text) => text.replace(/\s\((\d{4})?\)$/g, ''), // remove year of vinyl pressing
+});
+
+Connector.applyFilter(filter);
+
+Connector.trackArtSelector = '.universal-player .v-image__image--cover';
+
+Connector.playButtonSelector = '.universal-player button.v-size--large i.mdi-play';

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1764,6 +1764,13 @@ const connectors = [{
 	js: 'connectors/turntable.fm.js',
 	id: 'turntable.fm',
 }, {
+	label: 'Burntable',
+	matches: [
+		'*://*.burntable.com/*',
+	],
+	js: 'connectors/burntable.js',
+	id: 'burntable',
+}, {
 	label: 'Stingray Music',
 	matches: [
 		'*://*.stingray.com/*',


### PR DESCRIPTION
New connector for burntable.com, a site where users can upload digital files of their vinyl records. Tested with my personal account and scrobbles are successful. Screenshot below.
<img width="1189" alt="burntablescrobble" src="https://user-images.githubusercontent.com/6808988/162828314-c052ab44-1625-4aae-8cc3-fb589b99c9f7.png">

NOTES:

- Connector is only functional on mixes via https://burntable.com/listen and user playlists.
- Album playback is limited to only 60-second increments due to licensing restrictions and uses a different player, so those plays are not captured by the connector.
- Additional logic required due to DOM structure and metadata elements not found inside the player wrapper prior to initial playback.
- Duration only available on the full-page player and not in the persistent player, which is being used for the connector and is initially hidden but appears when navigating the site during playback.