### PR TITLE
Update Radio.co connector

### DIFF
--- a/src/connectors/radioco.js
+++ b/src/connectors/radioco.js
@@ -2,12 +2,12 @@
 
 Connector.playerSelector = '.radioco-player';
 
-Connector.trackSelector = '.track-name';
-
 Connector.artistSelector = '.track-artist';
+
+Connector.trackSelector = '.track-name';
 
 Connector.trackArtSelector = '.current-artwork';
 
-Connector.isPlaying = () => {
-	return $('.radioco-player').hasClass('playing');
-};
+Connector.currentTimeSelector = '.streamtime';
+
+Connector.isPlaying = () => Util.hasElementClass(Connector.playerSelector, 'playing');


### PR DESCRIPTION
Minor update to connector to remove jQuery and add currentTimeSelector (unsure if this is actually useful without also having a duration but included since it was available).
Example: https://embed.radio.co/player/dcd6202.html
