### PR TITLE
Provide way to release from GitHub UI

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -12,7 +12,7 @@ on:
         - major
 jobs:
   deploy:
-    name: Publish release on GitHub
+    name: Release a new extension version
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:
@@ -20,3 +20,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Release
         run: npx grunt release:${{ github.event.inputs.release-type }}
+        env:
+          CI: true

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -1,0 +1,21 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        type: choice
+        description: Release type
+        options:
+        - patch
+        - minor
+        - major
+jobs:
+  deploy:
+    name: Publish release on GitHub
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Release
+        run: npx grunt release:${{ github.event.inputs.release-type }}

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       release-type:
         type: choice
-        description: Release type
+        description: Release type (check uncommited draft release)
         options:
         - patch
         - minor

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -1,4 +1,5 @@
-name: Release
+name: Release extension
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BOT_PAT }}
       - name: Setup git config
         run: |
           git config user.name "${{ github.actor }}"

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -3,7 +3,7 @@ name: Release extension
 on:
   workflow_dispatch:
     inputs:
-      release-type:
+      release_type:
         type: choice
         description: Release type (check uncommited draft release)
         options:
@@ -17,8 +17,12 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - name: Setup git config
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "<>"
       - name: Release
-        run: npx grunt release:${{ github.event.inputs.release-type }}
+        run: npx grunt release:${{ inputs.release_type }}
         env:
           CI: true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,6 +49,8 @@ const DOC_FILES = [
 
 const isCi = process.env.CI === 'true';
 
+const BUMP_BRANCH = isCi ? 'origin' : 'upstream';
+
 module.exports = (grunt) => {
 	grunt.initConfig({
 		manifest: grunt.file.readJSON(MANIFEST_FILE),
@@ -161,6 +163,7 @@ module.exports = (grunt) => {
 				files: FILES_TO_BUMP,
 				updateConfigs: ['manifest'],
 				commitFiles: FILES_TO_BUMP,
+				pushTo: BUMP_BRANCH,
 			},
 		},
 


### PR DESCRIPTION
**Describe the changes you made**

Currently as a contributor I have to ensure I am on the latest master version of the code to be able to release.

This change introduces a new pipeline that you should be able to trigger from the UI to release with.

Modfied the [`pushTo`](https://github.com/vojtajina/grunt-bump#optionspushto) branch for when running on CI to help. 

Looks like we might need to use [PAT tokens](https://stackoverflow.com/questions/57921401/push-to-origin-from-github-action/58393457#58393457
) too :/ 

