### PR TITLE
Update Audacy connector

### DIFF
--- a/src/connectors/audacy.js
+++ b/src/connectors/audacy.js
@@ -14,7 +14,7 @@ Connector.getArtist = () => {
 		return miniArtistStationText.split(' • ')[0];
 	}
 
-	if (fullArtistTrackSelector !== null) {
+	if (Util.isElementVisible(fullArtistTrackSelector)) {
 		return Util.getTextFromSelectors(fullArtistTrackSelector).split(' - ')[1];
 	}
 
@@ -28,7 +28,7 @@ Connector.getTrack = () => {
 		return miniTrackText;
 	}
 
-	if (fullArtistTrackSelector !== null) {
+	if (Util.isElementVisible(fullArtistTrackSelector)) {
 		return Util.getTextFromSelectors(fullArtistTrackSelector).split(' - ')[0];
 	}
 
@@ -40,7 +40,7 @@ Connector.trackArtSelector = [`${audioPlayer} ${buttonOpenFullscreen} img`, `${b
 Connector.isTrackArtDefault = (url) => url.includes('base64');
 
 Connector.isPlaying = () => {
-	const buttonSvgTitle = 'button:not([aria-label=Like]) svg title';
+	const buttonSvgTitle = 'button:not([aria-label=Like], [aria-label*=thumbs]) svg title';
 	const buttonPlaying = Util.getTextFromSelectors([`${audioPlayer} ${buttonSvgTitle}`, `${buttonCloseFullscreen} + div ${buttonSvgTitle}`]);
 	return buttonPlaying === 'Pause' || buttonPlaying === 'Stop';
 };

--- a/src/connectors/audacy.js
+++ b/src/connectors/audacy.js
@@ -48,7 +48,7 @@ Connector.isPlaying = () => {
 Connector.isScrobblingAllowed = () => {
 	return (
 		Connector.getArtist() && !Connector.getArtist().includes('Audacy') &&
-		Connector.getTrack() && !Connector.getTrack().includes('Advertisement') &&
+		Connector.getTrack() && !Connector.getTrack().startsWith('Advertisement') &&
 		Connector.getArtist() !== Connector.getTrack()
 	);
 };


### PR DESCRIPTION
Minor improvements to Audacy connector to:

- Prevent an error on splitting artist and track for full-screen player.
- Maintain isPlaying after giving a "thumbs up" to a playlist track.

Test URL: https://www.audacy.com/stations/80sunderground