### PR TITLE
Add support for Super45.fm via Radio.co

### DIFF
--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1350,7 +1350,7 @@ const connectors = [{
 	js: 'connectors/funkwhale.js',
 	id: 'funkwhale',
 }, {
-	label: '9128 live',
+	label: '9128.live',
 	matches: [
 		'*://9128.live/*',
 	],

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1365,6 +1365,14 @@ const connectors = [{
 	js: 'connectors/radioco.js',
 	id: 'radioco',
 }, {
+	label: 'Super45.fm',
+	matches: [
+		'*://super45.fm/',
+	],
+	js: 'connectors/radioco.js',
+	id: 'super45fm',
+	allFrames: true,
+}, {
 	label: 'R/a/dio',
 	matches: [
 		'*://r-a-d.io/*',


### PR DESCRIPTION
Following #3474, adding support for Super45.fm. Site uses Radio.co, so only edit is to connectors.js. Resolves #3260.
URL: https://super45.fm/