### PR TITLE
Add connector for Streemlion

### DIFF
--- a/src/connectors/streemlion.js
+++ b/src/connectors/streemlion.js
@@ -1,0 +1,11 @@
+'use strict';
+
+Connector.playerSelector = '.player-wpr';
+
+Connector.artistSelector = `${Connector.playerSelector} .track-info .artist-name`;
+
+Connector.trackSelector = `${Connector.playerSelector} .track-info .track-title`;
+
+Connector.trackArtSelector = `${Connector.playerSelector} .album-cover`;
+
+Connector.isPlaying = () => Util.hasElementClass(`${Connector.playerSelector} .ppBtn`, 'playing');

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1006,6 +1006,13 @@ const connectors = [{
 	js: 'connectors/streamsquid.js',
 	id: 'streamsquid',
 }, {
+	label: 'Streemlion',
+	matches: [
+		'*://listen.streemlion.com/*',
+	],
+	js: 'connectors/streemlion.js',
+	id: 'streemlion',
+}, {
 	label: 'eMusic',
 	matches: [
 		'*://www.emusic.com/*',


### PR DESCRIPTION
This is a 3rd party player that I discovered while working on the connector for DKFM. Aside from their main stream, they have two additional streams available through Streemlion:

- DKFM Classic - https://listen.streemlion.com/radio_5fea66f604ac9
- DKFM EDGE - https://listen.streemlion.com/radio_5fea66f604ac2

I also found another stream using this player on nomadradio.eu: https://listen.streemlion.com/NomadRadio
That one uses a different player layout, but both versions work with the connector.