### PR TITLE
Update connector for freegalmusic.com

### DIFF
--- a/src/connectors/freegalmusic.js
+++ b/src/connectors/freegalmusic.js
@@ -2,10 +2,34 @@
 
 Connector.playerSelector = '#player-section';
 
-Connector.artistTrackSelector = '.fp-title';
+Connector.pauseButtonSelector = '.fp-playbtn[title=Pause]';
 
-Connector.isPlaying = () => $('.fp-playbtn').prop('title') === 'Pause';
+Connector.trackSelector = '.playlist-player ul > li.active-playlist-song';
+
+Connector.getArtist = () => {
+	const artistTrackText = Util.getTextFromSelectors('.fp-message');
+
+	if (artistTrackText) {
+		return artistTrackText.split(' - ')[0]; // track title may be truncated or missing; only return artist
+	}
+
+	return null;
+};
+
+Connector.durationSelector = '.fp-duration';
 
 Connector.currentTimeSelector = '.fp-elapsed';
 
-Connector.durationSelector = '.fp-duration';
+Connector.isScrobblingAllowed = () => {
+	return (
+		Connector.getTrack() &&
+		Util.isElementVisible(Connector.playerSelector) &&
+		!Connector.getArtist().includes('Sorry, this song is not available for streaming at this time')
+	);
+};
+
+const filter = MetadataFilter.createFilter({
+	artist: (text) => text.split(/(?<!\d),(?!\s)/g)[0], // only first artist if comma-separated list of contributors
+});
+
+Connector.applyFilter(filter);


### PR DESCRIPTION
Updates made to Freegal connector for more accurate scrobbling information as provided within the limited, persistent player. Tested with my personal account and scrobbles are successful. Screenshots below.

Issues Resolved:

- Null track title, other error minor error handling with `isScrobblingAllowed`.
- Some of Freegal's metadata is very messy and includes a CSV-type list of contributors as the artist, which can include the actual artist, a songwriter, a producer, or any other contributor. This makes scrobbling very tedious for these albums, as it requires continued manual updating of the information. Typically, the first artist in the list is the correct and only performer of the song, so the rest are filtered out.
- Additionally, with this extended artist info being combined with the track title in the main player, sometimes the title can be truncated partially or completely. Previous version split the artist and title from one location, but this update pulls the title from the playlist on the right side instead.
<img width="1352" alt="" src="https://user-images.githubusercontent.com/6808988/185703713-8cade24e-d5a3-49ba-a903-b35ed81e3b24.png">

The incorrect metadata mostly seems to occur when the commas are not followed by a space, so any correct multi-artist metadata will still scrobble as expected. (Note the title completely truncated after the artist.)
<img width="1353" alt="" src="https://user-images.githubusercontent.com/6808988/185704332-ab2d3cf9-70c7-42aa-be5b-53d82cdd9bb5.png">

Additionally, a single artist with a comma in their name will also scrobble as expected.
<img width="1354" alt="" src="https://user-images.githubusercontent.com/6808988/185704520-b03b4206-0d3a-41ac-ac34-aece7e858f06.png">

And lastly, 10,000 Maniacs (or any other artist with a numerical comma, if there are any) will scrobble as expected.
<img width="1352" alt="" src="https://user-images.githubusercontent.com/6808988/185704707-4804aa91-e839-4624-be4f-1e278efc5606.png">

Continued Issues:

- Still no album title or artwork provided within the persistent player. (As seen in the previous screenshot, the album title and artwork do not match the album that is actually playing.)
- Really long titles are still truncated in both locations within the player, so those will need to be manually updated because the full title simply isn't provided.
<img width="1352" alt="" src="https://user-images.githubusercontent.com/6808988/185705116-9a585214-2c1f-4205-8d1c-cb86b9ebe16b.png">

- Additionally, there may be some edge cases where the artist will still need to be manually updated, depending on how the incorrect metadata is provided. But I tried to test as thoroughly as possible with artists I could find available on the site.

Current connector (from #1607) is still technically working, so no rush on releasing this.