### PR TITLE
Update KCRW connector

### DIFF
--- a/src/connectors/kcrw.js
+++ b/src/connectors/kcrw.js
@@ -1,9 +1,30 @@
 'use strict';
 
-Connector.playerSelector = '#player';
+Connector.playerSelector = '.site-player'; // supports main and mini players
 
-Connector.artistSelector = '.episode-name';
+const filter = MetadataFilter.createFilter({
+	track: (text) => text.replace(/[‘’“”]/g, ''), // filter for Today's Top Tune
+});
 
-Connector.trackSelector = '.song-name';
+Connector.getTrackInfo = () => {
+	const metaSelector = '.site-player .meta';
+	const showNameText = Util.getTextFromSelectors(`${metaSelector} .show-name`);
+	const artistText = Util.getTextFromSelectors(`${metaSelector} .episode-name`);
+	const trackText = Util.getTextFromSelectors(`${metaSelector} .song-name`);
 
-Connector.isPlaying = () => Util.hasElementClass('.play', 'active');
+	if (Util.hasElementClass(metaSelector, 'music') && trackText && !artistText.includes('[BREAK]')) {
+		return {
+			artist: artistText,
+			track: trackText,
+		};
+
+	} else if (!Util.hasElementClass(metaSelector, 'music') && artistText && showNameText.includes('Today\'s Top Tune')) {
+		return Util.splitArtistTrack(artistText, [': ']);
+	}
+
+	return null;
+};
+
+Connector.applyFilter(filter);
+
+Connector.isPlaying = () => Util.hasElementClass('button.play', 'active');

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2148,7 +2148,7 @@ const connectors = [{
 	js: 'connectors/line-music.js',
 	id: 'linemusic',
 }, {
-	label: 'KCRW 89.9FM',
+	label: 'KCRW',
 	matches: [
 		'*://www.kcrw.com/*',
 	],


### PR DESCRIPTION
Made some updates to the KCRW connector to make it a bit more robust. Updates include:

- Player selector to support both the main player and the mini popup player.
- Ensure support for any music stream, including live and archived playlists, and not scrobble breaks.
- Add support for Today's Top Tune, which is a daily single song that is available to stream for a month: https://www.kcrw.com/music/shows/todays-top-tune
- Concise label as just "KCRW," since that's how they're known and available streams are more than just their live FM programming.