### PR TITLE
Add connector for DKFM

### DIFF
--- a/src/connectors/decayfm.js
+++ b/src/connectors/decayfm.js
@@ -1,0 +1,15 @@
+'use strict';
+
+Connector.playerSelector = '#qtmplayer';
+
+Connector.artistSelector = '.qtmplayer__songdata .qtmplayer__artist .marquee';
+
+Connector.trackSelector = '.qtmplayer__songdata .qtmplayer__title .marquee';
+
+Connector.trackArtSelector = '.qtmplayer__covercontainer img';
+
+Connector.isPlaying = () => Util.getTextFromSelectors('#qtmplayerPlay .material-icons') === 'pause';
+
+Connector.isScrobblingAllowed = () => {
+	return Connector.getArtist() && !Connector.getArtist().match(/^DKFM|^ID\/PSA|^Advert:/);
+};

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2196,6 +2196,13 @@ const connectors = [{
 	js: 'connectors/xrayfm.js',
 	id: 'xrayfm',
 }, {
+	label: 'DKFM Shoegaze Radio',
+	matches: [
+		'*://decayfm.com/*',
+	],
+	js: 'connectors/decayfm.js',
+	id: 'decayfm',
+}, {
 	label: 'QCIndie',
 	matches: [
 		'*://www.qcindie.com/listen-live/*',


### PR DESCRIPTION
URL: https://decayfm.com/

Coincidentally, this site uses the same player as the recently-added Indie 102.3 standalone site. However, it seems to be a slightly different version and requires a different check for both `isPlaying` and `isScrobblingAllowed`, so they can't share a connector script. This site doesn't seem to have an issue with refreshing the player information, as I have listened for an extended period of time with no issue of keeping up with the tracks played.

Adding label as "DKFM Shoegaze Radio," even though it's a bit long, as that is how they are listed everywhere.

DKFM also has their up-to-date play history on Last.fm: https://www.last.fm/user/DKFM_Shoegaze/library