### PR TITLE
Fix duplicate scrobbles on Spotify

### DIFF
--- a/src/connectors/spotify.js
+++ b/src/connectors/spotify.js
@@ -84,7 +84,7 @@ function isMainTab() {
 }
 
 function hasMultipleSources() {
-	return document.body.classList.contains('qualaroo--connect-bar-visible');
+	return document.querySelector(spotifyConnectSelector) !== null;
 }
 
 function getActiveDeviceName() {


### PR DESCRIPTION
This fixes #3434, so there are no duplicate scrobbles, even if Spotify is opened in multiple tabs.

The class 'qualaroo--connect-bar-visible' we used to detect if Spotify is playing on multiple sources was removed from Spotify. Also, the connection bar is now only shown when Spotify is playing on another tab, not on the main tab.

With this PR we use the selector for the connect bar to detect if there are multiple sources, instead of the removed class.