### PR TITLE
Update Amazon connector

### DIFF
--- a/src/connectors/amazon.js
+++ b/src/connectors/amazon.js
@@ -28,29 +28,27 @@ function setupPropertiesForNewPlayer() {
 
 	Connector.getTrackInfo = () => {
 		const trackContainer = document.querySelector(trackContainerSelector);
-		if (trackContainer === null) {
-			return null;
+
+		if (trackContainer) {
+			const artist = trackContainer.getAttribute('secondary-text');
+			const track = trackContainer.getAttribute('primary-text');
+			const trackArt = trackContainer.getAttribute('image-src');
+
+			return { artist, track, trackArt };
 		}
 
-		const artist = trackContainer.getAttribute('secondary-text');
-		const track = trackContainer.getAttribute('primary-text');
-		const trackArt = trackContainer.getAttribute('image-src');
-
-		return { artist, track, trackArt };
+		return null;
 	};
 
 	Connector.isScrobblingAllowed = () => {
-		const trackLink = Util.getAttrFromSelectors(
-			trackContainerSelector,
-			'primary-href'
-		);
+		const trackLink = Util.getAttrFromSelectors(trackContainerSelector, 'primary-href');
 
 		// NOTE Regular tracks have no link
 		// Check this condition first if the connector does not work
 		return trackLink === '#';
 	};
 
-	Connector.playButtonSelector = 'music-button[icon-name=play][variant=glass]';
+	Connector.pauseButtonSelector = `${playerBarSelector} music-button[icon-name=pause]`;
 }
 
 function setupPropertiesForOldPlayer() {

--- a/src/connectors/amazon.js
+++ b/src/connectors/amazon.js
@@ -28,16 +28,15 @@ function setupPropertiesForNewPlayer() {
 
 	Connector.getTrackInfo = () => {
 		const trackContainer = document.querySelector(trackContainerSelector);
-
-		if (trackContainer) {
-			const artist = trackContainer.getAttribute('secondary-text');
-			const track = trackContainer.getAttribute('primary-text');
-			const trackArt = trackContainer.getAttribute('image-src');
-
-			return { artist, track, trackArt };
+		if (trackContainer === null) {
+			return null;
 		}
 
-		return null;
+		const artist = trackContainer.getAttribute('secondary-text');
+		const track = trackContainer.getAttribute('primary-text');
+		const trackArt = trackContainer.getAttribute('image-src');
+
+		return { artist, track, trackArt };
 	};
 
 	Connector.isScrobblingAllowed = () => {

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -84,7 +84,7 @@ const connectors = [{
 	js: 'connectors/soundcloud.js',
 	id: 'soundcloud',
 }, {
-	label: 'Amazon',
+	label: 'Amazon Music',
 	matches: [
 		'*://music.amazon.*/*',
 		'*://www.amazon.*/gp/dmusic/cloudplayer/*',


### PR DESCRIPTION
Using the Amazon Music connector today and noticed it was not consistently registering that anything was playing and sometimes would even register as playing when not playing at all. (Behavior similar to issue #3311.)

Issue seemed to be with the play button selector that was used, as even with the last edit that was made, the selector was no longer unique. Updated as pause button selector (with a couple of other minor edits) and appears to be consistently recognizing play state as expected now. Also updated label to "Amazon Music" to be more descriptive of the service.

FWIW unsure if separate functions for old and new players are necessary anymore. Is an "old" player even available to users?