### PR TITLE
Fix Epidemic Sound connector

### DIFF
--- a/src/connectors/epidemicsound.js
+++ b/src/connectors/epidemicsound.js
@@ -1,11 +1,13 @@
 'use strict';
 
-Connector.playerSelector = '[class="src-mainapp-player-components-___PlayerBar__player___ZJ8j7"]';
+Connector.playerSelector = '[class*=_PlayerUI__container_]';
 
-Connector.artistSelector = '[aria-label="creatives"]';
+Connector.artistSelector = '[class*=_CreativesLabel__container_]';
 
-Connector.trackSelector = '[class="src-mainapp-components-___CreativesLabel__container___3sd3f"]';
+Connector.trackSelector = ['[class*=_ScrollingLabel__label_]', '[class*=_TrackInfo__mobileContainer_] > [aria-label^=track]'];
 
-Connector.timeInfoSelector = '["class=src-mainapp-player-components-___PlayerBar__elapsedTime___3j43S css-7bhp37"]';
+Connector.currentTimeSelector = '[class*=_PlayerBar__elapsedTime_]';
 
-Connector.playButtonSelector = '[class="src-mainapp-player-components-___PlaybackControls__button___2_sdi src-mainapp-player-components-___PlaybackControls__playPauseButton___2sy2U"]';
+Connector.durationSelector = '[class*=_PlayerBar__waveform_] + span';
+
+Connector.pauseButtonSelector = '[class*=_PlaybackControls__playPauseButton_][title=Pause]';

--- a/src/connectors/epidemicsound.js
+++ b/src/connectors/epidemicsound.js
@@ -10,4 +10,4 @@ Connector.currentTimeSelector = '[class*=_PlayerBar__elapsedTime_]';
 
 Connector.durationSelector = '[class*=_PlayerBar__waveform_] + span';
 
-Connector.pauseButtonSelector = '[class*=_PlaybackControls__playPauseButton_][title=Pause]';
+Connector.isPlaying = () => Util.getAttrFromSelectors('[class*=_PlaybackControls__playPauseButton_]', 'title') === 'Pause';

--- a/src/connectors/epidemicsound.js
+++ b/src/connectors/epidemicsound.js
@@ -1,6 +1,6 @@
 'use strict';
 
-Connector.playerSelector = '[class*=_PlayerUI__container_]';
+Connector.playerSelector = '[class*=_MessageContainer__messageContainer_]';
 
 Connector.artistSelector = '[class*=_CreativesLabel__container_]';
 


### PR DESCRIPTION
Fix for #3414.
I don't have an account with this site but tested using the URL provided: https://www.epidemicsound.com/music/featured/
Two selectors provided for trackSelector because its location changes when the screen width is less than 960px wide.

Unfortunately, the previous update to this connector did not use good selectors. Oddly, it also used attribute selectors, which were originally used to wildcard the classes, but still included the entire class with random strings.
When classes include random strings like that (seen most often on sites built with React), those characters will change whenever an update is pushed to the site—even if the actual markup remains the same. If a connector is submitted with random strings in the selectors, it's probably best to request changes to remove them before merging in order to prevent the connector from breaking too often.