### PR TITLE
Update Audacy connector to support both players

### DIFF
--- a/src/connectors/audacy.js
+++ b/src/connectors/audacy.js
@@ -1,31 +1,48 @@
 'use strict';
 
 const audioPlayer = 'div[aria-label="Audio player"]';
-const buttonFullscreen = 'button[aria-label="Open full-screen player"]';
+const buttonOpenFullscreen = 'button[aria-label="Open full-screen player"]';
+const buttonCloseFullscreen = 'button[aria-label="Close full-screen player"]';
+const fullArtistTrackSelector = `${buttonCloseFullscreen} + div span`;
 
 Connector.playerSelector = '#root'; // player not in DOM until initiated by user
 
-Connector.trackSelector = `${audioPlayer} ${buttonFullscreen} span:first-of-type`;
-
-Connector.artistSelector = `${audioPlayer} ${buttonFullscreen} span:nth-of-type(2)`;
-
 Connector.getArtist = () => {
-	const artistStationText = Util.getTextFromSelectors(Connector.artistSelector);
+	const miniArtistStationText = Util.getTextFromSelectors(`${audioPlayer} ${buttonOpenFullscreen} span:nth-of-type(2)`);
 
-	if (artistStationText === null) {
-		return null;
+	if (miniArtistStationText !== null) {
+		return miniArtistStationText.split(' • ')[0];
 	}
 
-	return artistStationText.split(' • ')[0];
+	if (fullArtistTrackSelector !== null) {
+		return Util.getTextFromSelectors(fullArtistTrackSelector).split(' - ')[1];
+	}
+
+	return null;
 };
 
-Connector.trackArtSelector = `${audioPlayer} ${buttonFullscreen} img`;
+Connector.getTrack = () => {
+	const miniTrackText = Util.getTextFromSelectors(`${audioPlayer} ${buttonOpenFullscreen} span:first-of-type`);
+
+	if (miniTrackText !== null) {
+		return miniTrackText;
+	}
+
+	if (fullArtistTrackSelector !== null) {
+		return Util.getTextFromSelectors(fullArtistTrackSelector).split(' - ')[0];
+	}
+
+	return null;
+};
+
+Connector.trackArtSelector = [`${audioPlayer} ${buttonOpenFullscreen} img`, `${buttonCloseFullscreen} + div img`];
 
 Connector.isTrackArtDefault = (url) => url.includes('base64');
 
 Connector.isPlaying = () => {
-	const buttonPlaying = Util.getTextFromSelectors(`${audioPlayer} button:not([aria-label=Like]) svg title`);
-	return buttonPlaying === 'Stop' || buttonPlaying === 'Pause';
+	const buttonSvgTitle = 'button:not([aria-label=Like]) svg title';
+	const buttonPlaying = Util.getTextFromSelectors([`${audioPlayer} ${buttonSvgTitle}`, `${buttonCloseFullscreen} + div ${buttonSvgTitle}`]);
+	return buttonPlaying === 'Pause' || buttonPlaying === 'Stop';
 };
 
 Connector.isScrobblingAllowed = () => {


### PR DESCRIPTION
As noted in the comments on the last Audacy connector update (#3561), they made another change where the mini player is removed from the DOM when the full-screen player is activated. The last overhaul of the connector (#3550) relied on the mini player always being available to read the track information.

This new update allows both the mini and full-screen players to be used and toggled without interrupting scrobbling. Selectors are still a bit odd to avoid using the randomly-generated React classes, which makes supporting two different players a bit tricky.

Still works for both broadcast stations and playlist stations:

- Broadcast station example: https://www.audacy.com/stations/kroq
- Playlist station example: https://www.audacy.com/stations/alterna90s

The only issue I noticed is that when linking directly to the full-screen player (if bookmarked, for example), the play button indicates that it's playing when it's really not, so the connector will be activated even though nothing is actually playing. Unfortunately, I couldn't find an additional check to combine with the play button, so this will just have to be considered as a bug in Audacy's player. Everything should work as expected if toggling to the full-screen player from the mini player though.