### PR TITLE
Fix play button case of default isPlaying.

### DIFF
--- a/src/core/content/connector.ts
+++ b/src/core/content/connector.ts
@@ -600,7 +600,7 @@ export default class BaseConnector {
 
 		this.isPlaying = () => {
 			if (this.playButtonSelector) {
-				return Util.isElementVisible(this.playButtonSelector);
+				return !Util.isElementVisible(this.playButtonSelector);
 			}
 
 			if (this.pauseButtonSelector) {


### PR DESCRIPTION
The V3 changes greatly simplified isPlaying, which changed the semantics slightly. This change flips the buggy first boolean case: When the play button is visible, music is *not* playing.