### PR TITLE
Update KEXP connector

### DIFF
--- a/src/connectors/kexp.js
+++ b/src/connectors/kexp.js
@@ -1,7 +1,13 @@
 'use strict';
 
-Connector.isPlaying = () => $('.Player').hasClass('Player--playing');
-
 Connector.playerSelector = '.Player';
+
 Connector.artistTrackSelector = '.Player-title';
+
 Connector.albumSelector = '.Player-album';
+
+Connector.trackArtSelector = '.Player-coverImage';
+
+Connector.isTrackArtDefault = (url) => url.includes('default');
+
+Connector.isPlaying = () => Util.hasElementClass(Connector.playerSelector, 'Player--playing');

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1240,7 +1240,7 @@ const connectors = [{
 	js: 'connectors/resonate.js',
 	id: 'resonate',
 }, {
-	label: 'KEXP Radio',
+	label: 'KEXP',
 	matches: [
 		'*://*.kexp.org/*',
 	],


### PR DESCRIPTION
Minor edit to connector to remove jQuery and add support for track art. Also updated label to just KEXP, since that is how they are known.
URL: https://www.kexp.org/