### PR TITLE
Minor CSS edit to fix small gap below image in popup

### DIFF
--- a/src/ui/popups/info.css
+++ b/src/ui/popups/info.css
@@ -33,6 +33,7 @@ input {
 	display: grid;
 	grid-template-columns: 136px 224px;
 	min-height: 136px;
+	overflow: hidden;
 }
 
 .popup-container {


### PR DESCRIPTION
Added overflow: hidden to .main-container
Alternate solution is to add display: block to .album-art
