### PR TITLE
Add connector for Colorado Public Radio

### DIFF
--- a/src/connectors/cpr.js
+++ b/src/connectors/cpr.js
@@ -1,0 +1,11 @@
+'use strict';
+
+Connector.playerSelector = '[class*=audioPlayer__liveStream-]';
+
+Connector.artistSelector = `${Connector.playerSelector} [class^=audioPlayerTitle__artist-]`;
+
+Connector.trackSelector = `${Connector.playerSelector} [class^=liveStreamTitle__heading-]`;
+
+Connector.pauseButtonSelector = `${Connector.playerSelector} [class^=playPauseButton__icon-][class*=playPauseButton__pause-]`;
+
+Connector.isStateChangeAllowed = () => Connector.getTrack();

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2200,7 +2200,14 @@ const connectors = [{
 		'*://www.qcindie.com/listen-live/*',
 	],
 	js: 'connectors/qcindie.js',
-	id: 'QCIndie',
+	id: 'qcindie',
+}, {
+	label: 'Colorado Public Radio',
+	matches: [
+		'*://www.cpr.org/*',
+	],
+	js: 'connectors/cpr.js',
+	id: 'cpr',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
URL: https://www.cpr.org/
Listen Live links for both CPR Classical and Indie 102.3 provide artist and track info for scrobbling.

`isStateChangeAllowed` added to ensure scrobbling isn't temporarily reset to null in the middle of a song, as the track selector is always populated when a state change should occur.