### PR TITLE
Update KCRW connector for Today's Top Tune

### DIFF
--- a/src/connectors/kcrw.js
+++ b/src/connectors/kcrw.js
@@ -1,7 +1,10 @@
 'use strict';
 
 const filter = MetadataFilter.createFilter({
-	artist: replaceSmartQuotes,
+	artist: [
+		removeShowName,
+		replaceSmartQuotes,
+	],
 	track: [
 		removeSmartQuotes,
 		replaceSmartQuotes,
@@ -27,7 +30,7 @@ Connector.getTrackInfo = () => {
 	}
 
 	if (!Util.hasElementClass(metaSelector, 'music') && artistText && showNameText === 'Today\'s Top Tune') {
-		const artistTrackSplit = artistText.split(': ');
+		const artistTrackSplit = artistText.split(/\s+[-\u2013]\s+/);
 		return {
 			artist: artistTrackSplit[0],
 			track: artistTrackSplit[1],
@@ -42,6 +45,10 @@ Connector.getTrackInfo = () => {
 Connector.isPlaying = () => Util.hasElementClass('button.play', 'active');
 
 Connector.applyFilter(filter);
+
+function removeShowName(text) { // filter for Today's Top Tune
+	return text.replace(/Today('|\u2019)s Top Tune:\s+/, '');
+}
 
 function removeSmartQuotes(text) { // filter for Today's Top Tune
 	return text.replace(/^[\u2018\u201c](.+)[\u2019\u201d](?=\s\(|$)/, '$1');


### PR DESCRIPTION
Haven't checked KCRW's Top Tune in a bit, but apparently as of Feb 20 they began including the name of the show with the artist and track in the player. They also changed the separator between the artist and track from a colon to either a dash or en dash. Spacing after the show name and around the separator is also inconsistent.

Updated the connector to account for the above changes. Can be tested at https://www.kcrw.com/music/shows/todays-top-tune

No rush to release, as this only affects Today's Top Tune; other music streams are still working as expected.
