### PR TITLE
Remove inject script exports

### DIFF
--- a/src/connectors/deezer-dom-inject.ts
+++ b/src/connectors/deezer-dom-inject.ts
@@ -1,8 +1,6 @@
-export {};
+deezerInitConnector();
 
-initConnector();
-
-function initConnector() {
+function deezerInitConnector() {
 	let retries = 0;
 	if (
 		'dzPlayer' in window &&
@@ -10,10 +8,10 @@ function initConnector() {
 		'Events' in window &&
 		window.Events
 	) {
-		addEventListeners();
+		deezerAddEventListeners();
 	} else if (retries < 6) {
 		window.setTimeout(function () {
-			initConnector();
+			deezerInitConnector();
 			retries++;
 		}, 1007);
 	} else {
@@ -21,32 +19,32 @@ function initConnector() {
 	}
 }
 
-function addEventListeners() {
+function deezerAddEventListeners() {
 	if (!('Events' in window)) {
 		return;
 	}
 	const ev = window.Events as any;
-	ev.subscribe(ev.player.play, sendEvent);
-	ev.subscribe(ev.player.playing, sendEvent);
-	ev.subscribe(ev.player.paused, sendEvent);
-	ev.subscribe(ev.player.resume, sendEvent);
-	ev.subscribe(ev.player.finish, sendEvent);
+	ev.subscribe(ev.player.play, deezerSendEvent);
+	ev.subscribe(ev.player.playing, deezerSendEvent);
+	ev.subscribe(ev.player.paused, deezerSendEvent);
+	ev.subscribe(ev.player.resume, deezerSendEvent);
+	ev.subscribe(ev.player.finish, deezerSendEvent);
 }
 
-function sendEvent() {
+function deezerSendEvent() {
 	window.postMessage(
 		{
 			sender: 'web-scrobbler',
 			type: 'DEEZER_STATE',
-			trackInfo: getCurrentMediaInfo(),
-			isPlaying: isPlaying(),
-			isPodcast: isPodcast(),
+			trackInfo: deezerGetCurrentMediaInfo(),
+			isPlaying: deezerIsPlaying(),
+			isPodcast: deezerIsPodcast(),
 		},
 		'*'
 	);
 }
 
-function getCurrentMediaInfo() {
+function deezerGetCurrentMediaInfo() {
 	if (!('dzPlayer' in window)) {
 		return;
 	}
@@ -72,12 +70,12 @@ function getCurrentMediaInfo() {
 
 	switch (mediaType) {
 		case 'episode': {
-			trackInfo = getEpisodeInfo(currentMedia);
+			trackInfo = deezerGetEpisodeInfo(currentMedia);
 			break;
 		}
 
 		case 'song': {
-			trackInfo = getTrackInfo(currentMedia);
+			trackInfo = deezerGetTrackInfo(currentMedia);
 			break;
 		}
 	}
@@ -95,7 +93,7 @@ function getCurrentMediaInfo() {
 	return trackInfo;
 }
 
-function getTrackInfo(currentMedia: any) {
+function deezerGetTrackInfo(currentMedia: any) {
 	let trackTitle = currentMedia.SNG_TITLE;
 	const trackVersion = currentMedia.VERSION;
 	if (trackVersion) {
@@ -107,11 +105,11 @@ function getTrackInfo(currentMedia: any) {
 		track: trackTitle,
 		album: currentMedia.ALB_TITLE,
 		uniqueID: currentMedia.SNG_ID,
-		trackArt: getTrackArt(currentMedia.ALB_PICTURE),
+		trackArt: deezerGetTrackArt(currentMedia.ALB_PICTURE),
 	};
 }
 
-function getEpisodeInfo(currentMedia: any) {
+function deezerGetEpisodeInfo(currentMedia: any) {
 	return {
 		artist: currentMedia.SHOW_NAME,
 		track: currentMedia.EPISODE_TITLE,
@@ -119,14 +117,14 @@ function getEpisodeInfo(currentMedia: any) {
 	};
 }
 
-function isPlaying() {
+function deezerIsPlaying() {
 	if (!('dzPlayer' in window)) {
 		return;
 	}
 	return (window.dzPlayer as any).isPlaying();
 }
 
-function isPodcast() {
+function deezerIsPodcast() {
 	if (!('dzPlayer' in window)) {
 		return;
 	}
@@ -134,6 +132,6 @@ function isPodcast() {
 	return currentMedia.__TYPE__ === 'episode';
 }
 
-function getTrackArt(pic: string) {
+function deezerGetTrackArt(pic: string) {
 	return `https://e-cdns-images.dzcdn.net/images/cover/${pic}/264x264-000000-80-0-0.jpg`;
 }

--- a/src/connectors/eggs-dom-inject.ts
+++ b/src/connectors/eggs-dom-inject.ts
@@ -1,37 +1,35 @@
-export {};
-
 /*
  * This script runs in non-isolated environment(eggs.mu itself)
  * for accessing window variables
  */
 
-const isArtistPage = window.location.href.includes('/artist/');
-let frameID = '';
-let currentTime = 0;
-let duration = 0;
+const eggsIsArtistPage = window.location.href.includes('/artist/');
+let eggsFrameID = '';
+let eggsCurrentTime = 0;
+let eggsDuration = 0;
 
-let videoId: string | undefined = '';
+let eggsVideoId: string | undefined = '';
 
-if (isArtistPage) {
-	const observer = new MutationObserver(toggleExternalPlayer);
+if (eggsIsArtistPage) {
+	const observer = new MutationObserver(eggsToggleExternalPlayer);
 
 	observer.observe(document.body, { childList: true });
 } else {
 	if ('player' in window) {
 		(window.player as any).addEventListener(
 			'onStateChange',
-			onYoutubeSongStateChange
+			eggsOnYoutubeSongStateChange
 		);
 	}
 }
 
-function toggleExternalPlayer(mutationList: MutationRecord[]) {
+function eggsToggleExternalPlayer(mutationList: MutationRecord[]) {
 	const removedList = mutationList[0].removedNodes;
 
 	if (removedList.length) {
 		// external player has been started
 		if ((removedList[0] as HTMLElement).id === 'fancybox-loading') {
-			replaceYoutubeVideo();
+			eggsReplaceYoutubeVideo();
 			return null;
 		}
 		// external player has been closed
@@ -40,25 +38,25 @@ function toggleExternalPlayer(mutationList: MutationRecord[]) {
 				'fancybox-overlay'
 			)
 		) {
-			onYoutubeClose();
+			eggsOnYoutubeClose();
 			return null;
 		}
 	}
 }
 
-function replaceYoutubeVideo() {
+function eggsReplaceYoutubeVideo() {
 	const videoFrame = document.querySelector(
 		'.fancybox-inner iframe'
 	) as HTMLIFrameElement;
-	videoId = videoFrame.src.split('/').pop()?.split('?')[0];
+	eggsVideoId = videoFrame.src.split('/').pop()?.split('?')[0];
 
 	videoFrame.src += '&enablejsapi=1&widgetid=1';
-	frameID = videoFrame.id;
+	eggsFrameID = videoFrame.id;
 
 	videoFrame.addEventListener('load', function () {
 		let message = JSON.stringify({
 			event: 'listening',
-			id: frameID,
+			id: eggsFrameID,
 			channel: 'widget',
 		});
 		videoFrame.contentWindow &&
@@ -71,7 +69,7 @@ function replaceYoutubeVideo() {
 			event: 'command',
 			func: 'addEventListener',
 			args: ['onStateChange'],
-			id: frameID,
+			id: eggsFrameID,
 			channel: 'widget',
 		});
 		videoFrame.contentWindow &&
@@ -89,16 +87,16 @@ window.addEventListener('message', (event) => {
 	const data = JSON.parse(event.data);
 	switch (data.event) {
 		case 'onStateChange':
-			onYoutubeStateChange(data);
+			eggsOnYoutubeStateChange(data);
 			break;
 		case 'infoDelivery':
-			getTimestamps(data);
+			eggsGetTimestamps(data);
 			break;
 	}
 });
 
-function onYoutubeStateChange(data: any) {
-	const currentPlayer = document.querySelector(`a[href*="${videoId}"]`);
+function eggsOnYoutubeStateChange(data: any) {
+	const currentPlayer = document.querySelector(`a[href*="${eggsVideoId}"]`);
 	const parentElmt =
 		(currentPlayer && currentPlayer.closest('li')) || document;
 	const playerTypeSuffix = data.info === -1 ? 'start' : '';
@@ -109,15 +107,15 @@ function onYoutubeStateChange(data: any) {
 			playerType: `youtube${playerTypeSuffix}`,
 			isPlaying: data.info === 1,
 			timeInfo: {
-				currentTime: currentTime || 0,
-				duration,
+				currentTime: eggsCurrentTime || 0,
+				eggsDuration,
 			},
 			trackInfo: {
 				artist: parentElmt.querySelector(
-					`.artist_name${isArtistPage ? '' : ' a'}`
+					`.artist_name${eggsIsArtistPage ? '' : ' a'}`
 				)?.textContent,
 				track: parentElmt.querySelector(
-					`.product_name${isArtistPage ? ' a' : ' p'}`
+					`.product_name${eggsIsArtistPage ? ' a' : ' p'}`
 				)?.textContent,
 			},
 		},
@@ -125,8 +123,8 @@ function onYoutubeStateChange(data: any) {
 	);
 }
 
-function onYoutubeClose() {
-	const currentPlayer = document.querySelector(`a[href*="${videoId}"]`);
+function eggsOnYoutubeClose() {
+	const currentPlayer = document.querySelector(`a[href*="${eggsVideoId}"]`);
 	const parentElmt =
 		(currentPlayer && currentPlayer.closest('li')) || document;
 	window.postMessage(
@@ -135,15 +133,15 @@ function onYoutubeClose() {
 			playerType: 'youtube',
 			isPlaying: false,
 			timeInfo: {
-				currentTime,
-				duration,
+				eggsCurrentTime,
+				eggsDuration,
 			},
 			trackInfo: {
 				artist: parentElmt.querySelector(
-					`.artist_name${isArtistPage ? '' : ' a'}`
+					`.artist_name${eggsIsArtistPage ? '' : ' a'}`
 				)?.textContent,
 				track: parentElmt.querySelector(
-					`.product_name${isArtistPage ? ' a' : ' p'}`
+					`.product_name${eggsIsArtistPage ? ' a' : ' p'}`
 				)?.textContent,
 			},
 		},
@@ -151,8 +149,8 @@ function onYoutubeClose() {
 	);
 }
 
-function onYoutubeSongStateChange(event: any) {
-	const currentPlayer = document.querySelector(`a[href*="${videoId}"]`);
+function eggsOnYoutubeSongStateChange(event: any) {
+	const currentPlayer = document.querySelector(`a[href*="${eggsVideoId}"]`);
 	const parentElmt =
 		(currentPlayer && currentPlayer.closest('li')) || document;
 	const playerTypeSuffix = event.data === -1 ? 'start' : '';
@@ -168,10 +166,10 @@ function onYoutubeSongStateChange(event: any) {
 			},
 			trackInfo: {
 				artist: parentElmt.querySelector(
-					`.artist_name${isArtistPage ? '' : ' a'}`
+					`.artist_name${eggsIsArtistPage ? '' : ' a'}`
 				)?.textContent,
 				track: parentElmt.querySelector(
-					`.product_name${isArtistPage ? ' a' : ' p'}`
+					`.product_name${eggsIsArtistPage ? ' a' : ' p'}`
 				)?.textContent,
 			},
 		},
@@ -179,13 +177,13 @@ function onYoutubeSongStateChange(event: any) {
 	);
 }
 
-function getTimestamps(data: any) {
+function eggsGetTimestamps(data: any) {
 	if (data.info) {
 		if (data.info.currentTime) {
-			currentTime = data.info.currentTime;
+			eggsCurrentTime = data.info.currentTime;
 		}
 		if (data.info.duration) {
-			duration = data.info.duration;
+			eggsDuration = data.info.duration;
 		}
 	}
 }

--- a/src/connectors/musickit-dom-inject.ts
+++ b/src/connectors/musickit-dom-inject.ts
@@ -1,51 +1,55 @@
-export {};
-
 /**
  * This script runs in the context of the player page to access the MusicKit
  * global. It listens to events directly from the player and propagates these
  * events to the extension via 'postMessage'.
  */
 if ('MusicKit' in window && window.MusicKit) {
-	addEventListeners();
+	musicKitAddEventListeners();
 } else {
-	document.addEventListener('musickitloaded', addEventListeners);
+	document.addEventListener('musickitloaded', musicKitAddEventListeners);
 }
 
-function addEventListeners() {
+function musicKitAddEventListeners() {
 	const Events = (window as any).MusicKit.Events;
-	player().addEventListener(Events.metadataDidChange, sendEvent);
-	player().addEventListener(Events.playbackStateDidChange, sendEvent);
+	musicKitPlayer().addEventListener(
+		Events.metadataDidChange,
+		musicKitSendEvent
+	);
+	musicKitPlayer().addEventListener(
+		Events.playbackStateDidChange,
+		musicKitSendEvent
+	);
 }
 
-function player() {
+function musicKitPlayer() {
 	return (window as any).MusicKit.getInstance().player;
 }
 
-function sendEvent() {
+function musicKitSendEvent() {
 	window.postMessage(
 		{
 			sender: 'web-scrobbler',
 			type: 'MUSICKIT_STATE',
-			trackInfo: getTrackInfo(),
-			isPlaying: isPlaying(),
+			trackInfo: musicKitGetTrackInfo(),
+			isPlaying: musicKitIsPlaying(),
 		},
 		'*'
 	);
 }
 
-function getTrackInfo() {
-	const item = player().nowPlayingItem;
+function musicKitGetTrackInfo() {
+	const item = musicKitPlayer().nowPlayingItem;
 	return {
 		album: item.albumName,
 		track: item.title,
 		artist: item.artistName,
 		trackArt: item.artworkURL,
-		duration: player().currentPlaybackDuration,
+		duration: musicKitPlayer().currentPlaybackDuration,
 		uniqueID: item.id,
-		currentTime: player().currentPlaybackTime,
+		currentTime: musicKitPlayer().currentPlaybackTime,
 	};
 }
 
-function isPlaying() {
-	return player().isPlaying;
+function musicKitIsPlaying() {
+	return musicKitPlayer().isPlaying;
 }

--- a/src/connectors/sber-zvuk-dom-inject.ts
+++ b/src/connectors/sber-zvuk-dom-inject.ts
@@ -1,6 +1,4 @@
-export {};
-
-function getTrackInfo(track: any, currentTime: number) {
+function sberGetTrackInfo(track: any, currentTime: number) {
 	const { title, credits, duration, id, image, release_title: album } = track;
 	const trackArt = image.src.replace('{size}', '400x400');
 
@@ -15,7 +13,7 @@ function getTrackInfo(track: any, currentTime: number) {
 	};
 }
 
-function queueEvent(event: any) {
+function sberQueueEvent(event: any) {
 	let type = null;
 	let queue;
 
@@ -40,7 +38,7 @@ function queueEvent(event: any) {
 			return;
 	}
 
-	const trackInfo = getTrackInfo(
+	const trackInfo = sberGetTrackInfo(
 		queue.currentTrack,
 		queue.Player.currentTime
 	);
@@ -55,8 +53,8 @@ function queueEvent(event: any) {
 	);
 }
 
-function setupEventListeners() {
-	(window as any).newPlayer.$mobx.observe(queueEvent);
+function sberSetupEventListeners() {
+	(window as any).newPlayer.$mobx.observe(sberQueueEvent);
 }
 
-setupEventListeners();
+sberSetupEventListeners();

--- a/src/connectors/vk-dom-inject.ts
+++ b/src/connectors/vk-dom-inject.ts
@@ -1,21 +1,19 @@
-'use strict';
-
 /*
  * This script runs in non-isolated environment(vk.com itself)
  * for accessing to `window.ap` which sends player events.
  */
 
-const INFO_ID = 0;
-const INFO_OWNER_ID = 1;
-const INFO_TRACK = 3;
-const INFO_ARTIST = 4;
-const INFO_DURATION = 5;
-const INFO_TRACK_ARTS = 14;
-const INFO_ADDITIONAL = 16;
+const VK_INFO_ID = 0;
+const VK_INFO_OWNER_ID = 1;
+const VK_INFO_TRACK = 3;
+const VK_INFO_ARTIST = 4;
+const VK_INFO_DURATION = 5;
+const VK_INFO_TRACK_ARTS = 14;
+const VK_INFO_ADDITIONAL = 16;
 
-setupEventListeners();
+vkSetupEventListeners();
 
-function sendUpdateEvent(type: string) {
+function vkSendUpdateEvent(type: string) {
 	const audioObject = (window as any).ap._currentAudio;
 	if (!audioObject) {
 		return;
@@ -30,13 +28,13 @@ function sendUpdateEvent(type: string) {
 	 * beginning, and repeat the song. Ignore this stage to avoid
 	 * this behavior.
 	 */
-	if (currentTime === audioObject[INFO_DURATION]) {
+	if (currentTime === audioObject[VK_INFO_DURATION]) {
 		return;
 	}
-	const trackArt = extractTrackArt(audioObject[INFO_TRACK_ARTS]);
+	const trackArt = vkExtractTrackArt(audioObject[VK_INFO_TRACK_ARTS]);
 
-	let track = audioObject[INFO_TRACK];
-	const additionalInfo = audioObject[INFO_ADDITIONAL];
+	let track = audioObject[VK_INFO_TRACK];
+	const additionalInfo = audioObject[VK_INFO_ADDITIONAL];
 	if (additionalInfo) {
 		track = `${track} (${additionalInfo})`;
 	}
@@ -49,20 +47,20 @@ function sendUpdateEvent(type: string) {
 				currentTime,
 				trackArt,
 				track,
-				duration: audioObject[INFO_DURATION],
-				uniqueID: `${audioObject[INFO_OWNER_ID]}_${audioObject[INFO_ID]}`,
-				artist: audioObject[INFO_ARTIST],
+				duration: audioObject[VK_INFO_DURATION],
+				uniqueID: `${audioObject[VK_INFO_OWNER_ID]}_${audioObject[VK_INFO_ID]}`,
+				artist: audioObject[VK_INFO_ARTIST],
 			},
 		},
 		'*'
 	);
 }
 
-function setupEventListeners() {
+function vkSetupEventListeners() {
 	for (const e of ['start', 'progress', 'pause', 'stop']) {
 		(window as any).ap.subscribers.push({
 			et: e,
-			cb: sendUpdateEvent.bind(null, e),
+			cb: vkSendUpdateEvent.bind(null, e),
 		});
 	}
 }
@@ -72,7 +70,7 @@ function setupEventListeners() {
  * @param trackArts - String contains list of track art URLs
  * @returns Track art URL
  */
-function extractTrackArt(trackArts: string) {
+function vkExtractTrackArt(trackArts: string) {
 	const trackArtArr = trackArts.split(',');
 	return trackArtArr.pop();
 }

--- a/src/connectors/yandex-music-dom-inject.ts
+++ b/src/connectors/yandex-music-dom-inject.ts
@@ -1,27 +1,25 @@
-export {};
-
 const YandexAPI = (window as any).externalAPI;
 
-setupListeners();
+yandexSetupListeners();
 
-function setupListeners() {
-	YandexAPI.on(YandexAPI.EVENT_STATE, onEvent);
-	YandexAPI.on(YandexAPI.EVENT_TRACK, onEvent);
+function yandexSetupListeners() {
+	YandexAPI.on(YandexAPI.EVENT_STATE, yandexOnEvent);
+	YandexAPI.on(YandexAPI.EVENT_TRACK, yandexOnEvent);
 }
 
-function onEvent() {
+function yandexOnEvent() {
 	window.postMessage(
 		{
 			sender: 'web-scrobbler',
 			type: 'YANDEX_MUSIC_STATE',
-			trackInfo: getTrackInfo(),
+			trackInfo: yandexGetTrackInfo(),
 			isPlaying: YandexAPI.isPlaying(),
 		},
 		'*'
 	);
 }
 
-function getTrackInfo() {
+function yandexGetTrackInfo() {
 	const trackInfo = YandexAPI.getCurrentTrack();
 
 	const track = trackInfo.title;


### PR DESCRIPTION
This was causing errors with Deezer. Eggs seemed to work, but might was well do this to all inject scripts in case.
Requires renaming top level vars/functions with prefixes because else compiler will yell at us since it thinks all the files are supposed to run in same context.

Closes #3771 though deezer connector still seems a little flakey, doesn't seem related to V3 though but might be. Fixing the connector further would require deeper fixes.