### PR TITLE
Update 163-music.ts

### DIFF
--- a/src/connectors/163-music.ts
+++ b/src/connectors/163-music.ts
@@ -16,7 +16,7 @@ Connector.getTrack = () => {
 
 Connector.getArtist = () => Util.getAttrFromSelectors('.by span', 'title');
 
-Connector.playButtonSelector = '[data-action="play"]';
+Connector.playButtonSelector = 'a[data-action="play"]';
 
 Connector.timeInfoSelector = '.time';
 


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
update the playButtonSelector.
When the playlist is open, all item of the list have the `[data-action="play"]` attr. So we should update the selector to `a[data-action="play"]` to select the play button. 当播放列表展开时，每条待播放曲目都有`[data-action="play"]`属性，所以需要指定 `a[data-action="play"]` 以和 `li[data-action="play"]` 相区别。

**Additional context**
<!-- Add any other context or screenshots here. -->
When Pause
![image](https://github.com/web-scrobbler/web-scrobbler/assets/6056413/4ee3f72b-bd36-47c7-a1e9-c11ec0bd5840)

When Play
![image](https://github.com/web-scrobbler/web-scrobbler/assets/6056413/d1d4e4b3-1df4-45f0-9437-37ae4019f919)

