### PR TITLE
Add connector for Rock Antenne

### DIFF
--- a/src/connectors/rockantenne.js
+++ b/src/connectors/rockantenne.js
@@ -1,0 +1,15 @@
+'use strict';
+
+Connector.playerSelector = '.l-highlight';
+
+Connector.artistSelector = '.c-player__currentartist';
+
+Connector.trackSelector = '.c-player__currenttitle';
+
+Connector.isPlaying = () => {
+	return Util.hasElementClass('.c-player', 'is-playing');
+};
+
+Connector.isScrobblingAllowed = () => {
+	return !Connector.getArtist().includes('ROCK ANTENNE');
+};

--- a/src/core/connectors.js
+++ b/src/core/connectors.js
@@ -2379,6 +2379,13 @@ const connectors = [{
 	],
 	js: 'connectors/lulu.fm.js',
 	id: 'lulufm',
+},	{
+	label: 'ROCK ANTENNE',
+	matches: [
+		'*://*rockantenne.*/webradio/*',
+	],
+	js: 'connectors/rockantenne.js',
+	id: 'rockantenne',
 }];
 
 define(() => connectors);


### PR DESCRIPTION
The Network has 30+ streams, including ROCK ANTENNE, ROCK ANTENNE Bayern, ROCK ANTENNE Hamburg und ROCK ANTENNE in Österreich