### PR TITLE
Implement "love track" feature for listenbrainz (closes #3212)

### DIFF
--- a/src/core/background/scrobbler/listenbrainz-scrobbler.js
+++ b/src/core/background/scrobbler/listenbrainz-scrobbler.js
@@ -11,7 +11,8 @@ define((require) => {
 	const ServiceCallResult = require('object/service-call-result');
 
 	const listenBrainzTokenPage = 'https://listenbrainz.org/profile/';
-	const apiUrl = 'https://api.listenbrainz.org/1/submit-listens';
+	const baseUrl = 'https://api.listenbrainz.org/1';
+	const apiUrl = `${baseUrl}/submit-listens`;
 
 	class ListenBrainz extends BaseScrobbler {
 		/** @override */
@@ -137,7 +138,7 @@ define((require) => {
 					},
 				],
 			};
-			return this.sendRequest(params, sessionID);
+			return this.sendScrobbleRequest(params, sessionID);
 		}
 
 		/** @override */
@@ -153,21 +154,66 @@ define((require) => {
 					},
 				],
 			};
-			return this.sendRequest(params, sessionID);
+			return this.sendScrobbleRequest(params, sessionID);
+		}
+
+
+		/** @override */
+		async toggleLove(song, isLoved) {
+			// https://listenbrainz.readthedocs.io/en/latest/users/api-usage.html#lookup-mbids
+			const lookupRequestParams = new URLSearchParams({
+				recording_name: song.getTrack(),
+				artist_name: song.getArtist()
+			});
+
+			let lookupResult = {};
+
+			try {
+				lookupResult = await this.listenBrainzApi('GET', `${baseUrl}/metadata/lookup?${lookupRequestParams}`, null, null);
+			} catch (e) {}
+
+			this.debugLog(`lookup result: ${JSON.stringify(lookupResult, null, 2)}`)
+
+			if (lookupResult.recording_mbid) {
+				// https://listenbrainz.readthedocs.io/en/latest/users/api-usage.html#love-hate-feedback
+				const { sessionID } = await this.getSession();
+				const loveRequestBody = {
+					recording_mbid: lookupResult.recording_mbid,
+					score: isLoved ? 1 : 0
+				};
+				const loveResult = await this.listenBrainzApi('POST', `${baseUrl}/feedback/recording-feedback`, loveRequestBody, sessionID);
+
+				return this.processResult(loveResult);
+			} else {
+				this.debugLog(`Could not lookup metadata for song: ${song}`);
+			}
+		}
+
+		/** @override */
+		canLoveSong() {
+			return true;
 		}
 
 		/** Private methods. */
 
-		async sendRequest(params, sessionID) {
+
+		async listenBrainzApi(method, url, body, sessionID) {
 			const requestInfo = {
-				method: 'POST',
+				method: method,
 				headers: {
-					Authorization: `Token ${sessionID}`,
-					'Content-Type': 'application/json; charset=UTF-8',
-				},
-				body: JSON.stringify(params),
+					'Content-Type': 'application/json; charset=UTF-8'
+				}
 			};
-			const promise = fetch(this.userApiUrl || apiUrl, requestInfo);
+
+			if (body) {
+				requestInfo.body = JSON.stringify(body)
+			}
+
+			if (sessionID != null) {
+				requestInfo.headers.Authorization = `Token ${sessionID}`;
+			}
+
+			const promise = fetch(url, requestInfo);
 			const timeout = BaseScrobbler.REQUEST_TIMEOUT;
 
 			let result = null;
@@ -192,6 +238,11 @@ define((require) => {
 
 			this.debugLog(JSON.stringify(result, null, 2));
 
+			return result;
+		}
+
+		async sendScrobbleRequest(params, sessionID) {
+			const result = await this.listenBrainzApi('POST', this.userApiUrl || apiUrl, params, sessionID);
 			return this.processResult(result);
 		}
 

--- a/src/core/background/scrobbler/listenbrainz-scrobbler.js
+++ b/src/core/background/scrobbler/listenbrainz-scrobbler.js
@@ -163,7 +163,7 @@ define((require) => {
 			// https://listenbrainz.readthedocs.io/en/latest/users/api-usage.html#lookup-mbids
 			const lookupRequestParams = new URLSearchParams({
 				recording_name: song.getTrack(),
-				artist_name: song.getArtist()
+				artist_name: song.getArtist(),
 			});
 
 			let lookupResult = {};
@@ -172,20 +172,20 @@ define((require) => {
 				lookupResult = await this.listenBrainzApi('GET', `${baseUrl}/metadata/lookup?${lookupRequestParams}`, null, null);
 			} catch (e) {}
 
-			this.debugLog(`lookup result: ${JSON.stringify(lookupResult, null, 2)}`)
+			this.debugLog(`lookup result: ${JSON.stringify(lookupResult, null, 2)}`);
 
-			if (lookupResult.recording_mbid) {
+			if (!lookupResult.recording_mbid) {
+				this.debugLog(`Could not lookup metadata for song: ${song}`);
+			} else {
 				// https://listenbrainz.readthedocs.io/en/latest/users/api-usage.html#love-hate-feedback
 				const { sessionID } = await this.getSession();
 				const loveRequestBody = {
 					recording_mbid: lookupResult.recording_mbid,
-					score: isLoved ? 1 : 0
+					score: isLoved ? 1 : 0,
 				};
 				const loveResult = await this.listenBrainzApi('POST', `${baseUrl}/feedback/recording-feedback`, loveRequestBody, sessionID);
 
 				return this.processResult(loveResult);
-			} else {
-				this.debugLog(`Could not lookup metadata for song: ${song}`);
 			}
 		}
 
@@ -199,17 +199,17 @@ define((require) => {
 
 		async listenBrainzApi(method, url, body, sessionID) {
 			const requestInfo = {
-				method: method,
+				method,
 				headers: {
-					'Content-Type': 'application/json; charset=UTF-8'
-				}
+					'Content-Type': 'application/json; charset=UTF-8',
+				},
 			};
 
 			if (body) {
-				requestInfo.body = JSON.stringify(body)
+				requestInfo.body = JSON.stringify(body);
 			}
 
-			if (sessionID != null) {
+			if (sessionID) {
 				requestInfo.headers.Authorization = `Token ${sessionID}`;
 			}
 


### PR DESCRIPTION
**Describe the changes you made**
This implements the "love track" feature for listenbrainz. I refactored the scrobbler code a tiny bit to be able to reuse some of the code.

**Additional context**
You can love and un-love a track while playing it. It does not correctly show whether a track has already been loved before, in which case pressing the heart button is a no-op (the track stays loved).
