### PR TITLE
Add connector for The Jazz Groove

### DIFF
--- a/src/connectors/jazzgroove.js
+++ b/src/connectors/jazzgroove.js
@@ -1,0 +1,17 @@
+'use strict';
+
+Connector.playerSelector = '.jg-player';
+
+Connector.artistSelector = ['.jg-song .MuiTypography-body2', '.jg-song .MuiTypography-caption'];
+
+Connector.trackSelector = ['.jg-song .MuiTypography-h6', '.jg-song .MuiTypography-body1'];
+
+Connector.trackArtSelector = '.jg-song .jg-player__album-art__image';
+
+Connector.isPlaying = () => !Util.hasElementClass(Connector.playerSelector, 'jg-player--paused');
+
+Connector.isScrobblingAllowed = () => {
+	// station bumpers and other messages play with default images
+	const defaultImages = ['Mix1', 'Mix2', 'Dreams', 'Gems', 'Smooth'];
+	return !defaultImages.some((image) => Connector.getTrackArt().includes(`${image}.jpg`));
+};

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2173,6 +2173,13 @@ const connectors = [{
 	js: 'connectors/hardtunes.js',
 	id: 'hardtunes',
 }, {
+	label: 'The Jazz Groove',
+	matches: [
+		'*://jazzgroove.org/*',
+	],
+	js: 'connectors/jazzgroove.js',
+	id: 'jazzgroove',
+}, {
 	label: 'XRAY.FM',
 	matches: [
 		'*://xray.fm/*',


### PR DESCRIPTION
New connector as per request #3407. https://jazzgroove.org/
Pretty straightforward player, aside from a couple of things:

- Two selectors for artist and track because the classes change when the screen width is less than 900px.
- Station bumpers and other announcements also use the artist and track locations for messaging. Initially tried to filter out specific words/phrases but wording didn't seem consistent enough for that to be reliable. Eventually decided to filter messages out by checking for default station artwork, which only appears to be used for non-music messages; all songs use actual album artwork.