### PR TITLE
Use offset icons for border

### DIFF
--- a/scripts/generate-icons.ts
+++ b/scripts/generate-icons.ts
@@ -97,7 +97,21 @@ enum themes {
 /**
  * Thickness of icon borders
  */
-const borderThickness = 1;
+const borderThickness = 0.5;
+
+/**
+ * Offset adjacency matrix
+ */
+const adjacencies = [
+	[borderThickness, 0],
+	[borderThickness, borderThickness],
+	[0, borderThickness],
+	[-borderThickness, borderThickness],
+	[-borderThickness, 0],
+	[-borderThickness, -borderThickness],
+	[0, -borderThickness],
+	[borderThickness, -borderThickness],
+];
 
 /**
  * Safari tints icons - we only use a single color for these.
@@ -183,10 +197,18 @@ async function createMonochromeIcon(
 		return iconCanvas.toBuffer();
 	}
 
-	// now draw icon border
+	// now draw offset icons to create a border
 	const canvas = createCanvas(size, size);
 	const ctx = canvas.getContext('2d');
-	ctx.drawImage(image, 0, 0, size, size);
+	for (const adjacency of adjacencies) {
+		ctx.drawImage(
+			image,
+			adjacency[0] + borderThickness,
+			adjacency[1] + borderThickness,
+			iconSize,
+			iconSize
+		);
+	}
 	// fill in
 	ctx.globalCompositeOperation = 'source-in';
 	ctx.fillStyle = borderColor;


### PR DESCRIPTION
Should make the icon borders more uniform and a bit nicer

Old:
<img width="244" alt="image" src="https://user-images.githubusercontent.com/69117606/232458703-c76a764b-bdfb-4a02-966a-48e298bdaa69.png">

New:
<img width="245" alt="image" src="https://user-images.githubusercontent.com/69117606/232458543-ed86651f-57fa-4e5c-9c72-b766beeff914.png">