### PR TITLE
Added connector for WSUM

### DIFF
--- a/src/connectors/wsum.js
+++ b/src/connectors/wsum.js
@@ -1,0 +1,7 @@
+'use strict';
+
+Connector.playerSelector = '.songLineOnNow';
+Connector.playButtonSelector = '.playButton';
+Connector.albumSelector = '.songLineOnNow .songDetail .songAlbum';
+Connector.artistSelector = '.songLineOnNow .songDetail .songArtist';
+Connector.trackSelector = '.songLineOnNow .songDetail .songTitle';

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2259,6 +2259,13 @@ const connectors = [{
 	],
 	js: 'connectors/lightningstream.js',
 	id: 'lightningstream',
+}, {
+	label: 'WSUM',
+	matches: [
+		'*://streamdb9web.securenetsystems.net/cirrusencore/WSUMFM',
+	],
+	js: 'connectors/wsum.js',
+	id: 'wsum',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
**Describe the changes you made**
New connector for WSUM, the University of Wisconsin's student radio station.

Player: https://streamdb9web.securenetsystems.net/cirrusencore/WSUMFM
Main Website: https://wsum.org


**Additional context**
<img width="1204" alt="image" src="https://user-images.githubusercontent.com/54562370/201248744-1c68411b-881a-41fd-b2e8-44d99e70b3f0.png">
