### PR TITLE
Remove unneeded data from originUrl in listens on YouTube and embedded YouTube

### DIFF
--- a/src/connectors/youtube-embed.js
+++ b/src/connectors/youtube-embed.js
@@ -10,6 +10,16 @@
  */
 const VIDEO_SELECTOR = '.html5-main-video';
 
+function getVideoUrl() {
+	return $('.ytp-title-link').attr('href');
+}
+
+function getVideoId() {
+	const videoUrl = getVideoUrl();
+
+	return Util.getYtVideoIdFromUrl(videoUrl);
+}
+
 function setupConnector() {
 	const videoElement = $(VIDEO_SELECTOR);
 	// Skip frames with no video element
@@ -33,8 +43,7 @@ function setupConnector() {
 	};
 
 	Connector.getUniqueID = () => {
-		const videoUrl = $('.ytp-title-link').attr('href');
-		return Util.getYtVideoIdFromUrl(videoUrl);
+		return getVideoId();
 	};
 
 	Connector.applyFilter(MetadataFilter.getYoutubeFilter());

--- a/src/connectors/youtube-embed.js
+++ b/src/connectors/youtube-embed.js
@@ -42,6 +42,12 @@ function setupConnector() {
 		return $('.html5-video-player').hasClass('playing-mode');
 	};
 
+	Connector.getOriginUrl = () => {
+		const videoId = getVideoId();
+
+		return `https://youtu.be/${videoId}`;
+	};
+
 	Connector.getUniqueID = () => {
 		return getVideoId();
 	};

--- a/src/connectors/youtube.js
+++ b/src/connectors/youtube.js
@@ -101,6 +101,12 @@ Connector.isPlaying = () => {
 	return $('.html5-video-player').hasClass('playing-mode');
 };
 
+Connector.getOriginUrl = () => {
+	const videoId = getVideoId();
+
+	return `https://youtu.be/${videoId}`;
+};
+
 Connector.getUniqueID = () => {
 	if (areChaptersAvailable()) {
 		return null;


### PR DESCRIPTION
**Describe the changes you made**
Remove data from the link like playlist ID and potentially something else if there is ever anything other than video ID in it.
Not implemented for YouTube music as I have never used it, and it seems like the one place where it may make sense to keep the playlist ID.

**Additional context**
I used the short-hand YouTube links (`youtu.be`), this might make listen-tracking services save some storage space.
I did not test embedded YouTube.
Closes #3290.

Edit: It doesn't work on videos with chapters and I'm not sure why.