### PR TITLE
Add MUSICat connector with support for 14 local library sites

### DIFF
--- a/src/connectors/musicat.js
+++ b/src/connectors/musicat.js
@@ -1,0 +1,29 @@
+'use strict';
+
+// MUSICat platform used by several local libraries: https://musicat.co/libraries
+
+Connector.playerSelector = '#player-wrapper';
+
+Connector.pauseButtonSelector = '.current-track .controls .pause-icon';
+
+Connector.trackSelector = '.current-track .album > div:first-of-type';
+
+Connector.getTrackInfo = () => {
+	const artistAlbumText = Util.getTextFromSelectors('.current-track .album .title');
+
+	if (artistAlbumText) {
+		return Util.splitArtistAlbum(artistAlbumText, [', ']);
+	}
+
+	return null;
+};
+
+Connector.getTrackArt = () => {
+	const trackArtUrl = Util.extractImageUrlFromSelectors('.current-track .album img.art');
+
+	if (trackArtUrl) {
+		return trackArtUrl.replace(/(?<=scale_width=)\d{3}/g, '540'); // larger image filename
+	}
+
+	return null;
+};

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -704,6 +704,104 @@ const connectors = [{
 	js: 'connectors/hoopladigital.js',
 	id: 'hoopladigital',
 }, {
+	label: 'Amplify 817',
+	matches: [
+		'*://amplify817.org/*',
+	],
+	js: 'connectors/musicat.js',
+	id: 'amplify817',
+}, {
+	label: 'Capital City Records',
+	matches: [
+		'*://capitalcityrecords.ca/*',
+	],
+	js: 'connectors/musicat.js',
+	id: 'capitalcityrecords',
+}, {
+	label: 'Electric Lady Bird',
+	matches: [
+		'*://atxlibrary.musicat.co/*',
+	],
+	js: 'connectors/musicat.js',
+	id: 'musicat-atxlibrary',
+}, {
+	label: 'FlipSide',
+	matches: [
+		'*://flipside.apl.org/*',
+	],
+	js: 'connectors/musicat.js',
+	id: 'apl-flipside',
+}, {
+	label: 'HUM (Hear Utah Music)',
+	matches: [
+		'*://hum.slcpl.org/*',
+	],
+	js: 'connectors/musicat.js',
+	id: 'slcpl-hum',
+}, {
+	label: 'KDL Vibes',
+	matches: [
+		'*://vibes.kdl.org/*',
+	],
+	js: 'connectors/musicat.js',
+	id: 'kdl-vibes',
+}, {
+	label: 'Library Music Project',
+	matches: [
+		'*://librarymusicproject.com/*',
+	],
+	js: 'connectors/musicat.js',
+	id: 'librarymusicproject',
+}, {
+	label: 'MNspin',
+	matches: [
+		'*://hclib.musicat.co/*',
+	],
+	js: 'connectors/musicat.js',
+	id: 'musicat-hclib',
+}, {
+	label: 'Nashville BoomBox',
+	matches: [
+		'*://boombox.library.nashville.org/*',
+	],
+	js: 'connectors/musicat.js',
+	id: 'nashville-library-boombox',
+}, {
+	label: 'QC Beats',
+	matches: [
+		'*://qcbeats.org/*',
+	],
+	js: 'connectors/musicat.js',
+	id: 'qcbeats',
+}, {
+	label: 'Sawdust City Sounds',
+	matches: [
+		'*://sawdustcitysounds.org/*',
+	],
+	js: 'connectors/musicat.js',
+	id: 'sawdustcitysounds',
+}, {
+	label: 'Seattle PlayBack',
+	matches: [
+		'*://playback.spl.org/*',
+	],
+	js: 'connectors/musicat.js',
+	id: 'spl-playback',
+}, {
+	label: 'STACKS',
+	matches: [
+		'*://stacks.carnegielibrary.org/*',
+	],
+	js: 'connectors/musicat.js',
+	id: 'carnegielibrary-stacks',
+}, {
+	label: 'Tracks Music Library',
+	matches: [
+		'*://tracksmusiclibrary.org/*',
+	],
+	js: 'connectors/musicat.js',
+	id: 'tracksmusiclibrary',
+}, {
 	label: 'Monstercat',
 	matches: [
 		'*://www.monstercat.com/*',
@@ -1732,10 +1830,9 @@ const connectors = [{
 	js: 'connectors/ragya.js',
 	id: 'ragya',
 }, {
-
 	label: 'CodeRadio',
 	matches: [
-		'https://coderadio.freecodecamp.org/*',
+		'*://coderadio.freecodecamp.org/*',
 	],
 	js: 'connectors/coderadio.js',
 	id: 'coderadio',
@@ -2026,7 +2123,7 @@ const connectors = [{
 }, {
 	label: 'Nonoki',
 	matches: [
-		'https://nonoki.com/music/*',
+		'*://nonoki.com/music/*',
 	],
 	js: 'connectors/nonoki.js',
 	id: 'nonoki',


### PR DESCRIPTION
Added support for 14 local library sites, which all use the MUSICat platform: https://musicat.co/libraries

One connector file (musicat.js) is used for all sites. Tested each site and scrobbling is successful.

Unlike other library sites, such as Freegal or hoopla, no library card login is required to listen to the available music. Example album links from each site provided below for additional testing/verification.

- Amplify 817 - https://amplify817.org/albums/driving-slow-motion-arda
- Capital City Records - https://capitalcityrecords.ca/albums/golden-grey-8-bit-machine
- Electric Lady Bird - https://atxlibrary.musicat.co/albums/john-dixon-attack-of-the-demons-soundtrack
- FlipSide - https://flipside.apl.org/albums/james-hall-lattice
- HUM (Hear Utah Music) - https://hum.slcpl.org/albums/ava-lux-princess-heaven
- KDL Vibes - https://vibes.kdl.org/albums/eli-kahn-how-are-you-no-really-how-are-you
- Library Music Project - https://librarymusicproject.com/albums/boink-something-colorful-for-sure
- MNspin - https://hclib.musicat.co/albums/ie-pome
- Nashville BoomBox - https://boombox.library.nashville.org/albums/jay-leo-phillips-one-million-one-million-one-million
- QC Beats - https://qcbeats.org/albums/kumate-69-chambers
- Sawdust City Sounds - https://sawdustcitysounds.org/albums/tonebox-last-encryption
- Seattle PlayBack - https://playback.spl.org/albums/acid-tongue-bullies
- STACKS - https://stacks.carnegielibrary.org/albums/else-collective-else-collective
- Tracks Music Library - https://tracksmusiclibrary.org/albums/dustlights-in-a-stillness
