### PR TITLE
Add new connector for KJazz 88.1

### DIFF
--- a/src/connectors/listenlive.js
+++ b/src/connectors/listenlive.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Connector.playerSelector = '#nowPlaying';
+
+Connector.artistSelector = '.nowPlayingCard .song .artist';
+
+Connector.trackSelector = '.nowPlayingCard .song .title';
+
+Connector.isPlaying = () => Util.hasElementClass('#nowPlaying', 'hasSong');

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -859,6 +859,14 @@ const connectors = [{
 	js: 'connectors/jazz24.js',
 	id: 'jazz24',
 }, {
+	label: 'KJazz 88.1',
+	matches: [
+		'*://kkjz.org/',
+		'*://player.listenlive.co/67941',
+	],
+	js: 'connectors/listenlive.js',
+	id: 'kkjz',
+}, {
 	label: 'Planet Radio',
 	matches: [
 		'*://planetradio.co.uk/*/player/*',


### PR DESCRIPTION
Added a new connector for KJazz 88.1, whose main site is https://kkjz.org/

Streaming player is at https://player.listenlive.co/67941 so JS connector file is listenlive.js

Tested and confirmed scrobbling.