### PR TITLE
Refactor Jazz24 + others for general use via WO Streaming

### DIFF
--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -851,61 +851,12 @@ const connectors = [{
 	js: 'connectors/radioultra.js',
 	id: 'radiojazzfm',
 }, {
-	label: 'WXBQ 96.9',
+	label: 'WO Streaming',
 	matches: [
-		'*://www.969wxbq.com/',
-		'*://*player.wostreaming.net/8773',
+		'*://*player.wostreaming.net/*',
 	],
 	js: 'connectors/wostreaming.js',
-	id: '969wxbq',
-}, {
-	label: 'Electric 94.9',
-	matches: [
-		'*://www.electric949.com/',
-		'*://*player.wostreaming.net/8774',
-	],
-	js: 'connectors/wostreaming.js',
-	id: 'electric949',
-}, {
-	label: '99.3 The X',
-	matches: [
-		'*://www.993thex.com/',
-		'*://*player.wostreaming.net/8775',
-	],
-	js: 'connectors/wostreaming.js',
-	id: '993thex',
-}, {
-	label: 'WQBE 97.5',
-	matches: [
-		'*://www.wqbe.com/',
-		'*://*player.wostreaming.net/8777',
-	],
-	js: 'connectors/wostreaming.js',
-	id: 'wqbe',
-}, {
-	label: 'Electric 102.7',
-	matches: [
-		'*://electric102.com/*',
-		'*://*player.wostreaming.net/8778',
-	],
-	js: 'connectors/wostreaming.js',
-	id: 'electric102',
-}, {
-	label: 'New Life 94.5',
-	matches: [
-		'*://newlife945.com/',
-		'*://*player.wostreaming.net/8779',
-	],
-	js: 'connectors/wostreaming.js',
-	id: 'newlife945',
-}, {
-	label: 'Jazz24',
-	matches: [
-		'*://www.jazz24.org/',
-		'*://*player.wostreaming.net/854',
-	],
-	js: 'connectors/wostreaming.js',
-	id: 'jazz24',
+	id: 'wostreaming',
 }, {
 	label: 'KJazz 88.1',
 	matches: [


### PR DESCRIPTION
Update to #3363. Initiated discussion at #3366 prior to submitting this but didn't receive any replies.

In short, I ended up agreeing with @jaccarmac's comments as far as making this a more general connector. Considering the number of stations using WO Streaming and potentially others that have yet to be found, it just made sense to refactor the connector to work automatically for them instead of manually adding each one to connectors.js.

I eventually want to figure out a way to allow support for podcasts, as are available on Jazz24, but wasn't able to manage the transition between the two. Will look into that more at another time.

Here are all of the stations using WO Streaming that have been found so far, and this connector should work for all of them:
https://v7player.wostreaming.net/854
https://v7player.wostreaming.net/8773
https://v7player.wostreaming.net/8774
https://v7player.wostreaming.net/8775
https://v7player.wostreaming.net/8777
https://v7player.wostreaming.net/8778
https://v7player.wostreaming.net/8779