### PR TITLE
Fix selector in Audacy connector

### DIFF
--- a/src/connectors/audacy.js
+++ b/src/connectors/audacy.js
@@ -24,7 +24,7 @@ Connector.trackArtSelector = `${audioPlayer} ${buttonFullscreen} img`;
 Connector.isTrackArtDefault = (url) => url.includes('base64');
 
 Connector.isPlaying = () => {
-	const buttonPlaying = Util.getTextFromSelectors(`${audioPlayer} > div:first-of-type > div:nth-of-type(2) > button:not([aria-label=Like]) svg title`);
+	const buttonPlaying = Util.getTextFromSelectors(`${audioPlayer} button:not([aria-label=Like]) svg title`);
 	return buttonPlaying === 'Stop' || buttonPlaying === 'Pause';
 };
 


### PR DESCRIPTION
Audacy made another update to their player where they added more nested divs, which broke the last selector used for the play button in #3550. After looking into it again and testing, the connector works with a less-specific and hopefully less fragile selector—basically removing the divs between the player selector and the play button.

Tested with the same links from the previous PR as well as https://www.audacy.com/stations/metallicaradio which was mentioned in a comment this morning.