### PR TITLE
Refactor WSUM connector for general use as Securenet Systems

### DIFF
--- a/src/connectors/securenetsystems.js
+++ b/src/connectors/securenetsystems.js
@@ -2,15 +2,15 @@
 
 const songOnNow = '.songLineOnNow';
 
-Connector.playerSelector = '.playlistSongArea';
+Connector.playerSelector = ['.playlistSongArea', '#playerDiv'];
 
-Connector.artistSelector = `${songOnNow} .songDetail .songArtist`;
+Connector.artistSelector = [`${songOnNow} .songDetail .songArtist`, '#now-playing-artist'];
 
-Connector.trackSelector = `${songOnNow} .songDetail .songTitle`;
+Connector.trackSelector = [`${songOnNow} .songDetail .songTitle`, '#now-playing-title'];
 
 Connector.albumSelector = `${songOnNow} .songDetail .songAlbum`;
 
-Connector.trackArtSelector = `${songOnNow} img.songCover`;
+Connector.trackArtSelector = [`${songOnNow} img.songCover`, '#now-playing-album-art'];
 
 Connector.durationSelector = `${songOnNow} .songDuration`;
 
@@ -18,4 +18,4 @@ Connector.currentTimeSelector = `${songOnNow} .progressTime`;
 
 Connector.isTrackArtDefault = (url) => url.includes('album-art-default');
 
-Connector.isPlaying = () => Util.isElementVisible('.songPlaying .pauseButton');
+Connector.isPlaying = () => Util.isElementVisible(['.songPlaying .pauseButton', '#transport-pause']);

--- a/src/connectors/securenetsystems.js
+++ b/src/connectors/securenetsystems.js
@@ -16,6 +16,6 @@ Connector.durationSelector = `${songOnNow} .songDuration`;
 
 Connector.currentTimeSelector = `${songOnNow} .progressTime`;
 
-Connector.isTrackArtDefault = (url) => url.includes('album-art-default');
+Connector.isTrackArtDefault = (url) => url.match(/album-art(-default)?.png$/);
 
 Connector.isPlaying = () => Util.isElementVisible(['.songPlaying .pauseButton', '#transport-pause']);

--- a/src/connectors/securenetsystems.js
+++ b/src/connectors/securenetsystems.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const songOnNow = '.songLineOnNow';
+
+Connector.playerSelector = '.playlistSongArea';
+
+Connector.artistSelector = `${songOnNow} .songDetail .songArtist`;
+
+Connector.trackSelector = `${songOnNow} .songDetail .songTitle`;
+
+Connector.albumSelector = `${songOnNow} .songDetail .songAlbum`;
+
+Connector.trackArtSelector = `${songOnNow} img.songCover`;
+
+Connector.durationSelector = `${songOnNow} .songDuration`;
+
+Connector.currentTimeSelector = `${songOnNow} .progressTime`;
+
+Connector.isTrackArtDefault = (url) => url.includes('album-art-default');
+
+Connector.isPlaying = () => Util.isElementVisible('.songPlaying .pauseButton');

--- a/src/connectors/wsum.js
+++ b/src/connectors/wsum.js
@@ -1,7 +1,0 @@
-'use strict';
-
-Connector.playerSelector = '.songLineOnNow';
-Connector.playButtonSelector = '.playButton';
-Connector.albumSelector = '.songLineOnNow .songDetail .songAlbum';
-Connector.artistSelector = '.songLineOnNow .songDetail .songArtist';
-Connector.trackSelector = '.songLineOnNow .songDetail .songTitle';

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2260,12 +2260,12 @@ const connectors = [{
 	js: 'connectors/lightningstream.js',
 	id: 'lightningstream',
 }, {
-	label: 'WSUM',
+	label: 'Securenet Systems',
 	matches: [
-		'*://streamdb9web.securenetsystems.net/cirrusencore/WSUMFM',
+		'*://*.securenetsystems.net/cirrusencore/*',
 	],
-	js: 'connectors/wsum.js',
-	id: 'wsum',
+	js: 'connectors/securenetsystems.js',
+	id: 'securenetsystems',
 }];
 
 define(() => connectors);

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2262,7 +2262,8 @@ const connectors = [{
 }, {
 	label: 'Securenet Systems',
 	matches: [
-		'*://*.securenetsystems.net/*',
+		'*://radio.securenetsystems.net/*',
+		'*://stream*.securenetsystems.net/*',
 	],
 	js: 'connectors/securenetsystems.js',
 	id: 'securenetsystems',

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2262,7 +2262,7 @@ const connectors = [{
 }, {
 	label: 'Securenet Systems',
 	matches: [
-		'*://*.securenetsystems.net/cirrusencore/*',
+		'*://*.securenetsystems.net/*',
 	],
 	js: 'connectors/securenetsystems.js',
 	id: 'securenetsystems',


### PR DESCRIPTION
Resolves #3340. This was just recently added as WSUM, but like #3385 and #3386, the player is actually on a 3rd party's domain and can be used for multiple stations. In addition to WSUM, I found a few more active stations using Securenet Systems via Google.
Also added support for track art and times and alternate player, which were missing from the previous version.

Example URLs:
https://streamdb9web.securenetsystems.net/cirrusencore/WSUMFM
https://streamdb8web.securenetsystems.net/cirrusencore/WEZV
https://streamdb8web.securenetsystems.net/cirrusencore/KABX
https://streamdb5web.securenetsystems.net/cirrusencore/index.cfm?stationCallSign=KNBZFM
https://streamdb5web.securenetsystems.net/cirrusencore/index.cfm?stationCallSign=KSDNFM
https://radio.securenetsystems.net/cwa/index.cfm?stationCallSign=WCLDFM
Alternate player: https://streamdb8web.securenetsystems.net/v5/index.cfm?stationCallSign=KQDIFM

It looks like they have several different players available: https://cir.st/features/live-streaming-player-examples/
This connector should support Cirrus Player, Cirrus Content, and Cirrus Encore, which seem to be the most commonly used versions.

One issue: On the Cirrus Encore player, the pause button is visible for a split second when the page loads, even before initiating playback. Although it quickly switches back to the play button being visible, this brief swap can cause the extension to think `isPlaying` is true when it's actually not yet playing. Not sure of the best way to resolve this, as there is no other indicator to be used for `isPlaying` other than the buttons.