### PR TITLE
Add connector for copyparty

### DIFF
--- a/src/connectors/copyparty.ts
+++ b/src/connectors/copyparty.ts
@@ -12,6 +12,6 @@ Connector.trackSelector = '#np_title';
 Connector.currentTimeSelector = '#np_pos';
 Connector.durationSelector = '#np_dur';
 
-this.getUniqueID = () => {
+Connector.getUniqueID = () => {
 	return Util.getTextFromSelectors('#np_url');
 };

--- a/src/connectors/copyparty.ts
+++ b/src/connectors/copyparty.ts
@@ -13,5 +13,5 @@ Connector.currentTimeSelector = '#np_pos';
 Connector.durationSelector = '#np_dur';
 
 this.getUniqueID = () => {
-	return document.getElementById('np_url').textContent;
+	return Util.getTextFromSelectors('#np_url');
 };

--- a/src/connectors/copyparty.ts
+++ b/src/connectors/copyparty.ts
@@ -1,0 +1,17 @@
+export {};
+
+Connector.playerSelector = '#np_inf';
+Connector.pauseButtonSelector = '#np_inf.playing';
+
+Connector.trackArtSelector = '#np_img';
+Connector.albumArtistSelector = '#np_circle';
+Connector.albumSelector = '#np_album';
+Connector.artistSelector = '#np_artist';
+Connector.trackSelector = '#np_title';
+
+Connector.currentTimeSelector = '#np_pos';
+Connector.durationSelector = '#np_dur';
+
+this.getUniqueID = () => {
+	return document.getElementById('np_url').textContent;
+};

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2088,4 +2088,10 @@ export default <ConnectorMeta[]>[
 		js: 'rockantenne.js',
 		id: 'rockantenne',
 	},
+	{
+		label: 'copyparty',
+		matches: ['*://127.0.0.1:3923/*', '*://a.ocv.me/*'],
+		js: 'copyparty.js',
+		id: 'copyparty',
+	},
 ];


### PR DESCRIPTION
**Describe the changes you made**
This adds support for [copyparty](https://github.com/9001/copyparty), a self-hosted file sharing service. As most copyparty instances are for private use, I've included patterns for the public demo server and for the default port when running the server locally.

These changes will work on all copyparty versions starting from v1.6.11 onwards. If you'd like to test the changes, please drop by the [demo server](https://a.ocv.me/pub/demo/music/Ubiktune%20-%20SOUNDSHOCK%202%20-%20FM%20FUNK%20TERRROR!!/) :>

**Additional context**
The same metadata is available through the media session api; however, the album cover URL inside the mediasession tags has a login token included as a URL parameter. Since everything works as expected even without this token, it felt like a good idea to strip it away before passing the image URL to the extension.