### PR TITLE
fix scrobble not working when play a playlist

### DIFF
--- a/src/core/object/timer.ts
+++ b/src/core/object/timer.ts
@@ -30,6 +30,7 @@ export default class Timer {
 	start(cb:()=>void):void {
 		this.reset();
 		this.startedOn = now();
+		this.pausedOn = null;
 		this.callback = cb;
 	}
 


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
Since there is a replayDetectionTimer, So when the song played end, it would be set to replay, and call the `pause()` method. So that `this.pausedOn` will not be null.
Then will play the next song on the playlist, and call the `start()` method. However, when `update()` called, `this.pausedOn == null` is false, so `this.setTrigger` is not called. This make the 2nd and the rest in the playlist would NOT be scrobbled.

So when `start`  called, we should set `this.pausedOn` to `null`~

**Additional context**
<!-- Add any other context or screenshots here. -->
