### PR TITLE
Preload options

### DIFF
--- a/src/ui/options/components/options/connector-options.tsx
+++ b/src/ui/options/components/options/connector-options.tsx
@@ -8,13 +8,14 @@ const connectorOptions = BrowserStorage.getStorage(
 	BrowserStorage.CONNECTORS_OPTIONS
 );
 
+const [options, setOptions] = createResource(
+	connectorOptions.get.bind(connectorOptions)
+);
+
 /**
  * Component that shows the options specific to only a certain connector.
  */
 export default function ConnectorOptionsList() {
-	const [options, setOptions] = createResource(
-		connectorOptions.get.bind(connectorOptions)
-	);
 	return (
 		<>
 			<h2>YouTube</h2>

--- a/src/ui/options/components/options/connector-override.tsx
+++ b/src/ui/options/components/options/connector-override.tsx
@@ -41,15 +41,11 @@ const [overrideOptions, setOverrideOptions] = createResource(
 const [customPatternOptions, setCustomPatternOptions] = createResource(
 	customPatterns.get.bind(customPatterns)
 );
-console.log(options.loading);
 
 /**
  * Component that shows the override options for all connectors
  */
 export default function ConnectorOverrideOptions() {
-	console.log(options());
-	console.log(overrideOptions());
-	console.log(customPatternOptions());
 	return (
 		<>
 			<h2>{t('optionsSupportedWebsites')}</h2>

--- a/src/ui/options/components/options/edited-tracks.tsx
+++ b/src/ui/options/components/options/edited-tracks.tsx
@@ -33,12 +33,13 @@ export default function EditedTracks(props: {
 	);
 }
 
+const [edits, { mutate }] = createResource(localCache.get.bind(localCache));
+
 /**
  * Component that shows all the currently registered track edits and allows the user to delete them.
  * To be displayed in a modal.
  */
 export function EditsModal() {
-	const [edits, { mutate }] = createResource(localCache.get.bind(localCache));
 	return (
 		<>
 			<h1>

--- a/src/ui/options/components/options/global-options.tsx
+++ b/src/ui/options/components/options/global-options.tsx
@@ -62,12 +62,12 @@ export default function GlobalOptionsList(props: {
 	);
 }
 
+const [theme, setTheme] = createResource(getTheme);
+
 /**
  * Component that allows the user to select a display theme.
  */
 function ThemeSelector() {
-	const [theme, setTheme] = createResource(getTheme);
-
 	return (
 		<div class={styles.selectOption}>
 			<label title={t('optionThemeTitle')} class={styles.bigLabel}>

--- a/src/ui/options/components/options/options.tsx
+++ b/src/ui/options/components/options/options.tsx
@@ -9,6 +9,10 @@ import ConnectorOverrideOptions from './connector-override';
 
 const globalOptions = BrowserStorage.getStorage(BrowserStorage.OPTIONS);
 
+const [options, setOptions] = createResource(
+	globalOptions.get.bind(globalOptions)
+);
+
 /**
  * Component that shows options to the user
  */
@@ -16,9 +20,6 @@ export default function OptionsComponent(props: {
 	setActiveModal: Setter<string>;
 	modal: HTMLDialogElement | undefined;
 }) {
-	const [options, setOptions] = createResource(
-		globalOptions.get.bind(globalOptions)
-	);
 	return (
 		<>
 			<h1>{t('optionsOptions')}</h1>


### PR DESCRIPTION
#3652 already fixed any speed issue there may have been due to not preloading, but left the transition to the options page looking pretty bad, with toggles flickering and select text popping in.

By preloading the options, it ensures the user's preferred settings are loaded before going to the page, ensuring no flickering.

Makes some additional changes to the loading of override options to reduce lag. (Does not render connector options until the user clicks to expand, did some modification to existing lazy loading too)