### PR TITLE
Update Amazing Radio connector

### DIFF
--- a/src/connectors/amazingradio.js
+++ b/src/connectors/amazingradio.js
@@ -1,25 +1,22 @@
 'use strict';
 
+const filter = MetadataFilter.createFilter({ track: removeEdit });
+
 Connector.playerSelector = '#player';
 
-Connector.trackSelector = [
-	'#player > div > div > div.playerInfo > div > div > h5 > a',
-	'#player > div > div > div.playerInfo > div:nth-child(2) > h3 > a.title',
-];
+Connector.artistSelector = ['#player .playerInfo h3.name > a', '#player .playerInfo .tune a.name'];
 
-Connector.artistSelector = [
-	'#player > div > div > div.playerInfo > div > div > h3 > a',
-	'#player > div > div > div.playerInfo > div:nth-child(2) > h3 > a.name',
-];
+Connector.trackSelector = ['#player .playerInfo h5.title > a', '#player .playerInfo .tune a.title'];
 
-Connector.trackArtSelector = '#player > div > div > img';
+Connector.trackArtSelector = '#player img.artwork';
 
-Connector.isPlaying = () =>
-	Util.hasElementClass(
-		'#player > div > div > div.control-btns > mat-icon',
-		'playing'
-	) ||
-	Util.getAttrFromSelectors(
-		'#player > div > div > div.control-btns.extras > mat-icon.mat-icon.notranslate.playerControls.mat-icon-no-color',
-		'data-mat-icon-name'
-	) === 'pause';
+Connector.isPlaying = () => {
+	const playerControlsIcon = Util.getAttrFromSelectors('#player .control-btns .playerControls', 'data-mat-icon-name');
+	return playerControlsIcon === 'levels' || playerControlsIcon === 'pause';
+};
+
+Connector.applyFilter(filter);
+
+function removeEdit(text) {
+	return text.replace(/\s?\((Clean|Radio) Edit\)/i, '');
+}

--- a/src/connectors/amazingradio.js
+++ b/src/connectors/amazingradio.js
@@ -10,6 +10,8 @@ Connector.trackSelector = ['#player .playerInfo h5.title > a', '#player .playerI
 
 Connector.trackArtSelector = '#player img.artwork';
 
+Connector.isTrackArtDefault = (url) => url.includes('/defaults/');
+
 Connector.isPlaying = () => {
 	const playerControlsIcon = Util.getAttrFromSelectors('#player .control-btns .playerControls', 'data-mat-icon-name');
 	return playerControlsIcon === 'levels' || playerControlsIcon === 'pause';


### PR DESCRIPTION
Update to PR #3535.

- Update unwieldy, fragile selectors to be more concise and utilize classes to hopefully prevent the connector from breaking if minor updates are made to the site.
- Update `isPlaying` to check value of a single attribute on the play button. Initial version had two different checks on the same element with different selectors.
- Add filter to remove "(Clean Edit)" and "(Radio Edit)" which are frequently appended to track titles.
- Add check for default track art.

Connector currently technically working, so no immediate need to release.