### PR TITLE
Minor CSS edits for popup

### DIFF
--- a/src/ui/popups/info.css
+++ b/src/ui/popups/info.css
@@ -40,8 +40,7 @@ input {
 	display: grid;
 	grid-template-columns: 209px;
 	grid-template-rows: auto auto;
-	margin: 5px;
-	margin-left: 10px;
+	margin: 5px 5px 5px 10px;
 }
 
 .debug-container {
@@ -58,6 +57,7 @@ input {
 	grid-row: 1;
 	height: 136px;
 	width: 136px;
+	object-fit: cover;
 }
 
 .edit-fields,

--- a/src/ui/popups/info.css
+++ b/src/ui/popups/info.css
@@ -10,9 +10,9 @@ body {
 	background-color: #fff;
 	color: #212529;
 	font-size: 13px;
-	margin: 0px;
+	margin: 0;
 	overflow: hidden;
-	padding: 0px;
+	padding: 0;
 	width: max-content;
 }
 
@@ -56,8 +56,8 @@ input {
 	grid-column: 1;
 	grid-row: 1;
 	height: 136px;
-	width: 136px;
 	object-fit: cover;
+	width: 136px;
 }
 
 .edit-fields,


### PR DESCRIPTION
While working on connectors for MUSICat sites and Dandelion Radio, I noticed that we're not always going to have access to clean, square artwork to feed into the extension popup. Unfortunately, when any rectangular image was used in the popup, it was distorted to fit into a square space.
To let the image automatically crop to a square instead of distorting, I added `object-fit: cover` to the `.album-art` CSS rule. (Additionally, I combined 2 properties in another rule into one for the popup-container margin.)

Examples of non-square artwork:

- Nearly every artist image provided in the bio area on https://www.dandelionradio.com/player.htm
- https://librarymusicproject.com/albums/megan-diana-women-in-my-head
- https://amplify817.org/albums/late-to-the-station-just-us
- https://amplify817.org/albums/elise-amara-soul-haven