### PR TITLE
Fix originUrl for Bandcamp collections

### DIFF
--- a/src/connectors/bandcamp.js
+++ b/src/connectors/bandcamp.js
@@ -140,7 +140,7 @@ function initPropertiesForCollectionsPlayer() {
 	Connector.trackArtSelector = '.now-playing img';
 
 	Connector.getOriginUrl = () => {
-		const buyNowAnchor = document.querySelector('.buy-now a');
+		const buyNowAnchor = document.querySelector('.playing .buy-now a');
 		if (buyNowAnchor === null) {
 			Util.debugLog('Failed to resolve originUrl');
 			return document.location.href;


### PR DESCRIPTION
**Describe the changes you made**
Added the `.playing` class to the DOM element selector which targets the currently playing element

**Additional context**
Fixing issue #3249, more context on the issue description
