### PR TITLE
Sanatise Bandcamp default origin URL

### DIFF
--- a/src/connectors/bandcamp.js
+++ b/src/connectors/bandcamp.js
@@ -93,6 +93,8 @@ function initGenericProperties() {
 
 		return null;
 	};
+
+	Connector.getOriginUrl = () => document.location.href.split('?')[0];
 }
 
 // Example: https://northlane.bandcamp.com/album/mesmer


### PR DESCRIPTION
Set default implementation for Connector.getOriginUrl() 

Resolves #3515