### PR TITLE
Update The Jazz Groove connector

### DIFF
--- a/src/connectors/jazzgroove.js
+++ b/src/connectors/jazzgroove.js
@@ -8,10 +8,12 @@ Connector.trackSelector = ['.jg-song .MuiTypography-h6', '.jg-song .MuiTypograph
 
 Connector.trackArtSelector = '.jg-song .jg-player__album-art__image';
 
-Connector.isPlaying = () => !Util.hasElementClass(Connector.playerSelector, 'jg-player--paused');
-
-Connector.isScrobblingAllowed = () => {
-	// station bumpers and other messages play with default images
+Connector.isTrackArtDefault = () => {
 	const defaultImages = ['Mix1', 'Mix2', 'Dreams', 'Gems', 'Smooth'];
-	return !defaultImages.some((image) => Connector.getTrackArt().includes(`${image}.jpg`));
+	return defaultImages.some((image) => Connector.getTrackArt().includes(`${image}.jpg`));
 };
+
+// station bumpers and other spoken messages play with default images
+Connector.isScrobblingAllowed = () => !Connector.isTrackArtDefault();
+
+Connector.isPlaying = () => !Util.hasElementClass(Connector.playerSelector, 'jg-player--paused');


### PR DESCRIPTION
Minor edit for clearer logic in connector for https://jazzgroove.org/

- Moved `isScrobblingAllowed` to `isTrackArtDefault`, since that is what it's actually checking, and then used `!isTrackArtDefault` for `isScrobblingAllowed`.

No rush to merge, as end behavior is the same as current version.