### PR TITLE
Extend invidious to more domains

### DIFF
--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1328,9 +1328,9 @@ const connectors = [{
 	label: 'Invidious',
 	matches: [
 		'*://*.invidio.us/*',
- 		'*://yewtu.be/*',
- 		'*://invidious.*/*',
- 		'*://inv.*/*',
+		'*://yewtu.be/*',
+		'*://invidious.*/*',
+		'*://inv.*/*',
 	],
 	js: 'connectors/invidious.js',
 	id: 'invidious',

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1328,6 +1328,9 @@ const connectors = [{
 	label: 'Invidious',
 	matches: [
 		'*://*.invidio.us/*',
+ 		'*://yewtu.be/*',
+ 		'*://invidious.*/*',
+ 		'*://inv.*/*',
 	],
 	js: 'connectors/invidious.js',
 	id: 'invidious',


### PR DESCRIPTION
**Describe the changes you made**
I extended the invidious connector to match on more domains. 

**Additional context**
The reason for this is that invidious is built with self-hosting in mind, so matching only on *.invidious.com will miss a lot of the instances. I took the list of domains at https://redirect.invidious.io/, included one very popular domain explicitly (yewtu.be) and saw that more than 90% of the remaining instances used `inv.` or `invidious.` subdomains. While this change won't match all instances of invidios, I feel like it's as good approximation for a domain-based heuristic.