### PR TITLE
Make options page more responsive, improve building

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -1,7 +1,7 @@
 import { build } from 'vite';
 import * as configs from './vite.configs';
 import { mkdir } from 'fs/promises';
-import { getBrowser, releaseTarget, releaseType } from './scripts/util';
+import { getBrowser, isDev, releaseTarget, releaseType } from './scripts/util';
 import colorLog from 'scripts/log';
 import { exec } from 'child_process';
 import { emptydirSync } from 'fs-extra';
@@ -40,20 +40,32 @@ async function main() {
 	];
 	await Promise.all(scripts);
 
+	if (isDev() && releaseTarget === 'safari') {
+		await new Promise((resolve) => {
+			setTimeout(resolve, 10000);
+		});
+	}
+
 	if (releaseTarget === 'safari') {
 		colorLog('Compiling safari extension', 'info');
 		await new Promise<void>((resolve, reject) => {
-			exec('bash safari.sh', (err, stdout, stderr) => {
-				if (err) {
-					colorLog(err, 'error');
-					colorLog(stdout, 'info');
-					colorLog(stderr, 'error');
-					reject();
-					return;
+			exec(
+				`bash safari.sh${isDev() ? ' dev' : ''}`,
+				(err, stdout, stderr) => {
+					if (err) {
+						colorLog(err, 'error');
+						colorLog(stdout, 'info');
+						colorLog(stderr, 'error');
+						reject();
+						return;
+					}
+					colorLog(
+						'Successfully compiled safari extension',
+						'success'
+					);
+					resolve();
 				}
-				colorLog('Successfully compiled safari extension', 'success');
-				resolve();
-			});
+			);
 		});
 	}
 

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -24,7 +24,7 @@ export const common: Manifest.WebExtensionManifest = {
 	],
 
 	background: {
-		service_worker: 'background/main.js',
+		scripts: ['background/main.js'],
 	},
 
 	web_accessible_resources: [
@@ -56,6 +56,9 @@ export const common: Manifest.WebExtensionManifest = {
  */
 export const chromeManifest: Manifest.WebExtensionManifest = {
 	...common,
+	background: {
+		service_worker: 'background/main.js',
+	},
 };
 
 /**
@@ -70,10 +73,6 @@ export const safariManifest: Manifest.WebExtensionManifest = {
  */
 export const firefoxManifest: Manifest.WebExtensionManifest = {
 	...common,
-
-	background: {
-		scripts: ['background/main.js'],
-	},
 
 	browser_specific_settings: {
 		gecko: {

--- a/safari.sh
+++ b/safari.sh
@@ -7,5 +7,9 @@ mkdir build/safarixcode
 rm -rf build/safari
 mkdir build/safari
 cd build/safarixcode
-xcrun safari-web-extension-converter ../safariraw --no-open
-xcodebuild -workspace "./Web Scrobbler/Web Scrobbler.xcodeproj/project.xcworkspace" -scheme "Web Scrobbler (macOS)" -configuration Release CONFIGURATION_BUILD_DIR="../../safari" build
+if [ "${@: -1}" = "dev" ]; then
+	xcrun safari-web-extension-converter ../safariraw
+else
+	xcrun safari-web-extension-converter ../safariraw --no-open
+	xcodebuild -workspace "./Web Scrobbler/Web Scrobbler.xcodeproj/project.xcworkspace" -scheme "Web Scrobbler (macOS)" -configuration Release CONFIGURATION_BUILD_DIR="../../safari" build
+fi

--- a/src/core/background/action.ts
+++ b/src/core/background/action.ts
@@ -38,13 +38,13 @@ export async function updateAction() {
  */
 async function updateMenus(tab: ManagerTab): Promise<void> {
 	if (tab.mode === ControllerMode.Unsupported) {
-		browser.contextMenus.update(contextMenus.ENABLE_CONNECTOR, {
+		browser.contextMenus?.update(contextMenus.ENABLE_CONNECTOR, {
 			visible: false,
 		});
-		browser.contextMenus.update(contextMenus.DISABLE_CONNECTOR, {
+		browser.contextMenus?.update(contextMenus.DISABLE_CONNECTOR, {
 			visible: false,
 		});
-		browser.contextMenus.update(contextMenus.DISABLE_UNTIL_CLOSED, {
+		browser.contextMenus?.update(contextMenus.DISABLE_UNTIL_CLOSED, {
 			visible: false,
 		});
 		return;
@@ -53,27 +53,27 @@ async function updateMenus(tab: ManagerTab): Promise<void> {
 	const tabData = await browser.tabs.get(tab.tabId);
 	const connector = await getConnectorByUrl(tabData.url ?? '');
 	if (tab.mode === ControllerMode.Disabled) {
-		browser.contextMenus.update(contextMenus.ENABLE_CONNECTOR, {
+		browser.contextMenus?.update(contextMenus.ENABLE_CONNECTOR, {
 			visible: true,
 			title: t('menuEnableConnector', connector?.label),
 		});
-		browser.contextMenus.update(contextMenus.DISABLE_CONNECTOR, {
+		browser.contextMenus?.update(contextMenus.DISABLE_CONNECTOR, {
 			visible: false,
 		});
-		browser.contextMenus.update(contextMenus.DISABLE_UNTIL_CLOSED, {
+		browser.contextMenus?.update(contextMenus.DISABLE_UNTIL_CLOSED, {
 			visible: false,
 		});
 		return;
 	}
 
-	browser.contextMenus.update(contextMenus.ENABLE_CONNECTOR, {
+	browser.contextMenus?.update(contextMenus.ENABLE_CONNECTOR, {
 		visible: false,
 	});
-	browser.contextMenus.update(contextMenus.DISABLE_CONNECTOR, {
+	browser.contextMenus?.update(contextMenus.DISABLE_CONNECTOR, {
 		visible: true,
 		title: t('menuDisableConnector', connector?.label),
 	});
-	browser.contextMenus.update(contextMenus.DISABLE_UNTIL_CLOSED, {
+	browser.contextMenus?.update(contextMenus.DISABLE_UNTIL_CLOSED, {
 		visible: true,
 		title: t('menuDisableUntilTabClosed', connector?.label),
 	});

--- a/src/core/background/main.ts
+++ b/src/core/background/main.ts
@@ -38,7 +38,7 @@ browser.runtime.onInstalled.addListener(startupFunc);
 browser.tabs.onRemoved.addListener(onRemovedUpdate);
 browser.tabs.onUpdated.addListener(updateTabList);
 browser.tabs.onActivated.addListener(onActivatedUpdate);
-browser.contextMenus.onClicked.addListener(contextMenuHandler);
+browser.contextMenus?.onClicked.addListener(contextMenuHandler);
 
 /**
  * Update action and context menus to reflect a tab being closed.
@@ -299,21 +299,21 @@ function startupFunc() {
 
 	setRegexDefaults();
 
-	browser.contextMenus.create({
+	browser.contextMenus?.create({
 		id: contextMenus.ENABLE_CONNECTOR,
 		visible: false,
 		contexts: ['action'],
 		title: 'Error: You should not be seeing this',
 	});
 
-	browser.contextMenus.create({
+	browser.contextMenus?.create({
 		id: contextMenus.DISABLE_CONNECTOR,
 		visible: false,
 		contexts: ['action'],
 		title: 'Error: You should not be seeing this',
 	});
 
-	browser.contextMenus.create({
+	browser.contextMenus?.create({
 		id: contextMenus.DISABLE_UNTIL_CLOSED,
 		visible: false,
 		contexts: ['action'],

--- a/src/theme/themes.scss
+++ b/src/theme/themes.scss
@@ -6,6 +6,7 @@ $themes: (
 		background: #fff,
 		checkbox-inactive: #8e8e8e,
 		sidebar-bg: rgba(250, 235, 235, 0.7),
+		context-bg: rgba(250, 235, 235, 0.95),
 		modal-bg: rgba(255, 255, 255, 0.95),
 		last-fm-bg: #faebeb,
 		muted-text: #555,
@@ -22,6 +23,7 @@ $themes: (
 		background: #1e1e1e,
 		checkbox-inactive: #8e8e8e,
 		sidebar-bg: rgba(194, 57, 55, 0.7),
+		context-bg: rgba(194, 57, 55, 0.95),
 		modal-bg: rgba(40, 40, 40, 0.95),
 		last-fm-bg: #c23937,
 		muted-text: #bbb,
@@ -39,4 +41,9 @@ $themes: (
 			--#{$key}: #{$value};
 		}
 	}
+}
+
+body {
+	// Avoid animation flickering in iOS
+	-webkit-transform: translate3d(0,0,0);
 }

--- a/src/ui/components/context-menu/context-menu.module.scss
+++ b/src/ui/components/context-menu/context-menu.module.scss
@@ -1,0 +1,139 @@
+.contextMenu {
+	background-color: var(--last-fm-bg);
+	bottom: 0;
+	color: var(--text);
+	display: flex;
+
+	.contextMenuItem {
+		flex-grow: 1;
+		padding: 0.5em 0;
+		position: relative;
+
+		&.activeDialogButton::after {
+			animation: 0.1s ease-in-out forwards showTip;
+			border-left: 20px solid transparent;
+			border-right: 20px solid transparent;
+			border-top: 20px solid var(--context-bg);
+			content: '';
+			height: 0;
+			left: 50%;
+			position: absolute;
+			top: -20px;
+			transform: translateX(-50%) scaleY(0);
+			transform-origin: center;
+			width: 0;
+		}
+	}
+}
+
+.contextMenuDialog {
+	animation: 0s ease-in-out forwards hide;
+	background-color: var(--context-bg);
+	border: none;
+	border-radius: 0.5em;
+	color: var(--text);
+	display: flex;
+	flex-direction: column;
+	min-width: 50vw;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	transform: translateY(calc(-100%)) scale(0);
+	transform-origin: bottom center;
+	z-index: 0;
+
+
+	// stylelint-disable-next-line no-duplicate-selectors
+	& {
+		/* avoid flickering on ios */
+		-webkit-backface-visibility: hidden;
+		-webkit-perspective: 1000;
+	}
+
+
+	&.mountedAnimation {
+		animation-duration: 0.1s;
+	}
+
+	&[open] {
+		animation: 0.1s ease-in-out forwards show;
+	}
+
+	.contextMenuItem {
+		padding: 1em;
+
+		&:not(:last-child) {
+			border-bottom: 1px solid var(--last-fm);
+		}
+	}
+}
+
+.contextMenu,
+.contextMenuDialog {
+	// stylelint-disable-next-line no-duplicate-selectors
+	& {
+		/* avoid flickering on ios */
+		-webkit-backface-visibility: hidden;
+		-webkit-perspective: 1000;
+	}
+
+	.contextMenuItem {
+		background-color: transparent;
+		border: none;
+		color: var(--text);
+		cursor: pointer;
+		display: flex;
+		flex-direction: column;
+		font-size: 1em;
+		justify-content: center;
+
+		& > * {
+			cursor: pointer;
+			display: block;
+			margin: 0 auto;
+		}
+
+		&:hover {
+			background-color: var(--always-last-fm-hover);
+			color: var(--always-light);
+		}
+	}
+}
+
+@keyframes show {
+	0% {
+		display: none;
+		transform: translateY(calc(-100%)) scale(0);
+	}
+	1% {
+		display: flex;
+		transform: translateY(calc(-100%)) scale(0);
+	}
+	100% {
+		display: flex;
+		transform: translateY(calc(-100% - 20px)) scale(1);
+	}
+}
+
+@keyframes hide {
+	0% {
+		display: flex;
+		transform: translateY(calc(-100% - 20px)) scale(1);
+	}
+	99% {
+		display: flex;
+		transform: translateY(calc(-100%)) scale(0);
+	}
+	100% {
+		display: none;
+	}
+}
+
+@keyframes showTip {
+	from {
+		transform: translateX(-50%) scaleY(0);
+	}
+	to {
+		transform: translateX(-50%) scaleY(1);
+	}
+}

--- a/src/ui/components/context-menu/context-menu.tsx
+++ b/src/ui/components/context-menu/context-menu.tsx
@@ -1,0 +1,107 @@
+import {
+	Navigator,
+	NavigatorButton,
+	NavigatorButtonGroup,
+	NavigatorNavigationButton,
+	itemIsSingular,
+	triggerNavigationButton,
+} from '@/ui/options/components/navigator';
+import { For, Setter, Show, createSignal, onMount } from 'solid-js';
+import styles from './context-menu.module.scss';
+import { t } from '@/util/i18n';
+
+function closeDialogs(e: MouseEvent) {
+	const dialogs = document.querySelectorAll('dialog');
+	dialogs.forEach((dialog) => {
+		dialog.close();
+	});
+	const dialogButtons = document.querySelectorAll(
+		`.${styles.activeDialogButton}`
+	);
+	dialogButtons.forEach((dialogButton) => {
+		dialogButton.classList.remove(styles.activeDialogButton);
+	});
+
+	if (!(e.target instanceof Element)) return;
+
+	const dialogButton = e.target.closest(`.${styles.contextMenuItem}`);
+	const dialog = dialogButton?.nextElementSibling;
+
+	if (!(dialog instanceof HTMLDialogElement)) return;
+
+	dialog.show();
+	dialogButton?.classList.add(styles.activeDialogButton);
+}
+
+export default function ContextMenu(props: {
+	items: Navigator;
+	setActiveSetting: Setter<NavigatorNavigationButton>;
+}) {
+	onMount(() => {
+		window.addEventListener('click', closeDialogs);
+		return () => window.removeEventListener('click', closeDialogs);
+	});
+
+	return (
+		<div class={styles.contextMenu}>
+			<ContextMenuItems
+				items={props.items}
+				setActiveSetting={props.setActiveSetting}
+			/>
+		</div>
+	);
+}
+
+function ContextMenuItems(props: {
+	items: Navigator;
+	setActiveSetting: Setter<NavigatorNavigationButton>;
+}) {
+	return (
+		<For each={props.items}>
+			{(item) => (
+				<ContextMenuItem
+					item={item}
+					setActiveSetting={props.setActiveSetting}
+				/>
+			)}
+		</For>
+	);
+}
+
+function ContextMenuItem(props: {
+	item: NavigatorButtonGroup | NavigatorButton;
+	setActiveSetting: Setter<NavigatorNavigationButton>;
+}) {
+	const [mounted, setMounted] = createSignal(false);
+	// hacky way to ensure animation doesnt play on load. If its not loaded it just fails to display an animation, no big deal.
+	onMount(() => {
+		setTimeout(() => {
+			setMounted(true);
+		}, 1000);
+	});
+	return (
+		<>
+			<button
+				class={styles.contextMenuItem}
+				onClick={() =>
+					triggerNavigationButton(props.item, props.setActiveSetting)
+				}
+			>
+				<props.item.icon />
+				<label>{t(props.item.namei18n)}</label>
+			</button>
+			<Show when={!itemIsSingular(props.item)}>
+				<dialog
+					class={`${styles.contextMenuDialog} ${
+						mounted() && `${styles.mountedAnimation}`
+					}`}
+				>
+					<ContextMenuItems
+						items={(props.item as NavigatorButtonGroup).group}
+						setActiveSetting={props.setActiveSetting}
+					/>
+				</dialog>
+			</Show>
+		</>
+	);
+}

--- a/src/ui/options/components/components.module.scss
+++ b/src/ui/options/components/components.module.scss
@@ -152,6 +152,7 @@ ul {
 		margin-left: auto;
 		position: relative;
 		width: $tickWidth;
+		z-index: -1;
 
 		.checkbox {
 			background-color: var(--always-light);

--- a/src/ui/options/components/edit-options/edit-options.tsx
+++ b/src/ui/options/components/edit-options/edit-options.tsx
@@ -2,9 +2,10 @@ import { Setter } from 'solid-js';
 import EditedTracks from './edited-tracks';
 import RegexEdits from './regex-edits';
 import { t } from '@/util/i18n';
+import { ModalType } from '../navigator';
 
 export default function EditOptions(props: {
-	setActiveModal: Setter<string>;
+	setActiveModal: Setter<ModalType>;
 	modal: HTMLDialogElement | undefined;
 }) {
 	return (

--- a/src/ui/options/components/edit-options/edited-tracks.tsx
+++ b/src/ui/options/components/edit-options/edited-tracks.tsx
@@ -5,7 +5,7 @@ import * as BrowserStorage from '@/core/storage/browser-storage';
 import styles from '../components.module.scss';
 import Delete from '@suid/icons-material/DeleteOutlined';
 import { ExportEdits, ImportEdits, ViewEdits } from './util';
-import { ModalType } from '../../main';
+import { ModalType } from '../navigator';
 
 const localCache = BrowserStorage.getStorage(BrowserStorage.LOCAL_CACHE);
 const [edits, { mutate }] = createResource(localCache.get.bind(localCache));

--- a/src/ui/options/components/edit-options/regex-edits.tsx
+++ b/src/ui/options/components/edit-options/regex-edits.tsx
@@ -5,7 +5,7 @@ import styles from '../components.module.scss';
 import Delete from '@suid/icons-material/DeleteOutlined';
 import { FieldType, RegexEdit, pascalCaseField } from '@/util/regex';
 import { ExportEdits, ImportEdits, ViewEdits } from './util';
-import { ModalType } from '../../main';
+import { ModalType } from '../navigator';
 
 const regexEdits = BrowserStorage.getStorage(BrowserStorage.REGEX_EDITS);
 const [edits, { mutate }] = createResource(regexEdits.get.bind(regexEdits));

--- a/src/ui/options/components/edit-options/util.tsx
+++ b/src/ui/options/components/edit-options/util.tsx
@@ -8,7 +8,7 @@ import styles from '../components.module.scss';
 import { t } from '@/util/i18n';
 import { Setter, createSignal } from 'solid-js';
 import { RegexEdit } from '@/util/regex';
-import { ModalType } from '../../main';
+import { ModalType } from '../navigator';
 
 type EditWrapper = StorageWrapper<
 	typeof BrowserStorage.REGEX_EDITS | typeof BrowserStorage.LOCAL_CACHE

--- a/src/ui/options/components/navigator.ts
+++ b/src/ui/options/components/navigator.ts
@@ -1,0 +1,124 @@
+import { Component, Setter } from 'solid-js';
+import Info from '@suid/icons-material/InfoOutlined';
+import Help from '@suid/icons-material/HelpOutlined';
+import Contacts from '@suid/icons-material/ContactsOutlined';
+import Settings from '@suid/icons-material/SettingsOutlined';
+import Edit from '@suid/icons-material/EditOutlined';
+import Extension from '@suid/icons-material/ExtensionOutlined';
+import ManageAccounts from '@suid/icons-material/ManageAccountsOutlined';
+import InfoComponent from '@/ui/options/components/info';
+import ShowSomeLove from '@/ui/options/components/showSomeLove';
+import FAQ from '@/ui/options/components/faq';
+import ContactComponent from '@/ui/options/components/contact';
+import OptionsComponent from '@/ui/options/components/options/options';
+import Accounts from '@/ui/options/components/accounts';
+import ConnectorOverrideOptions from '@/ui/options/components/connector-override';
+import EditOptions from '@/ui/options/components/edit-options/edit-options';
+import Favorite from '@suid/icons-material/FavoriteOutlined';
+
+/**
+ * Type indicating possible states for modal
+ */
+export type ModalType = 'savedEdits' | 'regexEdits' | '';
+
+/**
+ * Singular navigator button
+ */
+export type NavigatorNavigationButton = {
+	namei18n: string;
+	icon: typeof ManageAccounts;
+	element: Component<{
+		setActiveModal: Setter<ModalType>;
+		modal: HTMLDialogElement | undefined;
+	}>;
+};
+
+/**
+ * Singular navigator button that performs an action rather than opening a page
+ */
+export type NavigatorActionButton = {
+	namei18n: string;
+	icon: typeof ManageAccounts;
+	action: () => void;
+};
+
+export type NavigatorButton = NavigatorNavigationButton | NavigatorActionButton;
+
+/**
+ * Group of navigator buttons
+ */
+export type NavigatorButtonGroup = {
+	namei18n: string;
+	icon: typeof ManageAccounts;
+	group: NavigatorButton[];
+};
+
+/**
+ * A navigator consisting of a list of buttons and button groups
+ */
+export type Navigator = (NavigatorButton | NavigatorButtonGroup)[];
+
+/**
+ * All the different options pages, their sidebar labels, and icons.
+ */
+export const settings: Navigator = [
+	{ namei18n: 'optionsAccounts', icon: ManageAccounts, element: Accounts },
+	{
+		namei18n: 'optionsOptions',
+		icon: Settings,
+		group: [
+			{
+				namei18n: 'optionsOptions',
+				icon: Settings,
+				element: OptionsComponent,
+			},
+			{ namei18n: 'optionsEdits', icon: Edit, element: EditOptions },
+			{
+				namei18n: 'optionsConnectors',
+				icon: Extension,
+				element: ConnectorOverrideOptions,
+			},
+		],
+	},
+	{
+		namei18n: 'optionsAbout',
+		icon: Info,
+		group: [
+			{
+				namei18n: 'contactTitle',
+				icon: Contacts,
+				element: ContactComponent,
+			},
+			{ namei18n: 'faqTitle', icon: Help, element: FAQ },
+			{ namei18n: 'optionsAbout', icon: Info, element: InfoComponent },
+		],
+	},
+	{ namei18n: 'showSomeLoveTitle', icon: Favorite, element: ShowSomeLove },
+];
+
+export function triggerNavigationButton(
+	button: NavigatorButton | NavigatorButtonGroup,
+	setActiveSetting: Setter<NavigatorNavigationButton>
+) {
+	if ('group' in button) {
+		return;
+	}
+
+	if ('element' in button) {
+		setActiveSetting(button);
+	} else {
+		button.action();
+	}
+}
+
+/**
+ * Checks if a navigator item is a singular item or a group
+ *
+ * @param item - Item to check if singular
+ * @returns true if item is singular, false if item is a group
+ */
+export function itemIsSingular(
+	item: NavigatorButton | NavigatorButtonGroup
+): item is NavigatorButton {
+	return 'element' in item;
+}

--- a/src/ui/options/settings.module.scss
+++ b/src/ui/options/settings.module.scss
@@ -20,7 +20,10 @@ a {
 
 .settings {
 	display: flex;
-	min-height: 100vh;
+	//stylelint-disable-next-line unit-no-unknown
+	height: 100dvh;
+	//stylelint-disable-next-line unit-no-unknown
+	min-height: 100dvh;
 	overflow: hidden;
 	width: 100%;
 
@@ -35,14 +38,25 @@ a {
 		opacity: 0.2;
 		position: fixed;
 		width: 100%;
-		z-index: -1;
+		z-index: -2;
+	}
+}
+
+@media only screen and (max-width: 700px) {
+	.settings {
+		flex-direction: column-reverse;
+	}
+
+	.settingsContentWrapper {
+		padding: 0 1em;
 	}
 }
 
 .settingsContentWrapper {
-	flex-grow: 1;
-	height: 100vh;
+	flex: 1 1 auto;
 	overflow-y: auto;
+	padding: 0 1.5em;
+	padding-bottom: 1.5em;
 }
 
 .settingsContent {

--- a/src/ui/options/sidebar/sidebar.module.scss
+++ b/src/ui/options/sidebar/sidebar.module.scss
@@ -2,7 +2,6 @@
 	background-color: var(--sidebar-bg);
 	flex-shrink: 0;
 	height: 100vh;
-	margin-right: 1.5em;
 	overflow-y: auto;
 
 	.sidebar {

--- a/src/ui/options/sidebar/sidebar.tsx
+++ b/src/ui/options/sidebar/sidebar.tsx
@@ -1,5 +1,12 @@
-import { Accessor, For, Setter } from 'solid-js';
-import { Settings } from '../main';
+import { Accessor, For, Setter, Show } from 'solid-js';
+import {
+	Navigator,
+	NavigatorNavigationButton,
+	NavigatorButtonGroup,
+	NavigatorButton,
+	triggerNavigationButton,
+	itemIsSingular,
+} from '@/ui/options/components/navigator';
 import styles from './sidebar.module.scss';
 import { t } from '@/util/i18n';
 
@@ -7,24 +14,44 @@ import { t } from '@/util/i18n';
  * Button corresponding to a specific subsection of preferences in sidebar
  */
 function SidebarButton(props: {
-	item: Settings;
-	activeSetting: Accessor<Settings>;
-	setActiveSetting: Setter<Settings>;
+	item: NavigatorButton | NavigatorButtonGroup;
+	activeSetting: Accessor<NavigatorNavigationButton>;
+	setActiveSetting: Setter<NavigatorNavigationButton>;
 }) {
 	const { item, activeSetting, setActiveSetting } = props;
 	return (
-		<button
-			class={
-				styles.sidebarButton +
-				(activeSetting().namei18n === item.namei18n
-					? ' ' + styles.active
-					: '')
+		<Show
+			when={itemIsSingular(item)}
+			fallback={
+				<For each={(item as NavigatorButtonGroup).group}>
+					{(groupItem) => (
+						<SidebarButton
+							item={groupItem}
+							activeSetting={activeSetting}
+							setActiveSetting={setActiveSetting}
+						/>
+					)}
+				</For>
 			}
-			onClick={() => setActiveSetting(item)}
 		>
-			<item.icon />
-			{t(item.namei18n)}
-		</button>
+			<button
+				class={
+					styles.sidebarButton +
+					(activeSetting().namei18n === item.namei18n
+						? ' ' + styles.active
+						: '')
+				}
+				onClick={() =>
+					triggerNavigationButton(
+						item as NavigatorButton,
+						setActiveSetting
+					)
+				}
+			>
+				<item.icon />
+				{t(item.namei18n)}
+			</button>
+		</Show>
 	);
 }
 
@@ -32,9 +59,9 @@ function SidebarButton(props: {
  * Component that shows nav sidebar
  */
 export default function Sidebar(props: {
-	items: Settings[];
-	activeSetting: Accessor<Settings>;
-	setActiveSetting: Setter<Settings>;
+	items: Navigator;
+	activeSetting: Accessor<NavigatorNavigationButton>;
+	setActiveSetting: Setter<NavigatorNavigationButton>;
 }) {
 	const { items, activeSetting, setActiveSetting } = props;
 	return (


### PR DESCRIPTION
Implements a bottom context menu in place of sidebar on low widths for better experience. Still not 100% ideal but pretty close.

Example:
<img width="567" alt="image" src="https://user-images.githubusercontent.com/69117606/236924305-096a788b-66d5-4bd7-92fb-ba4797cc9db4.png">

Also adds a dev mode to safari build.

Also adds new build target as discussed.