### PR TITLE
Send more additional information to listenbrainz

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   "eslintConfig": {
     "extends": "web-scrobbler",
     "parserOptions": {
-      "sourceType": "script"
+      "sourceType": "script",
+      "ecmaVersion": 2020
     }
   },
   "prettier": "prettier-config-web-scrobbler",

--- a/src/connectors/spotify.js
+++ b/src/connectors/spotify.js
@@ -100,7 +100,7 @@ function getTrackUri() {
 
 	const url = new URL(contextLinkEl);
 	const trackUri = url.searchParams.get('uri');
-	const trackId = trackUri.split(':')?.[2];
+	const trackId = trackUri?.split(':')?.[2];
 	if (trackUri && trackUri.startsWith('spotify:track:') && trackId) {
 		const trackUrl = `https://open.spotify.com/track/${trackId}`;
 		return trackUrl;

--- a/src/connectors/spotify.js
+++ b/src/connectors/spotify.js
@@ -40,6 +40,8 @@ Connector.isPodcast = () => isPodcastPlaying();
 
 Connector.getUniqueID = () => getTrackUri();
 
+Connector.getOriginUrl = () => Connector.getUniqueID();
+
 function isMusicPlaying() {
 	return artistUrlIncludes('/artist/', '/show/') || isLocalFilePlaying();
 }
@@ -98,8 +100,10 @@ function getTrackUri() {
 
 	const url = new URL(contextLinkEl);
 	const trackUri = url.searchParams.get('uri');
-	if (trackUri && trackUri.startsWith('spotify:track:')) {
-		return trackUri;
+	const trackId = trackUri.split(':')?.[2];
+	if (trackUri && trackUri.startsWith('spotify:track:') && trackId) {
+		const trackUrl = `https://open.spotify.com/track/${trackId}`;
+		return trackUrl;
 	}
 
 	return null;

--- a/src/core/background/scrobbler/listenbrainz-scrobbler.js
+++ b/src/core/background/scrobbler/listenbrainz-scrobbler.js
@@ -284,6 +284,14 @@ define((require) => {
 				trackMeta.additional_info.release_artist_name = song.getAlbumArtist();
 			}
 
+			if (song.getUniqueId() && song.metadata.label === "Spotify") {
+				trackMeta.additional_info.spotify_id = song.getUniqueId();
+			}
+
+			if (song.getDuration()) {
+				trackMeta.additional_info.duration = song.getDuration();
+			}
+
 			return trackMeta;
 		}
 	}

--- a/src/core/background/scrobbler/listenbrainz-scrobbler.js
+++ b/src/core/background/scrobbler/listenbrainz-scrobbler.js
@@ -284,7 +284,7 @@ define((require) => {
 				trackMeta.additional_info.release_artist_name = song.getAlbumArtist();
 			}
 
-			if (song.getUniqueId() && song.metadata.label === "Spotify") {
+			if (song.getUniqueId() && song.metadata.label === 'Spotify') {
 				trackMeta.additional_info.spotify_id = song.getUniqueId();
 			}
 


### PR DESCRIPTION
As per API [spec](https://listenbrainz.readthedocs.io/en/latest/users/json.html#payload-json-details), send `duration` and `spotify_id` in `additional_info` 