### PR TITLE
Fix Audacy connector

### DIFF
--- a/src/connectors/audacy.js
+++ b/src/connectors/audacy.js
@@ -1,7 +1,37 @@
 'use strict';
 
-Connector.playerSelector = '#radioPlayer';
-Connector.artistSelector = '#showDescription';
-Connector.trackSelector = '#showName';
-Connector.trackArtSelector = '#poster';
-Connector.pauseButtonSelector = '#playButton.stop';
+const audioPlayer = 'div[aria-label="Audio player"]';
+const buttonFullscreen = 'button[aria-label="Open full-screen player"]';
+
+Connector.playerSelector = '#root'; // player not in DOM until initiated by user
+
+Connector.trackSelector = `${audioPlayer} ${buttonFullscreen} span:first-of-type`;
+
+Connector.artistSelector = `${audioPlayer} ${buttonFullscreen} span:nth-of-type(2)`;
+
+Connector.getArtist = () => {
+	const artistStationText = Util.getTextFromSelectors(Connector.artistSelector);
+
+	if (artistStationText === null) {
+		return null;
+	}
+
+	return artistStationText.split(' • ')[0];
+};
+
+Connector.trackArtSelector = `${audioPlayer} ${buttonFullscreen} img`;
+
+Connector.isTrackArtDefault = (url) => url.includes('base64');
+
+Connector.isPlaying = () => {
+	const buttonPlaying = Util.getTextFromSelectors(`${audioPlayer} > div:first-of-type > div:nth-of-type(2) > button:not([aria-label=Like]) svg title`);
+	return buttonPlaying === 'Stop' || buttonPlaying === 'Pause';
+};
+
+Connector.isScrobblingAllowed = () => {
+	return (
+		Connector.getArtist() && !Connector.getArtist().includes('Audacy') &&
+		Connector.getTrack() && !Connector.getTrack().includes('Advertisement') &&
+		Connector.getArtist() !== Connector.getTrack()
+	);
+};


### PR DESCRIPTION
Resolves #3320. As noted, Audacy has deactivated its main player previously used by this connector.

Updated connector to scrobble from the mini player, which is thankfully still in the DOM when the full-screen player is activated.

Works for both broadcast stations and playlist stations:
- Broadcast station example: https://www.audacy.com/stations/947thewave
- Playlist station example: https://www.audacy.com/stations/princeandfriends

Selectors are odd because the site is built with React and uses randomly generated classes, which cannot be used because they will likely change whenever any site update is pushed.