### PR TITLE
Improve service worker performance with many tabs

### DIFF
--- a/src/core/background/action.ts
+++ b/src/core/background/action.ts
@@ -1,5 +1,5 @@
 import browser from 'webextension-polyfill';
-import { contextMenus, getBrowserPreferredTheme, getCurrentTab } from './util';
+import { contextMenus, getBrowserPreferredTheme } from './util';
 import { sendPopupMessage } from '@/util/communication';
 import { ManagerTab } from '@/core/storage/wrapper';
 import * as ControllerMode from '@/core/object/controller/controller-mode';
@@ -22,13 +22,6 @@ export async function performUpdateAction(tab: ManagerTab) {
 
 	await updateMenus(tab);
 	setAction(tab);
-}
-
-/**
- * Fetches the tab to update action state from, and then updates the action state
- */
-export async function updateAction() {
-	await getCurrentTab();
 }
 
 /**

--- a/src/core/background/main.ts
+++ b/src/core/background/main.ts
@@ -23,7 +23,7 @@ import {
 } from './util';
 import {
 	ControllerModeStr,
-	controllerModeLowestPriority,
+	controllerModePriorityObject,
 } from '@/core/object/controller/controller';
 import { CloneableSong } from '@/core/object/song';
 import {
@@ -111,7 +111,11 @@ async function updateTabList(tabId: number, activated: boolean) {
 		: curState.activeTabs;
 
 	const curTab = await getActiveTabDetails(newTabs, tabId);
-	if (!controllerModeLowestPriority[curTab.mode]) {
+
+	if (
+		controllerModePriorityObject[curTab.mode] !== 0 &&
+		curTab.tabId === tabId
+	) {
 		if (activated) {
 			newTabs = [curTab, ...newTabs];
 		} else {

--- a/src/core/background/util.ts
+++ b/src/core/background/util.ts
@@ -78,6 +78,101 @@ export async function setState(data: StateManagement): Promise<void> {
 }
 
 /**
+ * Takes a list of tabs and updates the action state based on the first tab that matches a priority group.
+ *
+ * @param tabs - tabs from state
+ * @param tabId - Currently active tab id if known
+ * @returns the tab that was used to update the action state
+ */
+export async function updateTabsFromTabList(
+	tabs: ManagerTab[],
+	tabId?: number
+) {
+	const curTab = await getActiveTabDetails(tabs, tabId);
+	performUpdateAction(curTab);
+	return curTab;
+}
+
+/**
+ * Takes a list of tabs and returns the details of the first tab that matches a priority group.
+ *
+ * @param tabs - tabs from state
+ * @param tabId - Currently active tab id if known
+ * @returns the tab that was used to update the action state
+ */
+export async function getActiveTabDetails(
+	tabs: ManagerTab[],
+	tabId?: number
+): Promise<ManagerTab> {
+	const tab = getPriorityTabDetails(tabs);
+	if (tab) {
+		return tab;
+	}
+	if (!tabId) {
+		tabId = await getCurrentTabId();
+	}
+	return getTabDetails(tabId);
+}
+
+/**
+ * Get the controller state of a tab.
+ * @param tabId - tab to get state of
+ * @returns the tab with controller details
+ */
+async function getTabDetails(tabId: number): Promise<ManagerTab> {
+	try {
+		const tab = await browser.tabs.get(tabId);
+		if (!tab) {
+			throw new Error('Tab not found');
+		}
+		const tabState = await sendBackgroundMessage(tabId, {
+			type: 'getConnectorDetails',
+			payload: undefined,
+		});
+		const curTab: ManagerTab = {
+			tabId,
+			mode: tabState.mode,
+			song: tabState.song,
+		};
+		return curTab;
+	} catch (err) {
+		return {
+			tabId,
+			mode: ControllerMode.Unsupported,
+			song: null,
+		};
+	}
+}
+
+/**
+ * Get the highest priority priority tab for action state.
+ * This tab will be prioritized over the active tab.
+ * @param tabs - list of priority tabs from state
+ * @returns the tab that is the current priority for action state
+ */
+function getPriorityTabDetails(tabs: ManagerTab[]): ManagerTab | null {
+	for (const priorityGroup of controllerModePriority.slice(0, -1)) {
+		for (const tab of tabs) {
+			if (priorityGroup.includes(tab.mode)) {
+				return tab;
+			}
+		}
+	}
+	return null;
+}
+
+/**
+ * Returns the ID of the currently active tab in the browser.
+ * @returns the current tab id
+ */
+export async function getCurrentTabId() {
+	const queryOptions = { active: true, lastFocusedWindow: true };
+	// `tab` will either be a `tabs.Tab` instance or `undefined`.
+	const [tab] = await browser.tabs.query(queryOptions);
+	return tab?.id ?? -1;
+}
+
+/**
  * Gets the tab to base action and context menus on.
  * Generally, this prioritizes the most recent tab.
  * However, certain controller states are prioritized over other controller states.
@@ -86,27 +181,7 @@ export async function setState(data: StateManagement): Promise<void> {
  */
 export async function getCurrentTab(): Promise<ManagerTab> {
 	const curState = await getState();
-	const filteredTabs = await filterInactiveTabs(curState.activeTabs);
-	await setState({
-		activeTabs: filteredTabs,
-		browserPreferredTheme: curState.browserPreferredTheme,
-	});
-
-	for (const priorityGroup of controllerModePriority) {
-		for (const tab of filteredTabs) {
-			if (priorityGroup.includes(tab.mode)) {
-				performUpdateAction(tab);
-				return tab;
-			}
-		}
-	}
-	const defaultTab: ManagerTab = {
-		tabId: -1,
-		mode: ControllerMode.Unsupported,
-		song: null,
-	};
-	performUpdateAction(defaultTab);
-	return defaultTab;
+	return getActiveTabDetails(curState.activeTabs);
 }
 
 /**

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -52,6 +52,18 @@ export const controllerModePriority: ControllerModeStr[][] = [
 	],
 ];
 
+/**
+ * States of lowest priority.
+ */
+export const controllerModeLowestPriority: Partial<
+	Record<ControllerModeStr, true>
+> = {
+	[ControllerMode.Base]: true,
+	[ControllerMode.Skipped]: true,
+	[ControllerMode.Disabled]: true,
+	[ControllerMode.Unsupported]: true,
+};
+
 type updateEvent = {
 	updateEditStatus: (isEditing: boolean) => void;
 };

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -53,15 +53,19 @@ export const controllerModePriority: ControllerModeStr[][] = [
 ];
 
 /**
- * States of lowest priority.
+ * Priorities of each state as an object
  */
-export const controllerModeLowestPriority: Partial<
-	Record<ControllerModeStr, true>
-> = {
-	[ControllerMode.Base]: true,
-	[ControllerMode.Skipped]: true,
-	[ControllerMode.Disabled]: true,
-	[ControllerMode.Unsupported]: true,
+export const controllerModePriorityObject: Record<ControllerModeStr, number> = {
+	[ControllerMode.Base]: 0,
+	[ControllerMode.Skipped]: 0,
+	[ControllerMode.Disabled]: 0,
+	[ControllerMode.Unsupported]: 0,
+	[ControllerMode.Playing]: 1,
+	[ControllerMode.Scrobbled]: 1,
+	[ControllerMode.Loading]: 2,
+	[ControllerMode.Unknown]: 3,
+	[ControllerMode.Ignored]: 4,
+	[ControllerMode.Err]: 4,
 };
 
 type updateEvent = {

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -145,6 +145,13 @@ export default class Controller {
 			contentListener({
 				type: 'disableConnectorUntilTabIsClosed',
 				fn: () => this.disableUntilTabIsClosed(),
+			}),
+			contentListener({
+				type: 'getConnectorDetails',
+				fn: () => ({
+					mode: this.mode,
+					song: this.currentSong?.getCloneableData() ?? null,
+				}),
 			})
 		);
 	}

--- a/src/util/communication.ts
+++ b/src/util/communication.ts
@@ -86,6 +86,13 @@ interface BackgroundCommunications {
 		payload: boolean;
 		response: void;
 	};
+	getConnectorDetails: {
+		payload: undefined;
+		response: {
+			mode: ControllerModeStr;
+			song: CloneableSong | null;
+		};
+	};
 	disableConnectorUntilTabIsClosed: {
 		payload: undefined;
 		response: void;


### PR DESCRIPTION
Maximum priority issue, should be a hotfix ASAP.

Goes a long way to fixing #3789 and might even close it entirely.
Reduces CPU usage of service worker DRASTICALLY, also reduces RAM usage quite a bit.
V3 service worker now typically uses less RAM than V2 background page did, and hardly any more CPU it seems.

Mostly impacts the code determining which tab to use for setting action icon/page.
Seems stable on my end at least, but limited amounts of testing can be done in this short amount of time.