### PR TITLE
Send album and album artist data to maloja

### DIFF
--- a/src/core/background/scrobbler/maloja-scrobbler.js
+++ b/src/core/background/scrobbler/maloja-scrobbler.js
@@ -108,6 +108,14 @@ define((require) => {
 				time: song.metadata.startTimestamp,
 			};
 
+			if (song.getAlbum()) {
+				trackMeta.album = song.getAlbum();
+			}
+
+			if (song.getAlbumArtist()) {
+				trackMeta.albumartists = [song.getAlbumArtist()];
+			}
+
 			return trackMeta;
 		}
 	}


### PR DESCRIPTION
notes:
- `albumartists` accepts a list of artists[^1]. However, this will make a list with a single item, with all the artists joined together. it feels ‘hacky’ but i think that’s the best we can get at the moment.
- i didn’t include the `duration` because from what i've seen, `song.getDuration()` uses a duration of a song instead of duration of how long were you’ve been listening to it, as the api suggests.

[^1]: majola api: https://github.com/krateng/maloja/blob/master/API.md#submitting-a-scrobble