### PR TITLE
Update Freegal Music connector

### DIFF
--- a/src/connectors/freegalmusic.js
+++ b/src/connectors/freegalmusic.js
@@ -1,35 +1,50 @@
 'use strict';
 
+const filter = MetadataFilter.createFilter({
+	artist: extractPrimaryArtist,
+	track: [removeParody, removeRemaster],
+});
+
 Connector.playerSelector = '#player-section';
 
 Connector.pauseButtonSelector = '.fp-playbtn[title=Pause]';
 
 Connector.trackSelector = '.playlist-player ul > li.active-playlist-song';
 
+Connector.durationSelector = '.fp-duration';
+
+Connector.currentTimeSelector = '.fp-elapsed';
+
 Connector.getArtist = () => {
 	const artistTrackText = Util.getTextFromSelectors('.fp-message');
 
 	if (artistTrackText) {
-		return artistTrackText.split(' - ')[0]; // track title may be truncated or missing; only return artist
+		// track title may be truncated or missing; only return artist
+		return artistTrackText.split(' - ')[0];
 	}
 
 	return null;
 };
 
-Connector.durationSelector = '.fp-duration';
-
-Connector.currentTimeSelector = '.fp-elapsed';
-
 Connector.isScrobblingAllowed = () => {
 	return (
 		Connector.getTrack() &&
 		Util.isElementVisible(Connector.playerSelector) &&
-		!Connector.getArtist().includes('Sorry, this song is not available for streaming at this time')
+		!Connector.getArtist().includes('Sorry, this song is not available')
 	);
 };
 
-const filter = MetadataFilter.createFilter({
-	artist: (text) => text.split(/(?<!\d),(?!\s)/g)[0], // only first artist if comma-separated list of contributors
-});
-
 Connector.applyFilter(filter);
+
+function extractPrimaryArtist(text) {
+	// only return first artist if semicolon/comma-separated list of contributors
+	return text.split(/(;|((?<!\d),))(?!\s)/)[0];
+}
+
+function removeParody(text) {
+	return text.replace(/\s?\((Parody|Lyrical Adaption) of.*(\)|\.{3})/i, '');
+}
+
+function removeRemaster(text) {
+	return text.replace(/\s?(\(|\[)[\s\w]*Remaster(ed)?[\s\w]*(\)|\]|\.{3})/gi, '');
+}

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -691,7 +691,7 @@ const connectors = [{
 	js: 'connectors/emby.js',
 	id: 'emby',
 }, {
-	label: 'Freegal',
+	label: 'Freegal Music',
 	matches: [
 		'*://*.freegalmusic.com/*',
 	],


### PR DESCRIPTION
Initially updated to set up the original filter (see #3335 for more info) more clearly. Also realized it could use a couple of additional filters, whose concepts were borrowed from `metadata-filter` modules. Unfortunately, because of the possibly truncated song titles, I had to make modified versions of them just for this connector.
Also updated the connector label to Freegal Music, as that is the site's full name: https://www.freegalmusic.com/home

No rush to release this, as its functionality is essentially the same.