### PR TITLE
Update anime(bits) connector

### DIFF
--- a/src/connectors/animebits.js
+++ b/src/connectors/animebits.js
@@ -1,12 +1,14 @@
 'use strict';
 
+const filter = MetadataFilter.createFilter({ track: removePlaylistNumber });
+
 Connector.playerSelector = '#radio-left';
 
-Connector.artistSelector = '#meta-container .np-artist';
+Connector.trackSelector = ['#meta-container .np-song', '#meta-container .song-name'];
 
-Connector.albumSelector = '#meta-container .np-album';
+Connector.artistSelector = ['#meta-container .np-artist', '#meta-container .song-artist'];
 
-Connector.trackSelector = '#meta-container .np-song';
+Connector.albumSelector = ['#meta-container .np-album', '#meta-container .song-album'];
 
 Connector.trackArtSelector = 'img.main-cover';
 
@@ -15,3 +17,9 @@ Connector.durationSelector = '#time-container .duration';
 Connector.currentTimeSelector = '#time-container .current-time';
 
 Connector.isPlaying = () => Util.hasElementClass('#play-pause', 'playing');
+
+Connector.applyFilter(filter);
+
+function removePlaylistNumber(text) {
+	return text.replace(/^\d+\.\s/g, '');
+}

--- a/src/connectors/animebits.js
+++ b/src/connectors/animebits.js
@@ -21,5 +21,5 @@ Connector.isPlaying = () => Util.hasElementClass('#play-pause', 'playing');
 Connector.applyFilter(filter);
 
 function removePlaylistNumber(text) {
-	return text.replace(/^\d+\.\s/g, '');
+	return text.replace(/^\d+\.\s/, '');
 }

--- a/src/connectors/animebits.js
+++ b/src/connectors/animebits.js
@@ -16,6 +16,8 @@ Connector.durationSelector = '#time-container .duration';
 
 Connector.currentTimeSelector = '#time-container .current-time';
 
+Connector.isTrackArtDefault = (url) => url.includes('no-cover');
+
 Connector.isPlaying = () => Util.hasElementClass('#play-pause', 'playing');
 
 Connector.applyFilter(filter);

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -820,6 +820,7 @@ const connectors = [{
 	label: 'anime(bits)',
 	matches: [
 		'*://radio.animebits.moe/',
+		'*://radio.animebits.moe/player/*',
 	],
 	js: 'connectors/animebits.js',
 	id: 'animebits',


### PR DESCRIPTION
Updates to connector for https://radio.animebits.moe/

After submitting this connector, I realized there are also separate versions of the player available to a user for listening.

- The player is essentially the same, but a few classes are slightly different, so two selectors are now available for artist, track, and album.
- Also added a new filter to remove the playlist track number that gets prepended in the album player.
- Added check for default art.

Additional example URLs for testing:
https://radio.animebits.moe/player/hash/2d2258e32
https://radio.animebits.moe/player/album/hide+your+face
https://radio.animebits.moe/player/search/bump+of+chicken

No rush to merge, as main player at base URL is currently working.
