### PR TITLE
Update LightningStream connector

### DIFF
--- a/src/connectors/lightningstream.js
+++ b/src/connectors/lightningstream.js
@@ -1,7 +1,13 @@
 'use strict';
 
 Connector.playerSelector = '#MainContainer';
+
 Connector.trackSelector = '.SN_pw_slot.open .SN_pw_title';
+
 Connector.artistSelector = '.SN_pw_slot.open .SN_pw_artist';
+
 Connector.trackArtSelector = '.SN_pw_slot.open .SN_pw_cover';
+
+Connector.isTrackArtDefault = (url) => url.includes('noimage');
+
 Connector.isPlaying = () => Util.isElementVisible('#playerStopLink');

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2197,8 +2197,7 @@ const connectors = [{
 }, {
 	label: 'XRAY.FM',
 	matches: [
-		'*://xray.fm/*',
-		'*://www.xray.fm/*',
+		'*://*.xray.fm/*',
 	],
 	js: 'connectors/xrayfm.js',
 	id: 'xrayfm',
@@ -2240,8 +2239,7 @@ const connectors = [{
 }, {
 	label: 'FRISKY',
 	matches: [
-		'*://frisky.fm/*',
-		'*://www.frisky.fm/*',
+		'*://*.frisky.fm/*',
 	],
 	js: 'connectors/friskyfm.js',
 	id: 'friskyfm',
@@ -2255,7 +2253,8 @@ const connectors = [{
 }, {
 	label: 'LightningStream',
 	matches: [
-		'*://*lightningstream.com/*',
+		'*://*.lightningstream.com/Player*',
+		'*://*.lightningstream.com/player*',
 	],
 	js: 'connectors/lightningstream.js',
 	id: 'lightningstream',


### PR DESCRIPTION
Minor update to this recently-added connector to recognize the following image as "default" when it is displayed as track art:
![noimage180px](https://user-images.githubusercontent.com/6808988/201442686-b7c6f000-bdee-4650-ab56-eff5b11aa8b4.png)
Example:
<img width="188" alt="" src="https://user-images.githubusercontent.com/6808988/201445672-e6f75492-eed3-4d1d-819d-cf1b5e38f139.png">

Also updated the URL to ensure the extension is only activated for the player and not on their corporate website. Some players are linked with a lowercase "p", such as "Listen Live" link from https://www.weqx.com/ But an uppercase "P" is also valid.

Example URLs:
https://lightningstream.com/player.aspx?call=WEQX
https://www.lightningstream.com/Player.aspx?call=WSOU

Noticed a couple of other recently-added URLs that needed to be wildcarded better, as well.