### PR TITLE
Minor edit to MUSICat connector to fix blurry artwork in playlist

### DIFF
--- a/src/connectors/musicat.js
+++ b/src/connectors/musicat.js
@@ -22,7 +22,7 @@ Connector.getTrackArt = () => {
 	const trackArtUrl = Util.extractImageUrlFromSelectors('.current-track .album img.art');
 
 	if (trackArtUrl) {
-		return trackArtUrl.replace(/(?<=scale_width=)\d{3}/g, '540'); // larger image filename
+		return trackArtUrl.replace(/(?<=scale_width=)\d+/g, '540'); // larger image filename
 	}
 
 	return null;


### PR DESCRIPTION
Super minor edit to #3345

Some of the MUSICat library sites also include playlists, in addition to the album streams. The playlist uses the same persistent player as the albums, but the image width values are different—135 for album and only 28 for playlist. The previous regex was only replacing 3 digits, resulting in no value replacement on the playlist and very blurry artwork shown in the extension popup. Updated to replace any digits, no matter the length.

Playlist example: https://vibes.kdl.org/featured/playlist-1643220626398
Album example: https://vibes.kdl.org/albums/eli-kahn-how-are-you-no-really-how-are-you