### PR TITLE
Add connector for XRAY.FM

### DIFF
--- a/src/connectors/xrayfm.js
+++ b/src/connectors/xrayfm.js
@@ -1,0 +1,19 @@
+'use strict';
+
+Connector.playerSelector = '#audio-toolbar';
+
+Connector.pauseButtonSelector = '#audio-toolbar .stop-button';
+
+Connector.getArtistTrack = () => {
+	const artistTrackText = Util.getTextFromSelectors('#current-track a[href$=playlist]');
+
+	if (artistTrackText && !artistTrackText.includes('{{data.')) {
+		return Util.splitArtistTrack(artistTrackText);
+	}
+
+	return null;
+};
+
+Connector.isScrobblingAllowed = () => {
+	return Connector.getArtistTrack() && Util.isElementVisible('#current-track');
+};

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2209,6 +2209,14 @@ const connectors = [{
 	],
 	js: 'connectors/hardtunes.js',
 	id: 'hardtunes',
+}, {
+	label: 'XRAY.FM',
+	matches: [
+		'*://xray.fm/*',
+		'*://www.xray.fm/*',
+	],
+	js: 'connectors/xrayfm.js',
+	id: 'xrayfm',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
Most of their daytime programming appears to be talk radio—some of their own and some syndicated, so it didn't make sense to include recognition of that programming in the connector.

Connector will only work when artist and track info is provided, which is simultaneously populated on https://xray.fm/playlist (to get an idea of what times of the day they play music).

Set up to work on both https://xray.fm/ and https://www.xray.fm/ because a user could visit either one and won't be redirected.