### PR TITLE
Add safari build process to workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,3 +46,9 @@ jobs:
       - name: Build the extension for Safari
         run: |
           npm run build safari
+
+      - name: Upload the extension for Safari as an artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: web-scrobbler-safari
+          path: build/safari

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Build the extension
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
@@ -42,3 +42,7 @@ jobs:
         with:
           name: web-scrobbler-firefox
           path: build/firefox
+
+      - name: Build the extension for Safari
+        run: |
+          npm run build safari


### PR DESCRIPTION
Also migrates entire build workflow to macos, but has no impact on existing workflows.

EDIT: also makes the build process take significantly longer, but I don't think theres a way to avoid this