### PR TITLE
Only scrobble one artist in YouTube Music

### DIFF
--- a/src/connectors/youtube-music.js
+++ b/src/connectors/youtube-music.js
@@ -110,8 +110,7 @@ Connector.isScrobblingAllowed = () => !Util.isElementVisible(adSelector);
 
 function getArtists() {
 	// FIXME Use Array.from after jQuery support will be removed
-	const artistElements = Util.queryElements(artistSelectors);
-	return artistElements && Util.joinArtists(artistElements.toArray());
+	return Util.queryElements(artistSelectors).toArray()[0]?.textContent;
 }
 
 function filterYoutubeIfNonAlbum(text) {

--- a/src/connectors/youtube-music.js
+++ b/src/connectors/youtube-music.js
@@ -79,14 +79,14 @@ Connector.getArtistTrack = () => {
 	let track;
 
 	if (hasVideoAlbum()) {
-		artist = getArtists();
+		artist = getArtist();
 		track = Util.getTextFromSelectors(trackSelector);
 	} else {
 		({ artist, track } = Util.processYtVideoTitle(
 			Util.getTextFromSelectors(trackSelector)
 		));
 		if (!artist) {
-			artist = getArtists();
+			artist = getArtist();
 		}
 	}
 	return { artist, track };
@@ -108,8 +108,7 @@ Connector.getUniqueID = () => {
 
 Connector.isScrobblingAllowed = () => !Util.isElementVisible(adSelector);
 
-function getArtists() {
-	// FIXME Use Array.from after jQuery support will be removed
+function getArtist() {
 	return Util.queryElements(artistSelectors).toArray()[0]?.textContent;
 }
 


### PR DESCRIPTION
**Describe the changes you made**
Only scrobble the first artist in Youtube Music. Last.fm, the biggest music tracking service, only allows a single artist to be credited for each song. When the Web Scrobbler scrobbles multiple artists as a comma-separated string, it breaks compatibility with many of Last.fm's social features, such as identifying which songs and artists you share in common with other users. To maintain compatibility with Last.fm's single-artist paradigm for each song, the change made in this PR only scrobbles the first artist credited on a song, rather than comma-separating the entire list. 

**Additional context**
Example of Web Scrobbler scrobbling Phoenix by "League of Legends, Cailin Russo, Chrissy Costanza":
![image](https://user-images.githubusercontent.com/38502391/179424141-80b7df46-08a0-40d1-817e-b7e1c51f8986.png)
The actual song's entry in Last.fm, only by League of Legends:
![image](https://user-images.githubusercontent.com/38502391/179424160-e2e74d25-219c-47cf-93d2-1c74dfe1b74f.png)

By observing the global scrobble count, clearly the single-artist entry is the correct one. This is not a cherrypicked example - every example I have searched for with multiple artists follows the same pattern.