### PR TITLE
Update filters in KCRW connector

### DIFF
--- a/src/connectors/kcrw.js
+++ b/src/connectors/kcrw.js
@@ -44,7 +44,7 @@ Connector.isPlaying = () => Util.hasElementClass('button.play', 'active');
 Connector.applyFilter(filter);
 
 function removeSmartQuotes(text) { // filter for Today's Top Tune
-	return text.replace(/^[\u2018\u201c]|[\u2019\u201d](?=\s\(|$)/g, '');
+	return text.replace(/^[\u2018\u201c](.+)[\u2019\u201d](?=\s\(|$)/, '$1');
 }
 
 function replaceSmartQuotes(text) {

--- a/src/connectors/kcrw.js
+++ b/src/connectors/kcrw.js
@@ -1,6 +1,14 @@
 'use strict';
 
-const filter = MetadataFilter.createFilter({ track: removeFancyQuotes });
+const filter = MetadataFilter.createFilter({
+	artist: replaceSmartQuotes,
+	track: [
+		removeSmartQuotes,
+		replaceSmartQuotes,
+		MetadataFilter.removeVersion,
+		MetadataFilter.removeCleanExplicit,
+	],
+});
 
 Connector.playerSelector = '.site-player'; // supports main and mini players
 
@@ -11,7 +19,7 @@ Connector.getTrackInfo = () => {
 	const artistText = Util.getTextFromSelectors(`${metaSelector} .episode-name`);
 	const trackText = Util.getTextFromSelectors(`${metaSelector} .song-name`);
 
-	if (Util.hasElementClass(metaSelector, 'music') && trackText && !artistText.includes('[BREAK]')) {
+	if (Util.hasElementClass(metaSelector, 'music') && trackText && artistText !== '[BREAK]') {
 		return {
 			artist: artistText,
 			track: trackText,
@@ -35,6 +43,10 @@ Connector.isPlaying = () => Util.hasElementClass('button.play', 'active');
 
 Connector.applyFilter(filter);
 
-function removeFancyQuotes(text) {
-	return text.replace(/[‘’“”]/g, ''); // filter for Today's Top Tune
+function removeSmartQuotes(text) { // filter for Today's Top Tune
+	return text.replace(/^[\u2018\u201c]|[\u2019\u201d](?=\s\(|$)/g, '');
+}
+
+function replaceSmartQuotes(text) {
+	return text.replace(/[\u2018\u2019]/g, '\'').replace(/[\u201c\u201d]/g, '"');
 }


### PR DESCRIPTION
More robust filters for KCRW to fix the issue noted in [this comment](https://github.com/web-scrobbler/web-scrobbler/pull/3427#issuecomment-1296280680). (H/T @jbwharris)

In addition to ensuring the outer quotes are removed for Today's Top Tune, a filter has been added to replace "smart" quotes with plain quotes within any titles and artists.
Also added existing `removeVersion` and `removeCleanExplicit` filters.

P.S. @inverse Let me know if you still think either of these new filters are worth adding to the MetadataFilter module prior to merging this.
I could see the replacement one potentially being useful outside of this connector but not sure about the removal one.
