### PR TITLE
Fix beatbump's connector

### DIFF
--- a/src/connectors/beatbump.js
+++ b/src/connectors/beatbump.js
@@ -23,5 +23,5 @@ Connector.getTrackArt = () => {
 
 
 Connector.isPlaying = () => {
-    return document.querySelector('.player-btn.player-title svg use').href.baseVal.replace(/.*\//, '') === 'icons-9852f1b5.svg#pause';
+	return document.querySelector('.player-btn.player-title svg use').href.baseVal.replace(/.*\//, '') === 'icons-9852f1b5.svg#pause';
 };

--- a/src/connectors/beatbump.js
+++ b/src/connectors/beatbump.js
@@ -23,5 +23,5 @@ Connector.getTrackArt = () => {
 
 
 Connector.isPlaying = () => {
-	return document.querySelector('.player-btn.player-title svg use').href.baseVal === '/icons.svg#pause';
+    return document.querySelector('.player-btn.player-title svg use').href.baseVal.replace(/.*\//, '') === 'icons-9852f1b5.svg#pause';
 };


### PR DESCRIPTION
**Describe the changes you made**
I changed the filename of the play/pause button so the extension knows the actual isPlaying state for https://beatbump.ml/.
I've also added a regex that matches anything after the last slash of the URL.

Fixes https://github.com/web-scrobbler/web-scrobbler/issues/3559

This is my first pull request on someone else's repo, hope everything is alright!