### PR TITLE
Update Mixcloud connector

### DIFF
--- a/src/connectors/mixcloud.js
+++ b/src/connectors/mixcloud.js
@@ -4,26 +4,60 @@ const filter = MetadataFilter.createFilter({
 	artist: [removeByPrefix, removeBuySuffix],
 });
 
-Connector.playerSelector = '[class*=playerQueue__PlayerWrapper]';
+Connector.playerSelector = '[class^=playerQueue__PlayerWrapper-]';
 
-Connector.artistSelector = '[class*=PlayerSliderComponent__Artist]';
+const trackInfoSelector = '[class^=PlayerSliderComponent__PlayerTrackInfo-]';
 
-Connector.trackSelector = '[class*=PlayerSliderComponent__Track]';
+Connector.getTrackInfo = () => {
+	const artistTrackElement = document.querySelector(trackInfoSelector);
+	let artistText;
+	let trackText;
+	let trackArtUrl;
+	let currentTimeValue;
+	let remainingTimeValue;
+	let podcastBoolean;
 
-Connector.playButtonSelector = '[aria-label=Play]';
+	if (artistTrackElement && artistTrackElement.hasChildNodes()) {
+		artistText = Util.getTextFromSelectors('[class*=PlayerSliderComponent__Artist-]');
+		trackText = Util.getTextFromSelectors('[class*=PlayerSliderComponent__Track-]');
+		podcastBoolean = false;
+
+	} else if (artistTrackElement && !artistTrackElement.hasChildNodes()) {
+		artistText = Util.getTextFromSelectors('[class^=PlayerControls__ShowOwnerName-]');
+		trackText = Util.getTextFromSelectors('[class*=PlayerControls__ShowTitle-]');
+		trackArtUrl = Util.extractImageUrlFromSelectors('[class^=PlayerControls__ShowPicture-] > img')
+			.replace(/(?<=\/)\d+x\d+(?=\/)/g, '300x300'); // larger image path
+		currentTimeValue = Util.getSecondsFromSelectors('[class^=PlayerSliderComponent__StartTime-]');
+		remainingTimeValue = Util.getSecondsFromSelectors('[class^=PlayerSliderComponent__EndTime-]');
+		podcastBoolean = true;
+	}
+
+	return {
+		artist: artistText,
+		track: trackText,
+		trackArt: trackArtUrl,
+		currentTime: currentTimeValue,
+		duration: -remainingTimeValue + currentTimeValue,
+		isPodcast: podcastBoolean,
+	};
+};
+
+Connector.isPlaying = () => Util.getAttrFromSelectors('[class^=PlayButton__PlayerControl-]', 'aria-label') === 'Pause';
 
 Connector.isStateChangeAllowed = () => {
 	/*
 	 * Mixcloud player hides artist and track elements while seeking the stream,
 	 * and we should not update state in such case.
 	 */
-	return Connector.getArtist() || Connector.getTrack();
+	return Connector.getTrackInfo() && Util.isElementVisible(trackInfoSelector);
 };
+
+Connector.isScrobblingAllowed = () => Connector.isStateChangeAllowed();
 
 Connector.applyFilter(filter);
 
 function removeByPrefix(text) {
-	return text.replace('by ', '');
+	return text.replace(/^by\s/g, '');
 }
 
 function removeBuySuffix(text) {

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -253,7 +253,7 @@ const connectors = [{
 	js: 'connectors/tunein.js',
 	id: 'tunein',
 }, {
-	label: 'MixCloud',
+	label: 'Mixcloud',
 	matches: [
 		'*://mixcloud.com/*',
 		'*://*.mixcloud.com/*',


### PR DESCRIPTION
While working on #3387, I went to their Mixcloud page and thought that the Mixcloud connector wasn't working. What I eventually realized is that it works only when individual artist/track info is provided but appears to be broken otherwise. This may be why issue #3313 was opened, but it doesn't provide any details.

Updated Mixcloud connector to work whether artist/track info is provided or not. If artist/track info is not provided, the selectors are adjusted and `isPodcast` is set to true. Added checks to ensure that the connector doesn't incorrectly switch between the two. Also updated label to "Mixcloud" instead of "MixCloud."

Example with artist/track info: https://www.mixcloud.com/totallywiredradio/duvet-rustling-jazz-alan-mckinnon-170922/
Example without artist/track info: https://www.mixcloud.com/totallywiredradio/underlying-oddities-martha-cleary-150922/
