### PR TITLE
Add permission request to settings

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -12,6 +12,10 @@
         "message": "General",
         "description": "'General' section"
     },
+    "optionsPermissionsLabel": {
+        "message": "You have not granted Web Scrobbler the permission to access all sites, which means you have to click the extension icon to start scrobbling every time. Click here to grant the permission. Note that in safari the permission will not automatically be granted, but the next time you visit a supported site you will be able to click \"Always Allow on Every Website...\" to grant the permission.",
+        "description": "Label for permissions button"
+    },
     "optionUseNotifications": {
         "message": "Use now playing notifications",
         "description": "Option label"

--- a/src/ui/options/components/components.module.scss
+++ b/src/ui/options/components/components.module.scss
@@ -385,3 +385,19 @@ summary {
 	margin-left: 0.5em;
 	padding: 0.25em 0.5em;
 }
+
+.permissionsPopup {
+	background-color: var(--sidebar-bg);
+	color: var(--text);
+	margin: 0;
+	text-align: center;
+
+	button {
+		background: none;
+		border: none;
+		cursor: pointer;
+		font-size: 1.25em;
+		margin: 0;
+		padding: 1em 15vw;
+	}
+}

--- a/src/ui/options/components/permissions.tsx
+++ b/src/ui/options/components/permissions.tsx
@@ -3,6 +3,10 @@ import browser from 'webextension-polyfill';
 import styles from './components.module.scss';
 import { t } from '@/util/i18n';
 
+const desiredPermissions = {
+	origins: ['http://*/', 'https://*/'],
+};
+
 export default function Permissions() {
 	const [perms, setPerms] = createSignal(true);
 	hasPermissions(setPerms);
@@ -15,9 +19,7 @@ export default function Permissions() {
 					onClick={() => {
 						// This is inline and not async, as when it was not there were some issues with safari isTrusted
 						browser.permissions
-							.request({
-								origins: ['http://*/', 'https://*/'],
-							})
+							.request(desiredPermissions)
 							.then(setPerms);
 					}}
 				>
@@ -29,9 +31,5 @@ export default function Permissions() {
 }
 
 async function hasPermissions(setPerms: Setter<boolean>) {
-	setPerms(
-		await browser.permissions.contains({
-			origins: ['http://*/', 'https://*/'],
-		})
-	);
+	setPerms(await browser.permissions.contains(desiredPermissions));
 }

--- a/src/ui/options/components/permissions.tsx
+++ b/src/ui/options/components/permissions.tsx
@@ -1,0 +1,37 @@
+import { Setter, Show, createSignal } from 'solid-js';
+import browser from 'webextension-polyfill';
+import styles from './components.module.scss';
+import { t } from '@/util/i18n';
+
+export default function Permissions() {
+	const [perms, setPerms] = createSignal(true);
+	hasPermissions(setPerms);
+
+	return (
+		<Show when={!perms()}>
+			<div class={styles.permissionsPopup}>
+				<button
+					type="button"
+					onClick={() => {
+						// This is inline and not async, as when it was not there were some issues with safari isTrusted
+						browser.permissions
+							.request({
+								origins: ['http://*/', 'https://*/'],
+							})
+							.then(setPerms);
+					}}
+				>
+					{t('optionsPermissionsLabel')}
+				</button>
+			</div>
+		</Show>
+	);
+}
+
+async function hasPermissions(setPerms: Setter<boolean>) {
+	setPerms(
+		await browser.permissions.contains({
+			origins: ['http://*/', 'https://*/'],
+		})
+	);
+}

--- a/src/ui/options/main.tsx
+++ b/src/ui/options/main.tsx
@@ -18,6 +18,7 @@ import ContactComponent from './components/contact';
 import OptionsComponent from './components/options/options';
 import Accounts from './components/accounts';
 import { EditsModal } from './components/options/edited-tracks';
+import Permissions from './components/permissions';
 
 /**
  * All the different options pages, their sidebar labels, and icons.
@@ -93,6 +94,7 @@ function Options() {
 
 	return (
 		<>
+			<Permissions />
 			<div class={styles.settings}>
 				<Sidebar
 					items={settings}

--- a/src/ui/options/settings.module.scss
+++ b/src/ui/options/settings.module.scss
@@ -1,11 +1,16 @@
 body {
 	background-color: var(--background);
 	color: var(--text);
-	font-family: Helvetica, Arial, sans-serif;
 	font-size: 14px;
 	margin: 0;
 	padding: 0;
 	width: 100%;
+}
+
+body,
+button,
+input {
+	font-family: Helvetica, Arial, sans-serif;
 }
 
 a {


### PR DESCRIPTION
Adds a popup-esque thing on top of settings that asks the user to give host permissions if they didn't already. Helps a bit with UX, since this permission is no longer automatically granted in firefox/safari with manifest V3.

<img width="1278" alt="image" src="https://user-images.githubusercontent.com/69117606/232282714-4b6e773d-1cd7-42d6-a09c-32fc37969bde.png">
