### PR TITLE
Add Gimme Metal to existing gimmeRadio connector

### DIFF
--- a/src/connectors/gimmeradio.js
+++ b/src/connectors/gimmeradio.js
@@ -11,6 +11,7 @@ Connector.onReady = Connector.onStateChanged;
 Connector.isScrobblingAllowed = () => {
 	return !(
 		Connector.getArtist().includes('Gimme Country') ||
-		Connector.getArtist().includes('Gimme Radio')
+		Connector.getArtist().includes('Gimme Radio') ||
+		Connector.getArtist().includes('Gimme Metal')
 	);
 };

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -1198,6 +1198,8 @@ const connectors = [{
 		'*://www.gimmeradio.com/*',
 		'*://gimmecountry.com/*',
 		'*://www.gimmecountry.com/*',
+		'*://gimmemetal.com/*',
+		'*://www.gimmemetal.com/*',
 	],
 	js: 'connectors/gimmeradio.js',
 	id: 'gimmeradio',


### PR DESCRIPTION
Added functionality to Gimme Radio connector so that it functions the same for www.gimmemetal.com as it does for  www.gimmecountry.com. 

- Adds gimmemetal.com urls to the existing gimmeradio connector.
- Adds 'Gimme Metal' to isScrobblingAllowed() function to ignore ads on Gimme Metal.  

Resolves #3588.
