### PR TITLE
LightningStream Connector

### DIFF
--- a/src/connectors/lightningstream.js
+++ b/src/connectors/lightningstream.js
@@ -1,0 +1,7 @@
+'use strict';
+
+Connector.playerSelector = '#MainContainer';
+Connector.trackSelector = '.SN_pw_slot.open .SN_pw_title';
+Connector.artistSelector = '.SN_pw_slot.open .SN_pw_artist';
+Connector.trackArtSelector = '.SN_pw_slot.open .SN_pw_cover';
+Connector.isPlaying = () => Util.isElementVisible('#playerStopLink');

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2252,6 +2252,13 @@ const connectors = [{
 	],
 	js: 'connectors/gotradio.js',
 	id: 'gotradio',
+}, {
+	label: 'LightningStream',
+	matches: [
+		'*://*lightningstream.com/*',
+	],
+	js: 'connectors/lightningstream.js',
+	id: 'lightningstream',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
New connector for stations that use lightningstream.com to power their sites.

**Describe the changes you made**
I was looking to create a connector for [weqx.com](https://weqx.com) when I discovered there was a whole network of sites powered by [lightningstream.com](https://lightningstream.com). Not every site has a proper playlist, but there are quite a few that can be scrobbled ie. [WSOU](https://www.lightningstream.com/Player.aspx?call=WSOU), [WRHQ](https://www.lightningstream.com/Player.aspx?call=WRHQ), [WMWV](https://www.lightningstream.com/Player.aspx?call=WMWV), [WEQX](https://www.lightningstream.com/Player.aspx?call=WEQX)

**Additional context**
![image](https://user-images.githubusercontent.com/2962327/200051530-486f2de5-6533-4571-a45f-b5cb46b4871a.png)
