### PR TITLE
Add settings button to popup

### DIFF
--- a/src/ui/popup/main.tsx
+++ b/src/ui/popup/main.tsx
@@ -4,7 +4,7 @@ import Unsupported from './unsupported';
 import * as ControllerMode from '@/core/object/controller/controller-mode';
 import { initializeThemes } from '@/theme/themes';
 import '@/theme/themes.scss';
-import { Match, Switch, createResource } from 'solid-js';
+import { Match, Switch, createResource, Show } from 'solid-js';
 import { popupListener, setupPopupListeners } from '@/util/communication';
 import Base from './base';
 import { getCurrentTab } from '@/core/background/util';
@@ -12,6 +12,15 @@ import Disabled from './disabled';
 import Err from './err';
 import NowPlaying from './nowplaying';
 import Edit from './edit';
+import Settings from '@suid/icons-material/SettingsOutlined';
+import browser from 'webextension-polyfill';
+import styles from './popup.module.scss';
+import { t } from '@/util/i18n';
+
+/**
+ * List of modes that have a settings button in the popup content, dont show supplementary settings icon.
+ */
+const settingModes = [ControllerMode.Disabled, ControllerMode.Err];
 
 /**
  * Component that determines what popup to show, and then shows it
@@ -29,32 +38,46 @@ function Popup() {
 	);
 
 	return (
-		<Switch fallback={<></>}>
-			<Match when={tab()?.mode === ControllerMode.Base}>
-				<Base />
-			</Match>
-			<Match when={tab()?.mode === ControllerMode.Disabled}>
-				<Disabled />
-			</Match>
-			<Match when={tab()?.mode === ControllerMode.Err}>
-				<Err />
-			</Match>
-			<Match
-				when={
-					tab()?.mode === ControllerMode.Playing ||
-					tab()?.mode === ControllerMode.Skipped ||
-					tab()?.mode === ControllerMode.Scrobbled
-				}
-			>
-				<NowPlaying tab={tab} />
-			</Match>
-			<Match when={tab()?.mode === ControllerMode.Unknown}>
-				<Edit tab={tab} />
-			</Match>
-			<Match when={tab()?.mode === ControllerMode.Unsupported}>
-				<Unsupported />
-			</Match>
-		</Switch>
+		<>
+			<Switch fallback={<></>}>
+				<Match when={tab()?.mode === ControllerMode.Base}>
+					<Base />
+				</Match>
+				<Match when={tab()?.mode === ControllerMode.Disabled}>
+					<Disabled />
+				</Match>
+				<Match when={tab()?.mode === ControllerMode.Err}>
+					<Err />
+				</Match>
+				<Match
+					when={
+						tab()?.mode === ControllerMode.Playing ||
+						tab()?.mode === ControllerMode.Skipped ||
+						tab()?.mode === ControllerMode.Scrobbled
+					}
+				>
+					<NowPlaying tab={tab} />
+				</Match>
+				<Match when={tab()?.mode === ControllerMode.Unknown}>
+					<Edit tab={tab} />
+				</Match>
+				<Match when={tab()?.mode === ControllerMode.Unsupported}>
+					<Unsupported />
+				</Match>
+			</Switch>
+
+			<Show when={!settingModes.includes(tab()?.mode ?? '')}>
+				<a
+					href={browser.runtime.getURL('src/ui/options/index.html')}
+					class={styles.settingsIcon}
+					target="_blank"
+					title={t('disabledSiteButton')}
+					rel="noopener noreferrer"
+				>
+					<Settings />
+				</a>
+			</Show>
+		</>
 	);
 }
 

--- a/src/ui/popup/popup.module.scss
+++ b/src/ui/popup/popup.module.scss
@@ -135,3 +135,15 @@ a {
 .bold {
 	font-weight: bold;
 }
+
+.settingsIcon {
+	bottom: 0.75em;
+	color: var(--text);
+	position: absolute;
+	right: 0.75em;
+
+	&:hover,
+	&:active {
+		color: var(--last-fm);
+	}
+}


### PR DESCRIPTION
Adds a settings button to the bottom right corner. Makes UX a bit better, especially in firefox/safari where theres a few button presses to get to preferences. Does not show on the pages that already have options buttons.

Closes #3507 

<img width="329" alt="image" src="https://user-images.githubusercontent.com/69117606/232286419-c303345c-1f6a-471e-93c1-8cd82a6da3c1.png">