### PR TITLE
Allow youtube connector to get data from Youtube Music

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -80,6 +80,14 @@
         "message": "Ignore videos that are not in Entertainment category",
         "description": "Option title"
     },
+    "optionYtMusicRecognisedOnly": {
+        "message": "Scrobble only videos that are recognized by YouTube Music as music",
+        "description": "Option label"
+    },
+    "optionYtMusicRecognisedOnlyTitle": {
+        "message": "Ignore videos that are not recognised by YouTube Music as music",
+        "description": "Option title"
+    },
 
     "optionsAccounts": {
         "message": "Accounts",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -80,6 +80,14 @@
         "message": "Ignore videos that are not in Entertainment category",
         "description": "Option title"
     },
+    "optionYtGetTrackInfoFromYtMusic": {
+        "message": "Use Youtube Music to get track info",
+        "description": "Option label"
+    },
+    "optionYtGetTrackInfoFromYtMusicTitle": {
+        "message": "Use Youtube Music to get track info, if disabled defaults to using description and video title",
+        "description": "Option title"
+    },
     "optionYtMusicRecognisedOnly": {
         "message": "Scrobble only videos that are recognized by YouTube Music as music",
         "description": "Option label"

--- a/src/connectors/youtube.js
+++ b/src/connectors/youtube.js
@@ -373,9 +373,9 @@ function getTrackInfoFromYoutubeMusic() {
 			getTrackInfoFromYoutubeMusicCache[videoId] = {
 				done: true,
 				recognisedByYtMusic:
-					videoInfo.videoDetails?.musicVideoType.startsWith(
+					videoInfo.videoDetails?.musicVideoType?.startsWith(
 						'MUSIC_VIDEO_'
-					),
+					) || false,
 			};
 
 			// if videoDetails is not MUSIC_VIDEO_TYPE_OMV, it seems like it's
@@ -390,6 +390,16 @@ function getTrackInfoFromYoutubeMusic() {
 					track: videoInfo.videoDetails.title,
 				};
 			}
+		})
+		.catch((err) => {
+			Util.debugLog(
+				`Failed to fetch youtube music data for ${videoId}: ${err}`,
+				'warn'
+			);
+			getTrackInfoFromYoutubeMusicCache[videoId] = {
+				done: true,
+				recognisedByYtMusic: false,
+			};
 		});
 }
 

--- a/src/core/background/storage/options.js
+++ b/src/core/background/storage/options.js
@@ -68,6 +68,7 @@ define((require) => {
 			scrobbleMusicOnly: false,
 			scrobbleEntertainmentOnly: false,
 			scrobbleMusicRecognisedOnly: false,
+			enableGetTrackInfoFromYtMusic: false,
 		},
 	};
 

--- a/src/core/background/storage/options.js
+++ b/src/core/background/storage/options.js
@@ -67,6 +67,7 @@ define((require) => {
 		YouTube: {
 			scrobbleMusicOnly: false,
 			scrobbleEntertainmentOnly: false,
+			scrobbleMusicRecognisedOnly: false,
 		},
 	};
 

--- a/src/ui/options/index.html
+++ b/src/ui/options/index.html
@@ -91,6 +91,10 @@
 										<label class="form-check-label" for="yt-entertainment-only" i18n="optionYtEntertainmentOnly" i18n-title="optionYtEntertainmentOnlyTitle"></label>
 									</div>
 									<div class="form-check">
+										<input class="form-check-input" type="checkbox" id="yt-enable-get-track-info-from-yt-music">
+										<label class="form-check-label" for="yt-enable-get-track-info-from-yt-music" i18n="optionYtGetTrackInfoFromYtMusic" i18n-title="optionYtGetTrackInfoFromYtMusicTitle"></label>
+									</div>
+									<div class="form-check">
 										<input class="form-check-input" type="checkbox" id="yt-music-recognised-only">
 										<label class="form-check-label" for="yt-music-recognised-only" i18n="optionYtMusicRecognisedOnly" i18n-title="optionYtMusicRecognisedOnlyTitle"></label>
 									</div>

--- a/src/ui/options/index.html
+++ b/src/ui/options/index.html
@@ -92,7 +92,7 @@
 									</div>
 									<div class="form-check">
 										<input class="form-check-input" type="checkbox" id="yt-music-recognised-only">
-										<label class="form-check-label" for="yt-music-recognised-only" i18n="optionYtMusicRecognisedOnly" i18n-title="optionYtMusicRecognisedOnly"></label>
+										<label class="form-check-label" for="yt-music-recognised-only" i18n="optionYtMusicRecognisedOnly" i18n-title="optionYtMusicRecognisedOnlyTitle"></label>
 									</div>
 
 									<p class="mb-0">

--- a/src/ui/options/index.html
+++ b/src/ui/options/index.html
@@ -90,6 +90,10 @@
 										<input class="form-check-input" type="checkbox" id="yt-entertainment-only">
 										<label class="form-check-label" for="yt-entertainment-only" i18n="optionYtEntertainmentOnly" i18n-title="optionYtEntertainmentOnlyTitle"></label>
 									</div>
+									<div class="form-check">
+										<input class="form-check-input" type="checkbox" id="yt-music-recognised-only">
+										<label class="form-check-label" for="yt-music-recognised-only" i18n="optionYtMusicRecognisedOnly" i18n-title="optionYtMusicRecognisedOnly"></label>
+									</div>
 
 									<p class="mb-0">
 										<small class="text-muted" i18n="optionYtDesc"></small>

--- a/src/ui/options/options.js
+++ b/src/ui/options/options.js
@@ -17,13 +17,15 @@ define((require) => {
 	const OPTIONS_UI_MAP = {
 		'#force-recognize': Options.FORCE_RECOGNIZE,
 		'#use-notifications': Options.USE_NOTIFICATIONS,
-		'#use-unrecognized-song-notifications': Options.USE_UNRECOGNIZED_SONG_NOTIFICATIONS,
+		'#use-unrecognized-song-notifications':
+			Options.USE_UNRECOGNIZED_SONG_NOTIFICATIONS,
 		'#scrobble-podcasts': Options.SCROBBLE_PODCASTS,
 	};
 	const CONNECTORS_OPTIONS_UI_MAP = {
 		YouTube: {
 			'#yt-music-only': 'scrobbleMusicOnly',
 			'#yt-entertainment-only': 'scrobbleEntertainmentOnly',
+			'#yt-music-recognised-only': 'scrobbleMusicRecognisedOnly',
 		},
 	};
 

--- a/src/ui/options/options.js
+++ b/src/ui/options/options.js
@@ -26,6 +26,8 @@ define((require) => {
 			'#yt-music-only': 'scrobbleMusicOnly',
 			'#yt-entertainment-only': 'scrobbleEntertainmentOnly',
 			'#yt-music-recognised-only': 'scrobbleMusicRecognisedOnly',
+			'#yt-enable-get-track-info-from-yt-music':
+				'enableGetTrackInfoFromYtMusic',
 		},
 	};
 


### PR DESCRIPTION
**Describe the changes you made**
Add a track info getter that uses youtube music to get its information. This information seems to be more reliable than the info in the description. Downside is that this getter has to make a request, which takes a bit, so there's a bit more delay before the scrobbler finds the information. It does cache all requests it has made already, so this is only the first time, as long as the user doesn't restart their browser.

At least in my experience this getter seems to me more reliable than the ones based on description/title, but I'm not sure how to verify this as it might depend greatly on the type of music you listen to. It's not perfect regrettably, for example it might swap names around compared to the most common value in Last.fm, eg. "Fireboy DML & Asake" becomes "Asake & Fireboy DML".

I also added an option to only scrobble videos that are recognised by yt music as a music video, which seems to work quite well.

**I can only write in English so someone else will have to translate this option to the other locales.**
