### PR TITLE
Split build workflow into multiple jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,66 @@ on:
   pull_request:
     types: [opened, synchronize]
 jobs:
-  build:
-    name: Build the extension
+  build-chrome:
+    name: Build the extension for Chrome
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Get Node.js version from .nvmrc
+        id: get-node-version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '${{ steps.get-node-version.outputs.NODE_VERSION }}'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build the extension
+        run: |
+          npm run build chrome
+
+      - name: Upload the extension as an artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: web-scrobbler-chrome
+          path: build/chrome
+    
+  build-firefox:
+    name: Build the extension for Firefox
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Get Node.js version from .nvmrc
+        id: get-node-version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '${{ steps.get-node-version.outputs.NODE_VERSION }}'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build the extension
+        run: |
+          npm run build firefox
+
+      - name: Upload the extension as an artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: web-scrobbler-firefox
+          path: build/firefox
+
+  build-safari:
+    name: Build the extension for Safari
     runs-on: macos-latest
     steps:
       - name: Checkout the repository
@@ -23,31 +81,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build the extension for Chrome
-        run: |
-          npm run build chrome
-
-      - name: Upload the extension for Chrome as an artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: web-scrobbler-chrome
-          path: build/chrome
-
-      - name: Build the extension for Firefox
-        run: |
-          npm run build firefox
-
-      - name: Upload the extension for Firefox as an artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: web-scrobbler-firefox
-          path: build/firefox
-
-      - name: Build the extension for Safari
+      - name: Build the extension
         run: |
           npm run build safari
 
-      - name: Upload the extension for Safari as an artifact
+      - name: Upload the extension as an artifact
         uses: actions/upload-artifact@v3
         with:
           name: web-scrobbler-safari


### PR DESCRIPTION
Makes the build workflow not take quite as long (but still usually a bit longer than before safari build).

Not very DRY, but it does the trick.