### PR TITLE
(fix) update Idagio `isPlaying` selector

### DIFF
--- a/src/connectors/idagio.js
+++ b/src/connectors/idagio.js
@@ -4,7 +4,7 @@ const symphonySelector = '.player-PlayerInfo__infoEl--2jhHY span:nth-child(3) sp
 const commonNameSelector = '.player-PlayerInfo__infoEl--2jhHY span:nth-child(3) span:nth-child(2)';
 const directorSelector = '.player-PlayerInfo__recordingInfo--15VMv>span:first-child span';
 const trackSelector = '.player-PlayerInfo__infoEl--2jhHY';
-const pauseButtonSelector = '.player-PlayerControls__btn--1r-vy:nth-child(2) .util-IconLabel__component--3Uitr span';
+const pauseButtonSelector = '.player-PlayerControls__btn--1r-vy:nth-child(3) .util-IconLabel__component--3Uitr span';
 
 Connector.playerSelector = '.player-PlayerBar__bar--2yos_';
 


### PR DESCRIPTION
Idagio connector was broken because the play/pause button changed position.
Looks like a 'shuffle' element was added to the playback controls. The play/pause button is now the third (3rd)
child.

<img width="1679" alt="image" src="https://user-images.githubusercontent.com/1251344/164716489-0ae5a5d3-a34d-401d-bd5a-463e4ee9f903.png">
