### PR TITLE
Fix vivaldi crashing when opening links from popup

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,6 +18,7 @@ rules:
   tsdoc/syntax: warn
   react/react-in-jsx-scope: off
   react/no-unknown-property: off
+  react/jsx-key: off
   no-mixed-spaces-and-tabs:
     - error
     - smart-tabs

--- a/src/ui/components/util.tsx
+++ b/src/ui/components/util.tsx
@@ -1,3 +1,10 @@
+import { For, JSXElement, Show, createSignal, onMount } from 'solid-js';
+import { t } from '../../util/i18n';
+import browser from 'webextension-polyfill';
+
+/**
+ * Returns a squircle svg element with the given id.
+ */
 export function Squircle(props: { id: string }) {
 	return (
 		<svg width="0" height="0">
@@ -8,6 +15,100 @@ export function Squircle(props: { id: string }) {
 	);
 }
 
+/**
+ * @returns true if the user is on an iOS device, false otherwise.
+ */
 export function isIos() {
 	return CSS.supports('-webkit-touch-callout', 'none');
+}
+
+/**
+ * Vivaldi crashes when clicking target _blank urls from a popup.
+ * This allows us to open urls in a new tab from a popup without crashes.
+ *
+ * @param url - The url to open in a new tab.
+ */
+function openInNewTabFromPopup(url: string) {
+	browser.tabs.create({ url });
+}
+
+/**
+ * Vivaldi crashes when clicking target _blank urls from a popup.
+ * Returns an anchor JSX component that opens the url in a new tab from a popup without crashing.
+ */
+export function PopupAnchor(props: {
+	children: JSXElement | string;
+	href: string;
+	class?: string;
+	title?: string;
+}) {
+	return (
+		<a
+			href={props.href}
+			title={props.title}
+			class={props.class}
+			onClick={(e) => {
+				e.preventDefault();
+				openInNewTabFromPopup(props.href);
+			}}
+		>
+			{props.children}
+		</a>
+	);
+}
+
+/**
+ * Regex that finds anchor tag
+ */
+const anchorRegex = /<a.*?href="([^"]+)".*?>([^<]+)<\/a>/;
+
+/**
+ * Gets localized string from locale and turns anchors into popup anchors.
+ * Has a maximum iterations count just for safety's sake because while loop with janky code moment.
+ */
+export function TPopupAnchor(props: {
+	messageName: string;
+	substitutions?: string | string[];
+}): JSXElement {
+	const [res, setRes] = createSignal<(string | [string, string])[]>([]);
+	onMount(() => {
+		let message = t(props.messageName, props.substitutions);
+		const maxIterations = 5;
+		let i = 0;
+		while (message) {
+			// check if we've gone over the max iterations
+			i++;
+			if (i > maxIterations) {
+				break;
+			}
+
+			// get match and break if there is none, inserting remaining message
+			const match = message.match(anchorRegex);
+			if (!match) {
+				setRes((prev) => [...prev, message]);
+				break;
+			}
+
+			// get full string, href from capture group 1, and tag content from capture group 2
+			const [str, href, content] = match;
+
+			// push the content before the anchor, the anchor, and then slice the message to repeat the loop on remaining text.
+			setRes((prev) => [
+				...prev,
+				message.slice(0, match.index),
+				[href, content],
+			]);
+			message = message.slice((match.index ?? 0) + str.length);
+		}
+	});
+	// convert the array of strings and tuples into a JSX element
+	return (
+		<For each={res()}>
+			{(item) => (
+				<Show when={typeof item !== 'string'} fallback={item}>
+					<PopupAnchor href={item[0]}>{item[1]}</PopupAnchor>
+				</Show>
+			)}
+		</For>
+	);
 }

--- a/src/ui/popup/base.tsx
+++ b/src/ui/popup/base.tsx
@@ -2,6 +2,7 @@ import { t } from '@/util/i18n';
 import MusicNote from '@suid/icons-material/MusicNoteOutlined';
 import styles from './popup.module.scss';
 import ExpandMore from '@suid/icons-material/ExpandMoreOutlined';
+import { TPopupAnchor } from '../components/util';
 
 /**
  * Info to be shown on a recognized website before anything is played.
@@ -17,8 +18,9 @@ export default function Base() {
 					{t('getStartedSubheader')}
 				</summary>
 				<p>{t('getStartedSiteChanged')}</p>
-				{/* eslint-disable-next-line */}
-				<p innerHTML={t('getStartedSubmitIssue')} />
+				<p>
+					<TPopupAnchor messageName="getStartedSubmitIssue" />
+				</p>
 			</details>
 		</div>
 	);

--- a/src/ui/popup/disabled.tsx
+++ b/src/ui/popup/disabled.tsx
@@ -4,6 +4,7 @@ import styles from './popup.module.scss';
 import browser from 'webextension-polyfill';
 import Settings from '@suid/icons-material/SettingsOutlined';
 import optionComponentStyles from '../options/components/components.module.scss';
+import { PopupAnchor } from '../components/util';
 
 /**
  * Information to be shown on a website where web scrobbler has been disabled
@@ -14,15 +15,13 @@ export default function Disabled() {
 			<MusicOff class={styles.bigIcon} />
 			<h1>{t('disabledSiteHeader')}</h1>
 			<p>{t('disabledSiteDesc')}</p>
-			<a
+			<PopupAnchor
 				href={browser.runtime.getURL('src/ui/options/index.html')}
 				class={`${optionComponentStyles.linkButton} ${styles.centered}`}
-				target="_blank"
-				rel="noopener noreferrer"
 			>
 				<Settings />
 				{t('disabledSiteButton')}
-			</a>
+			</PopupAnchor>
 		</div>
 	);
 }

--- a/src/ui/popup/edit.tsx
+++ b/src/ui/popup/edit.tsx
@@ -22,7 +22,7 @@ import PublishedWithChanges from '@suid/icons-material/PublishedWithChangesOutli
 import { sendBackgroundMessage } from '@/util/communication';
 import savedEdits from '@/core/storage/saved-edits';
 import Regex, { RegexEditContextMenu } from './regex';
-import { Squircle, isIos } from '../components/util';
+import { PopupAnchor, Squircle, isIos } from '../components/util';
 import {
 	Navigator,
 	getMobileNavigatorGroup,
@@ -110,7 +110,7 @@ export default function Edit(props: { tab: Resource<ManagerTab> }) {
 						<Regex clonedSong={clonedSong} tab={tab} />
 					</Match>
 					<Match when={!isRegex()}>
-						<a
+						<PopupAnchor
 							class={styles.coverArtWrapper}
 							href={
 								clonedSong.getTrackArt() ??
@@ -118,8 +118,6 @@ export default function Edit(props: { tab: Resource<ManagerTab> }) {
 									'img/cover_art_default.png'
 								)
 							}
-							target="_blank"
-							rel="noopener noreferrer"
 							title={t('infoOpenAlbumArt')}
 						>
 							<img
@@ -132,7 +130,7 @@ export default function Edit(props: { tab: Resource<ManagerTab> }) {
 								}
 							/>
 							<Squircle id="coverArtClip" />
-						</a>
+						</PopupAnchor>
 						<div
 							class={styles.songDetails}
 							onKeyDown={(event) => {

--- a/src/ui/popup/err.tsx
+++ b/src/ui/popup/err.tsx
@@ -4,6 +4,7 @@ import styles from './popup.module.scss';
 import browser from 'webextension-polyfill';
 import Settings from '@suid/icons-material/SettingsOutlined';
 import optionComponentStyles from '../options/components/components.module.scss';
+import { PopupAnchor, TPopupAnchor } from '../components/util';
 
 /**
  * Info to be shown when an error occurs when submitting scrobbles to a service
@@ -13,19 +14,18 @@ export default function Err() {
 		<div class={styles.alertPopup}>
 			<Error class={styles.bigIcon} />
 			<h1>{t('serviceErrorHeader')}</h1>
-			{/* eslint-disable-next-line */}
-			<p innerHTML={t('serviceErrorDesc')} />
+			<p>
+				<TPopupAnchor messageName="serviceErrorDesc" />
+			</p>
 			{/* eslint-disable-next-line */}
 			<p innerHTML={t('serviceErrorAdblock')} />
-			<a
+			<PopupAnchor
 				href={browser.runtime.getURL('src/ui/options/index.html')}
 				class={`${optionComponentStyles.linkButton} ${styles.centered}`}
-				target="_blank"
-				rel="noopener noreferrer"
 			>
 				<Settings />
 				{t('disabledSiteButton')}
-			</a>
+			</PopupAnchor>
 		</div>
 	);
 }

--- a/src/ui/popup/main.tsx
+++ b/src/ui/popup/main.tsx
@@ -24,7 +24,7 @@ import Settings from '@suid/icons-material/SettingsOutlined';
 import browser from 'webextension-polyfill';
 import styles from './popup.module.scss';
 import { t } from '@/util/i18n';
-import { isIos } from '../components/util';
+import { PopupAnchor, isIos } from '../components/util';
 import ContextMenu from '../components/context-menu/context-menu';
 import {
 	Navigator,
@@ -120,15 +120,13 @@ function Popup() {
 			</Switch>
 
 			<Show when={!settingModes.includes(tab()?.mode ?? '') && !isIos()}>
-				<a
+				<PopupAnchor
 					href={browser.runtime.getURL('src/ui/options/index.html')}
 					class={styles.settingsIcon}
-					target="_blank"
 					title={t('disabledSiteButton')}
-					rel="noopener noreferrer"
 				>
 					<Settings />
-				</a>
+				</PopupAnchor>
 			</Show>
 		</>
 	);

--- a/src/ui/popup/nowplaying.tsx
+++ b/src/ui/popup/nowplaying.tsx
@@ -36,7 +36,7 @@ import {
 } from '@/util/util';
 import scrobbleService from '@/core/object/scrobble-service';
 import { SessionData } from '@/core/scrobbler/base-scrobbler';
-import { Squircle, isIos } from '../components/util';
+import { PopupAnchor, Squircle, isIos } from '../components/util';
 import ContextMenu from '../components/context-menu/context-menu';
 import {
 	Navigator,
@@ -111,7 +111,7 @@ export default function NowPlaying(props: { tab: Resource<ManagerTab> }) {
 					/>
 				</Show>
 				<div class={styles.nowPlayingPopup} ref={nowplaying}>
-					<PopupLink
+					<PopupAnchor
 						class={styles.coverArtWrapper}
 						href={
 							song()?.getTrackArt() ??
@@ -129,7 +129,7 @@ export default function NowPlaying(props: { tab: Resource<ManagerTab> }) {
 							}
 						/>
 						<Squircle id="coverArtClip" />
-					</PopupLink>
+					</PopupAnchor>
 					<SongDetails
 						song={song}
 						tab={tab}
@@ -240,20 +240,20 @@ function TrackData(props: { song: Accessor<ClonedSong | null> }) {
 	const { song } = props;
 	return (
 		<>
-			<PopupLink
+			<PopupAnchor
 				class={styles.bold}
 				href={createTrackURL(song()?.getArtist(), song()?.getTrack())}
 				title={t('infoViewTrackPage', song()?.getTrack() ?? '')}
 			>
 				{song()?.getTrack()}
-			</PopupLink>
-			<PopupLink
+			</PopupAnchor>
+			<PopupAnchor
 				href={createArtistURL(song()?.getArtist())}
 				title={t('infoViewArtistPage', song()?.getArtist() ?? '')}
 			>
 				{song()?.getArtist()}
-			</PopupLink>
-			<PopupLink
+			</PopupAnchor>
+			<PopupAnchor
 				href={createAlbumURL(
 					song()?.getAlbumArtist() || song()?.getArtist(),
 					song()?.getTrack()
@@ -261,13 +261,13 @@ function TrackData(props: { song: Accessor<ClonedSong | null> }) {
 				title={t('infoViewAlbumPage', song()?.getAlbum() ?? '')}
 			>
 				{song()?.getAlbum()}
-			</PopupLink>
-			<PopupLink
+			</PopupAnchor>
+			<PopupAnchor
 				href={createArtistURL(song()?.getAlbumArtist())}
 				title={t('infoViewArtistPage', song()?.getAlbumArtist() ?? '')}
 			>
 				{song()?.getAlbumArtist()}
-			</PopupLink>
+			</PopupAnchor>
 		</>
 	);
 }
@@ -286,7 +286,7 @@ function TrackMetadata(props: { song: Accessor<ClonedSong | null> }) {
 
 	return (
 		<div class={styles.playDetails}>
-			<PopupLink
+			<PopupAnchor
 				class={`${styles.playCount} ${styles.label}`}
 				href={createTrackLibraryURL(
 					session()?.sessionName,
@@ -300,7 +300,7 @@ function TrackMetadata(props: { song: Accessor<ClonedSong | null> }) {
 			>
 				<LastFMIcon />
 				{song()?.metadata.userPlayCount || 0}
-			</PopupLink>
+			</PopupAnchor>
 			<span class={styles.label}>{song()?.connectorLabel}</span>
 		</div>
 	);
@@ -381,28 +381,6 @@ function TrackControls(props: {
 				</span>
 			</button>
 		</div>
-	);
-}
-
-/**
- * Create a link that opens in a new tab
- */
-function PopupLink(props: {
-	class?: string;
-	href: string;
-	title: string;
-	children: string | JSXElement | JSXElement[];
-}) {
-	return (
-		<a
-			class={`${props.class} ${styles.notRedAnchor}`}
-			href={props.href}
-			target="_blank"
-			rel="noopener noreferrer"
-			title={props.title}
-		>
-			{props.children}
-		</a>
 	);
 }
 

--- a/src/ui/popup/unsupported.tsx
+++ b/src/ui/popup/unsupported.tsx
@@ -1,6 +1,7 @@
 import { t } from '@/util/i18n';
 import SentimentDissatisfied from '@suid/icons-material/SentimentDissatisfiedOutlined';
 import styles from './popup.module.scss';
+import { PopupAnchor } from '../components/util';
 
 /**
  * Info to show when the user is on a website not supported by web scrobbler
@@ -14,13 +15,9 @@ export default function Unsupported() {
 			<p>{t('unsupportedWebsiteUpdateNote')}</p>
 			<p>
 				<span>{t('unsupportedWebsiteDesc2')} </span>
-				<a
-					target="_blank"
-					rel="noopener noreferrer"
-					href="https://cloud.google.com/docs/chrome-enterprise/policies/?policy=ExtensionSettings"
-				>
+				<PopupAnchor href="https://cloud.google.com/docs/chrome-enterprise/policies/?policy=ExtensionSettings">
 					{t('learnMoreLabel')}
-				</a>
+				</PopupAnchor>
 			</p>
 		</div>
 	);

--- a/src/util/i18n.ts
+++ b/src/util/i18n.ts
@@ -1,5 +1,5 @@
 import browser from 'webextension-polyfill';
-import { getExtensionVersion } from './util-browser';
+import { getExtensionVersion } from '@/util/util-browser';
 
 /**
  * Gets localized string from locale.


### PR DESCRIPTION
Wraps all the popup anchors in a component that prevents the default link opening behavior and overrides it with browser.tabs.create as suggested by @Pekito 

Closes #3788 