### PR TITLE
Add connector for anime(bits)

### DIFF
--- a/src/connectors/animebits.js
+++ b/src/connectors/animebits.js
@@ -1,0 +1,17 @@
+'use strict';
+
+Connector.playerSelector = '#radio-left';
+
+Connector.artistSelector = '#meta-container .np-artist';
+
+Connector.albumSelector = '#meta-container .np-album';
+
+Connector.trackSelector = '#meta-container .np-song';
+
+Connector.trackArtSelector = 'img.main-cover';
+
+Connector.durationSelector = '#time-container .duration';
+
+Connector.currentTimeSelector = '#time-container .current-time';
+
+Connector.isPlaying = () => Util.hasElementClass('#play-pause', 'playing');

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -817,6 +817,13 @@ const connectors = [{
 	js: 'connectors/listen.moe.js',
 	id: 'listen.moe',
 }, {
+	label: 'anime(bits)',
+	matches: [
+		'*://radio.animebits.moe/',
+	],
+	js: 'connectors/animebits.js',
+	id: 'animebits',
+}, {
 	label: 'Fair Price Music',
 	matches: [
 		'*://www.fairpricemusic.com/*',


### PR DESCRIPTION
New connector as per request #3412.
URL: https://radio.animebits.moe/

Fairly standard player with clear classes for selectors, except track art src is a root-relative path. Will require merging of update to util.js normalizeUrl helper (#3415) for this connector to work with track art.