### PR TITLE
Update util.js normalizeUrl helper

### DIFF
--- a/src/core/content/util.js
+++ b/src/core/content/util.js
@@ -497,8 +497,8 @@ const Util = {
 
 	/**
 	 * Normalize given URL. Currently it only normalizes
-	 * protocol-relative links.
-	 * @param  {String} url URL, which is possibly protocol-relative
+	 * protocol-relative and root-relative links.
+	 * @param  {String} url URL, which is possibly relative
 	 * @return {String} Normalized URL
 	 */
 	/* istanbul ignore next */
@@ -507,7 +507,15 @@ const Util = {
 			return null;
 		}
 
-		return url.startsWith('//') ? location.protocol + url : url;
+		if (url.startsWith('//')) {
+			return location.protocol + url;
+		}
+
+		if (url.match(/^\/(?!\/)/g)) {
+			return location.origin + url;
+		}
+
+		return url;
 	},
 
 	/**


### PR DESCRIPTION
While working on a potential new connector, I encountered a root-relative src value for the track art.
The normalizeUrl helper previously only normalized the protocol. Updated to also normalize a root-relative path. Checks for a link beginning with a single slash and prepends the location.origin if found. Previous functionality is the same.

This is my first update to util.js, and I tried to maintain the style of other methods, but please advise if this update should be written in a different way.