### PR TITLE
Add connector for Indie 102.3

### DIFF
--- a/src/connectors/cpr-indie.js
+++ b/src/connectors/cpr-indie.js
@@ -1,0 +1,18 @@
+'use strict';
+
+Connector.playerSelector = '#qtmplayer';
+
+Connector.artistSelector = '.qtmplayer__songdata .qtmplayer__artist';
+
+Connector.trackSelector = '.qtmplayer__songdata .qtmplayer__title';
+
+Connector.isPlaying = () => Util.hasElementClass('#qtmplayerNotif', 'playing');
+
+Connector.isScrobblingAllowed = () => {
+	const stationID = 'Indie 102.3';
+	return (
+		!Connector.getTrack().includes(stationID) &&
+		!Connector.getArtist().includes(stationID) &&
+		!Connector.getArtist().startsWith('with ')
+	);
+};

--- a/src/connectors/cpr-indie.js
+++ b/src/connectors/cpr-indie.js
@@ -9,10 +9,8 @@ Connector.trackSelector = '.qtmplayer__songdata .qtmplayer__title';
 Connector.isPlaying = () => Util.hasElementClass('#qtmplayerNotif', 'playing');
 
 Connector.isScrobblingAllowed = () => {
-	const stationID = 'Indie 102.3';
 	return (
-		!Connector.getTrack().includes(stationID) &&
-		!Connector.getArtist().includes(stationID) &&
+		!Util.getTextFromSelectors('.qtmplayer__songdata').includes('Indie 102.3') &&
 		!Connector.getArtist().startsWith('with ')
 	);
 };

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2209,6 +2209,13 @@ const connectors = [{
 	],
 	js: 'connectors/cpr.js',
 	id: 'cpr',
+}, {
+	label: 'Indie 102.3',
+	matches: [
+		'*://indie.cpr.org/',
+	],
+	js: 'connectors/cpr-indie.js',
+	id: 'cpr-indie',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
New connector. Resolves #3344 (H/T @jbwharris)
URL: https://indie.cpr.org/

After spending some time with this site, it seems that "Indie 102.3" can appear in either the artist or track location, and that is when scrobbling should be prevented. Additional check for artist, which sometimes says "with DJ Name," in case the accompanying show does not include "Indie 102.3."
Adding as a separate connector from CPR, even though this station feed can also be accessed at https://www.cpr.org/indie/ , since it is a different player design and a separate subdomain.