### PR TITLE
Add tooltips for common errors

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -475,6 +475,10 @@
         "message": "Looks like something went wrong while scrobbling the music. Please open the options page and try to reauthenticate with services. If reauthentication doesn't help, and you still see this message, please create <a href=\"https://github.com/web-scrobbler/web-scrobbler/issues\" target=\"_blank\">a new issue</a> at the GitHub project page.",
         "description": "The description of service error"
     },
+    "serviceErrorAdblock": {
+        "message": "Note that some adblockers may interfere with the extension. If you have any adblocker installed, try to disable it and see if it helps. If you are using uBlock Origin, you can add an exception for last.fm by adding <code>@@||ws.audioscrobbler.com</code> under \"My filters\" tab. Other adblockers may have similar functionality.",
+        "description": "The description of service error"
+    },
     "disabledSiteHeader": {
         "message": "This website is turned off",
         "description": "The header of 'disabled' popup"
@@ -497,6 +501,10 @@
     },
     "unsupportedWebsiteDesc2": {
         "message": "Some Google websites supported by the extension (e.g. Google Play Music, YouTube) can be blocked due to an ExtensionSettings policy.",
+        "description": "The description of 'unsupported' popup"
+    },
+    "unsupportedWebsiteUpdateNote": {
+        "message": "If the extension recently updated sites may show as unsupported until you refresh the page.",
         "description": "The description of 'unsupported' popup"
     },
     "infoLove": {

--- a/src/ui/popup/err.tsx
+++ b/src/ui/popup/err.tsx
@@ -15,6 +15,8 @@ export default function Err() {
 			<h1>{t('serviceErrorHeader')}</h1>
 			{/* eslint-disable-next-line */}
 			<p innerHTML={t('serviceErrorDesc')} />
+			{/* eslint-disable-next-line */}
+			<p innerHTML={t('serviceErrorAdblock')} />
 			<a
 				href={browser.runtime.getURL('src/ui/options/index.html')}
 				class={`${optionComponentStyles.linkButton} ${styles.centered}`}

--- a/src/ui/popup/unsupported.tsx
+++ b/src/ui/popup/unsupported.tsx
@@ -11,6 +11,7 @@ export default function Unsupported() {
 			<SentimentDissatisfied class={styles.bigIcon} />
 			<h1>{t('unsupportedWebsiteHeader')}</h1>
 			<p>{t('unsupportedWebsiteDesc')}</p>
+			<p>{t('unsupportedWebsiteUpdateNote')}</p>
 			<p>
 				<span>{t('unsupportedWebsiteDesc2')} </span>
 				<a


### PR DESCRIPTION
Adds a tooltip for service error informing about adblock things
Adds a tooltip for unsupported site informing about needing to refresh after update

This is definitely not optimal and we should make better long term fixes, but I think it's an ok temporary bandaid while we focus on more pressing issues