### PR TITLE
Add connector for Totally Wired Radio

### DIFF
--- a/src/connectors/totallywiredradio.js
+++ b/src/connectors/totallywiredradio.js
@@ -1,0 +1,32 @@
+'use strict';
+
+Connector.playerSelector = '.the_wrapper';
+
+Connector.getTrackInfo = () => {
+	const trackElement = document.querySelector('#headerLiveHolderNow .now-playing-bar .current');
+
+	if (trackElement) {
+		return {
+			artist: 'Totally Wired Radio', // individual artist info not provided
+			track: trackElement.childNodes[2].textContent, // name of show
+		};
+	}
+
+	return null;
+};
+
+Connector.trackArtSelector = '#CurrentShowImage img'; // only available in popup player
+
+Connector.currentTimeSelector = '#time-elapsed';
+
+Connector.remainingTimeSelector = '#time-remaining';
+
+Connector.isPlaying = () => Util.hasElementClass('a.AudioPlay', 'AudioPause');
+
+Connector.isPodcast = () => true;
+
+const filter = MetadataFilter.createFilter({
+	track: (text) => text.replace(' #live', ''), // remove #live hash appended to some shows
+});
+
+Connector.applyFilter(filter);

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2198,6 +2198,14 @@ const connectors = [{
 	],
 	js: 'connectors/kcrw.js',
 	id: 'kcrw',
+}, {
+	label: 'Totally Wired Radio',
+	matches: [
+		'*://totallywiredradio.com/',
+		'*://totallywiredradio.com/player/',
+	],
+	js: 'connectors/totallywiredradio.js',
+	id: 'totallywiredradio',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
New connector for Totally Wired Radio. This one is a bit different, as it does not provide individual artist and track info during its streams. As such, the artist is set to "Totally Wired Radio," and `isPodcast` is set to true. Last.fm already has an artist for TWR https://www.last.fm/music/Totally+Wired+Radio —presumably from people scrobbling via Mixcloud.

TWR stream is available at https://totallywiredradio.com/ and https://totallywiredradio.com/player/

If this doesn't make sense to add to the connector, since it doesn't include artist/track info, that is understandable so feel free to decline. Added in consideration of anybody who may want to keep track of listening to the shows on this station.