### PR TITLE
Add connector for KINK

### DIFF
--- a/src/connectors/kinknl.js
+++ b/src/connectors/kinknl.js
@@ -1,0 +1,14 @@
+'use strict';
+
+Connector.playerSelector = '[class^=PopupPlayer_popupPlayer__player__]';
+
+Connector.artistTrackSelector = '[class^=PlayerTriton_playerTriton__title__]';
+
+Connector.isPlaying = () => {
+	return (
+		!Util.isElementVisible('[class*=PlayerTriton_playerTriton--loading__]') &&
+		Util.getAttrFromSelectors('[class^=PlayerTriton_playerTriton__left__] svg path', 'd') === 'M.08.192h28v28h-28z'
+	);
+};
+
+Connector.isScrobblingAllowed = () => !Connector.getArtistTrack().artist.startsWith('KINK');

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2239,6 +2239,13 @@ const connectors = [{
 	js: 'connectors/hardtunes.js',
 	id: 'hardtunes',
 }, {
+	label: 'KINK',
+	matches: [
+		'*://kink.nl/player/*',
+	],
+	js: 'connectors/kinknl.js',
+	id: 'kinknl',
+}, {
 	label: 'The Jazz Groove',
 	matches: [
 		'*://jazzgroove.org/*',

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2241,6 +2241,7 @@ const connectors = [{
 }, {
 	label: 'KINK',
 	matches: [
+		'*://kink.nl/player',
 		'*://kink.nl/player/*',
 	],
 	js: 'connectors/kinknl.js',


### PR DESCRIPTION
Requested in #3560 but was closed after realizing the main station is available via TuneIn.
However, it's a simple enough player, so added support for the actual site and its two other stations.
Player can be activated in the top right at https://kink.nl/ or https://kink.nl/player
NOTE: There is track art in the player, but it doesn't seem to refresh correctly, so it was left out.