### PR TITLE
fix: update yt music connector playingPath variable

### DIFF
--- a/src/connectors/youtube-music.js
+++ b/src/connectors/youtube-music.js
@@ -51,7 +51,7 @@ const adSelector = '.ytmusic-player-bar.advertisement';
 
 const playButtonSelector =
 	'.ytmusic-player-bar.play-pause-button #icon > svg > g > path';
-const playingPath = 'M6 19h4V5H6v14zm8-14v14h4V5h-4z';
+const playingPath = 'M9,19H7V5H9ZM17,5H15V19h2Z';
 
 Connector.playerSelector = 'ytmusic-player-bar';
 


### PR DESCRIPTION
**Describe the changes you made**
The Youtube Music connector stopped working after a UI update. Reading the opened [issue](https://github.com/web-scrobbler/web-scrobbler/issues/3371) and implementing the proposed solution by @forsureitsme could make it work again.