### PR TITLE
dont output "expected a number or a string"

### DIFF
--- a/src/core/storage/wrapper.ts
+++ b/src/core/storage/wrapper.ts
@@ -227,9 +227,6 @@ export default class StorageWrapper<K extends keyof DataModels> {
 			if (hiddenKeys.includes(key)) {
 				return hideObjectValue(value);
 			}
-			if (typeof value !== 'string' && typeof value !== 'number') {
-				return 'expected a number or a string';
-			}
 
 			return value;
 		};


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->

Seems to work just fine without this when testing  - should we even be logging this? Feels like it's causing a bit of noise in the console of each page? 

**Additional context**
<!-- Add any other context or screenshots here. -->
