### PR TITLE
Update project version in package-lock to 2.69.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "web-scrobbler",
-      "version": "2.68.0",
+      "version": "2.69.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
**Describe the changes you made**
When I ran `npm install` locally this file updated. The latest version release is 2.69.0, which matches the version in package.json.

**Additional context**
None
