### PR TITLE
Refactor KJazz connector for general use as Listen Live

### DIFF
--- a/src/connectors/listenlive.js
+++ b/src/connectors/listenlive.js
@@ -6,4 +6,26 @@ Connector.artistSelector = '.nowPlayingCard .song .artist';
 
 Connector.trackSelector = '.nowPlayingCard .song .title';
 
+Connector.getAlbum = () => {
+	const albumText = Util.getTextFromSelectors('.nowPlayingCard .song .album');
+
+	if (albumText && !albumText.includes('{album}')) {
+		return albumText;
+	}
+
+	return null;
+};
+
+Connector.getTrackArt = () => {
+	const trackArtUrl = Util.extractImageUrlFromSelectors('.nowPlayingCard figure img');
+
+	if (trackArtUrl) {
+		return trackArtUrl.replace(/(?<=\/)\d+x\d+/g, '300x300'); // larger image path
+	}
+
+	return null;
+};
+
+Connector.isTrackArtDefault = (url) => url.includes('default');
+
 Connector.isPlaying = () => Util.hasElementClass('#nowPlaying', 'hasSong');

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -907,13 +907,12 @@ const connectors = [{
 	js: 'connectors/wostreaming.js',
 	id: 'jazz24',
 }, {
-	label: 'KJazz 88.1',
+	label: 'Listen Live',
 	matches: [
-		'*://kkjz.org/',
-		'*://player.listenlive.co/67941',
+		'*://player.listenlive.co/*',
 	],
 	js: 'connectors/listenlive.js',
-	id: 'kkjz',
+	id: 'listenlive',
 }, {
 	label: 'Planet Radio',
 	matches: [


### PR DESCRIPTION
Update to #3362. Initiated discussion at #3366 prior to submitting this but didn't receive any replies.

In short, I ended up agreeing with @jaccarmac's comments as far as making this a more general connector. I found several more stations using Listen Live, and it just made sense to refactor the connector to work automatically for them instead of manually adding each one to connectors.js.

Also added support for artwork and album text, which were not used on KJazz, for any other stations that may use them.

Here are all of the stations using Listen Live that I have found so far, and this connector should now work for all of them:
https://player.listenlive.co/67941
https://player.listenlive.co/35541
https://player.listenlive.co/42241
https://player.listenlive.co/44461
https://player.listenlive.co/50151
https://player.listenlive.co/55891
https://player.listenlive.co/63411
https://player.listenlive.co/63431
https://player.listenlive.co/64101
https://player.listenlive.co/64111
https://player.listenlive.co/64121
https://player.listenlive.co/64131