### PR TITLE
Refine Amazon playButtonSelector

### DIFF
--- a/src/connectors/amazon.js
+++ b/src/connectors/amazon.js
@@ -50,7 +50,7 @@ function setupPropertiesForNewPlayer() {
 		return trackLink === '#';
 	};
 
-	Connector.playButtonSelector = 'music-button[icon-name=play]';
+	Connector.playButtonSelector = 'music-button[icon-name=play][variant=glass]';
 }
 
 function setupPropertiesForOldPlayer() {


### PR DESCRIPTION
in Amazon playlist view there are multiple `music-buttons` with `icon-name=play`, but only the music-button of interest also has `variant=glass`
fixes #3062
probably also #2604

**Describe the changes you made**
Added `variant=glass` to playButtonSelector, because the current playButtonSelector sometimes is not specific enough.
