### PR TITLE
Add connector for Indonesian music archive Irama Nusantara

### DIFF
--- a/src/connectors/iramanusantara.js
+++ b/src/connectors/iramanusantara.js
@@ -1,0 +1,14 @@
+'use strict';
+
+Connector.playerSelector = '#player';
+
+Connector.artistSelector = '#pl-info-text > h4';
+
+Connector.trackSelector = '#pl-info-text > h3';
+
+// Album title is only available when track is played through the album page 
+Connector.albumSelector = '.ad-info-text1 > h1';
+
+Connector.playButtonSelector = '#pl-ctrl-play';
+
+Connector.trackArtSelector = '.player-img > img';

--- a/src/connectors/iramanusantara.js
+++ b/src/connectors/iramanusantara.js
@@ -6,7 +6,7 @@ Connector.artistSelector = '#pl-info-text > h4';
 
 Connector.trackSelector = '#pl-info-text > h3';
 
-// Album title is only available when track is played through the album page 
+// Album title is only available when track is played through the album page
 Connector.albumSelector = '.ad-info-text1 > h1';
 
 Connector.playButtonSelector = '#pl-ctrl-play';

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1975,6 +1975,13 @@ const connectors = [{
 	],
 	js: 'connectors/radiocuca.js',
 	id: 'radiocuca',
+}, {
+	label: 'Irama Nusantara',
+	matches: [
+		'*://*.iramanusantara.org/*',
+	],
+	js: 'connectors/iramanusantara.js',
+	id: 'iramanusantara',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
New connector for the Indonesian music archive and streaming service iramanusantara.org. 
![kisahpasarbaru](https://user-images.githubusercontent.com/41536722/165218513-f7ac53ca-7d15-4d3f-a931-1210a7a0278c.png)

**Notes**
* The site does not currently keep track of which albums the tracks are from (playback is based on the album that the user is currently viewing), so album titles are fetched only if the track is being played directly from the album page.
