### PR TITLE
Update playlist-randomizer connector

### DIFF
--- a/src/connectors/playlist-randomizer.js
+++ b/src/connectors/playlist-randomizer.js
@@ -23,3 +23,4 @@ Connector.getArtistTrack = () => {
 };
 
 Connector.applyFilter(MetadataFilter.getYoutubeFilter());
+Connector.onReady = Connector.onStateChanged;

--- a/src/connectors/playlist-randomizer.js
+++ b/src/connectors/playlist-randomizer.js
@@ -2,9 +2,20 @@
 
 Connector.playerSelector = '#root';
 Connector.trackArtSelector = '.Mui-selected .MuiListItemAvatar-root .MuiAvatar-circular .MuiAvatar-img';
-Connector.playButtonSelector = 'button[title="Play"]';
 
 const trackSelector = '.Mui-selected .MuiListItemText-root .MuiListItemText-primary';
+
+Connector.isPlaying = () => {
+	const playButton = document.querySelector('button[title="Play"]');
+	const tooltip = document.querySelector('.MuiTooltip-popper');
+	const tooltipText = tooltip ? tooltip.innerText : '';
+
+	if (playButton || tooltipText.includes('Play')) {
+		return false;
+	}
+
+	return true;
+};
 
 Connector.getArtistTrack = () => {
 	const currentTrack = document.querySelector(trackSelector);
@@ -13,8 +24,7 @@ Connector.getArtistTrack = () => {
 	}
 	let { artist, track } = Util.processYtVideoTitle(currentTrack.firstChild.nodeValue);
 
-	// Set to some default information that we have (probably "Song Title Song Artist" with a space)
-	// so that the user can edit the info in the extension
+	// Set to some default information that we have so that the user can edit the info in the extension
 	if (!artist) {
 		const regex = /^(.*) - Topic$/;
 		artist = currentTrack.lastChild.innerText.replace(regex, '$1');

--- a/src/connectors/playlist-randomizer.js
+++ b/src/connectors/playlist-randomizer.js
@@ -1,20 +1,22 @@
 'use strict';
 
-Connector.playerSelector = '.MuiList-root';
-Connector.trackArtSelector = '.Mui-selected .MuiListItemAvatar-root .MuiAvatar-circle .MuiAvatar-img';
+Connector.playerSelector = '.MuiCard-root';
+Connector.trackArtSelector = '.Mui-selected .MuiListItemAvatar-root .MuiAvatar-circular .MuiAvatar-img';
 
 const trackSelector = '.Mui-selected .MuiListItemText-root .MuiListItemText-primary';
 
 Connector.getArtistTrack = () => {
-	let { artist, track } = Util.processYtVideoTitle(Util.getTextFromSelectors(trackSelector));
+	const currentTrack = document.querySelector(trackSelector);
+	let { artist, track } = Util.processYtVideoTitle(currentTrack.firstChild.nodeValue);
 
 	// Set to some default information that we have (probably "Song Title Song Artist" with a space)
 	// so that the user can edit the info in the extension
 	if (!artist) {
-		artist = Util.getTextFromSelectors(trackSelector);
+		const regex = /^(.*) - Topic$/;
+		artist = currentTrack.lastChild.innerText.replace(regex, '$1');
 	}
 	if (!track) {
-		track = Util.getTextFromSelectors(trackSelector);
+		track = currentTrack.firstChild.nodeValue;
 	}
 
 	return { artist, track };

--- a/src/connectors/playlist-randomizer.js
+++ b/src/connectors/playlist-randomizer.js
@@ -1,12 +1,15 @@
 'use strict';
 
-Connector.playerSelector = '.MuiCard-root';
+Connector.playerSelector = '#root';
 Connector.trackArtSelector = '.Mui-selected .MuiListItemAvatar-root .MuiAvatar-circular .MuiAvatar-img';
 
 const trackSelector = '.Mui-selected .MuiListItemText-root .MuiListItemText-primary';
 
 Connector.getArtistTrack = () => {
 	const currentTrack = document.querySelector(trackSelector);
+	if (!currentTrack) {
+		return;
+	}
 	let { artist, track } = Util.processYtVideoTitle(currentTrack.firstChild.nodeValue);
 
 	// Set to some default information that we have (probably "Song Title Song Artist" with a space)

--- a/src/connectors/playlist-randomizer.js
+++ b/src/connectors/playlist-randomizer.js
@@ -2,6 +2,7 @@
 
 Connector.playerSelector = '#root';
 Connector.trackArtSelector = '.Mui-selected .MuiListItemAvatar-root .MuiAvatar-circular .MuiAvatar-img';
+Connector.playButtonSelector = 'button[title="Play"]';
 
 const trackSelector = '.Mui-selected .MuiListItemText-root .MuiListItemText-primary';
 

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1798,6 +1798,7 @@ const connectors = [{
 	label: 'Playlist Randomizer',
 	matches: [
 		'*://www.playlist-randomizer.com/*',
+		'*://playlist-randomizer.com/*',
 	],
 	js: 'connectors/playlist-randomizer.js',
 	id: 'playlist-randomizer',


### PR DESCRIPTION
**Describe the changes you made**
Updated the playlist-randomizer connector to work since the dev changed some styles. The "www." was also dropped from the URL, so I added the version without it.

I'm not sure if there's something in the Util to better address "Artist - Topic" (provided by youtube) channel names, it looked like the other connectors were getting around that by using the video description rather than the channel name, which isn't available on this site.

One small bug I'm not sure how to fix, if the page is refreshed during play (or the user goes directly to a playlist link rather than via the homepage), the first song isn't scrobbled but all the rest will be.

**Additional context**
Fixes #3293