### PR TITLE
Reduce and prefix logging

### DIFF
--- a/scripts/set-test-env.ts
+++ b/scripts/set-test-env.ts
@@ -1,0 +1,1 @@
+process.env.VITE_TEST = 'true';

--- a/src/connectors/clyp.ts
+++ b/src/connectors/clyp.ts
@@ -6,7 +6,7 @@ function setup() {
 	} else if (isCardsPlayerPage()) {
 		setupCardsPlayer();
 	} else {
-		console.warn('Unmapped page found');
+		Util.debugLog('Unmapped page found', 'warn');
 	}
 }
 

--- a/src/connectors/deezer-dom-inject.ts
+++ b/src/connectors/deezer-dom-inject.ts
@@ -15,7 +15,7 @@ function deezerInitConnector() {
 			retries++;
 		}, 1007);
 	} else {
-		console.warn('Web Scrobbler: Failed to initialize deezer connector!');
+		Util.debugLog('Failed to initialize deezer connector!', 'warn');
 	}
 }
 
@@ -81,8 +81,9 @@ function deezerGetCurrentMediaInfo() {
 	}
 
 	if (!trackInfo) {
-		console.warn(
-			`Web Scrobbler: Unable to load track info for ${mediaType} media type`
+		Util.debugLog(
+			`Unable to load track info for ${mediaType} media type`,
+			'warn'
 		);
 		return null;
 	}

--- a/src/connectors/gaana.ts
+++ b/src/connectors/gaana.ts
@@ -97,10 +97,8 @@ async function fetchSongInfo(albumInfoUrl: string) {
 			const songTitle = songTitleElement.textContent?.trim();
 
 			if (songTitle === track) {
-				console.log(2222);
 				const artists = song.querySelectorAll('.s_artist .sng_c');
 				artist = Util.joinArtists(Array.from(artists));
-				console.log(artist);
 				break;
 			}
 		}

--- a/src/core/content/main.ts
+++ b/src/core/content/main.ts
@@ -14,11 +14,14 @@ async function main() {
 	updateTheme();
 	try {
 		await fetchConnector();
+		start();
 	} catch (err) {
+		if (err instanceof Error && err.message === 'dontlog') {
+			return;
+		}
 		Util.debugLog(err, 'error');
 		return;
 	}
-	start();
 }
 
 /**
@@ -28,12 +31,12 @@ async function main() {
 async function fetchConnector(): Promise<void> {
 	const connector = await getConnectorByUrl(window.location.href);
 	if (!connector) {
-		return;
+		throw new Error('dontlog');
 	}
 
 	// Don't run the connector in frames if it's not allowed to run in frames
 	if (window !== top && !connector.allFrames) {
-		return;
+		throw new Error('dontlog');
 	}
 
 	window.Connector = new BaseConnector(connector);

--- a/src/core/content/reactor.ts
+++ b/src/core/content/reactor.ts
@@ -19,7 +19,6 @@ export default class Reactor {
 	constructor(connector: BaseConnector, isEnabled: boolean) {
 		this.controller = new Controller(connector.meta, isEnabled);
 
-		console.log('binding');
 		// Setup listening for state changes on connector.
 		connector.controllerCallback = this.onStateChanged.bind(this);
 	}

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -2,7 +2,6 @@ import { ConnectorMeta } from '@/core/connectors';
 import * as Options from '@/core/storage/options';
 import {
 	areAllResults,
-	debugLog,
 	DebugLogType,
 	getSecondsToScrobble,
 	isAnyResult,
@@ -23,6 +22,7 @@ import {
 } from '@/util/communication';
 import EventEmitter from '@/util/emitter';
 import * as BrowserStorage from '@/core/storage/browser-storage';
+import { debugLog } from '@/core/content/util';
 
 /**
  * List of song fields used to check if song is changed. If any of
@@ -118,7 +118,7 @@ export default class Controller {
 				this.shouldScrobblePodcasts = shouldScrobblePodcasts;
 			})
 			.catch((err) => {
-				console.error(err);
+				debugLog(err, 'error');
 			});
 
 		this.debugLog(`Created controller for ${connector.label} connector`);

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -263,8 +263,6 @@ export default class Controller {
 				break;
 			}
 		}
-		console.log(event);
-		// do nothing
 	}
 
 	/** Public functions */

--- a/src/core/object/pipeline/coverartarchive/coverartarchive.ts
+++ b/src/core/object/pipeline/coverartarchive/coverartarchive.ts
@@ -1,5 +1,6 @@
 import Song from '@/core/object/song';
 import { MusicBrainzSearch } from './coverartarchive.types';
+import { debugLog } from '@/core/content/util';
 
 /**
  * Fetch coverart from MusicBrainz archive.
@@ -7,10 +8,10 @@ import { MusicBrainzSearch } from './coverartarchive.types';
  */
 export async function process(song: Song): Promise<void> {
 	if (song.parsed.trackArt) {
-		console.log('Using local/parsed artwork');
+		debugLog('Using local/parsed artwork');
 		return;
 	} else if (song.metadata.trackArtUrl) {
-		console.log('Found album artwork via LastFM');
+		debugLog('Found album artwork via LastFM');
 		return;
 	} else if (song.isEmpty()) {
 		return;
@@ -32,7 +33,7 @@ export async function process(song: Song): Promise<void> {
 		}
 
 		if (coverArtUrl) {
-			console.log('Found album artwork via MusicBrainz');
+			debugLog('Found album artwork via MusicBrainz');
 
 			song.metadata.trackArtUrl = coverArtUrl;
 			return;

--- a/src/core/object/pipeline/regex-edits.ts
+++ b/src/core/object/pipeline/regex-edits.ts
@@ -1,3 +1,4 @@
+import { debugLog } from '@/core/content/util';
 import Song from '@/core/object/song';
 import RegexEdits from '@/core/storage/regex-edits';
 
@@ -13,6 +14,6 @@ export async function process(song: Song): Promise<void> {
 	try {
 		await RegexEdits.loadSongInfo(song);
 	} catch (err) {
-		console.error(err);
+		debugLog(err, 'error');
 	}
 }

--- a/src/core/object/pipeline/user-input.ts
+++ b/src/core/object/pipeline/user-input.ts
@@ -5,6 +5,7 @@
 
 import SavedEdits from '@/core/storage/saved-edits';
 import Song from '@/core/object/song';
+import { debugLog } from '@/core/content/util';
 
 /**
  * Fill song info by user defined values.
@@ -15,7 +16,7 @@ export async function process(song: Song): Promise<void> {
 	try {
 		isSongInfoLoaded = await SavedEdits.loadSongInfo(song);
 	} catch (err) {
-		console.error(err);
+		debugLog(err, 'error');
 	}
 
 	song.flags.isCorrectedByUser = isSongInfoLoaded;

--- a/src/core/object/scrobble-service.ts
+++ b/src/core/object/scrobble-service.ts
@@ -6,6 +6,7 @@ import MalojaScrobbler from '@/core/scrobbler/maloja/maloja-scrobbler';
 import { ServiceCallResult } from '@/core/object/service-call-result';
 import Song, { BaseSong } from '@/core/object/song';
 import { ScrobblerSongInfo } from '@/core/scrobbler/base-scrobbler';
+import { debugLog } from '../content/util';
 
 /**
  * Service to handle all scrobbling behavior.
@@ -57,7 +58,7 @@ class ScrobbleService {
 				await scrobbler.getSession();
 				this.bindScrobbler(scrobbler);
 			} catch (e) {
-				console.warn(`Unable to bind ${scrobbler.getLabel()}`);
+				debugLog(`Unable to bind ${scrobbler.getLabel()}`, 'warn');
 			}
 		}
 
@@ -71,7 +72,7 @@ class ScrobbleService {
 	bindScrobbler(scrobbler: Scrobbler): void {
 		if (!isScrobblerInArray(scrobbler, this.boundScrobblers)) {
 			this.boundScrobblers.push(scrobbler);
-			console.log(`Bind ${scrobbler.getLabel()} scrobbler`);
+			debugLog(`Bind ${scrobbler.getLabel()} scrobbler`);
 		}
 	}
 
@@ -84,9 +85,9 @@ class ScrobbleService {
 			const index = this.boundScrobblers.indexOf(scrobbler);
 			this.boundScrobblers.splice(index, 1);
 
-			console.log(`Unbind ${scrobbler.getLabel()} scrobbler`);
+			debugLog(`Unbind ${scrobbler.getLabel()} scrobbler`);
 		} else {
-			console.error(`${scrobbler.getLabel()} is not bound`);
+			debugLog(`${scrobbler.getLabel()} is not bound`, 'error');
 		}
 	}
 
@@ -101,15 +102,17 @@ class ScrobbleService {
 		const scrobblers = registeredScrobblers.filter((scrobbler) => {
 			return scrobbler.canLoadSongInfo();
 		});
-		console.log(`Send "get info" request: ${scrobblers.length}`);
+
+		debugLog(`Send "get info" request: ${scrobblers.length}`);
 
 		return Promise.all(
 			scrobblers.map(async (scrobbler) => {
 				try {
 					return await scrobbler.getSongInfo(song);
 				} catch {
-					console.warn(
-						`Unable to get song info from ${scrobbler.getLabel()}`
+					debugLog(
+						`Unable to get song info from ${scrobbler.getLabel()}`,
+						'warn'
 					);
 					return null;
 				}
@@ -123,9 +126,7 @@ class ScrobbleService {
 	 * @returns Promise that will be resolved then the task will complete
 	 */
 	sendNowPlaying(song: Song): Promise<ServiceCallResult[]> {
-		console.log(
-			`Send "now playing" request: ${this.boundScrobblers.length}`
-		);
+		debugLog(`Send "now playing" request: ${this.boundScrobblers.length}`);
 
 		return Promise.all(
 			this.boundScrobblers.map(async (scrobbler) => {
@@ -150,7 +151,7 @@ class ScrobbleService {
 	 * @returns Promise that will be resolved then the task will complete
 	 */
 	scrobble(song: Song): Promise<ServiceCallResult[]> {
-		console.log(`Send "scrobble" request: ${this.boundScrobblers.length}`);
+		debugLog(`Send "scrobble" request: ${this.boundScrobblers.length}`);
 
 		return Promise.all(
 			this.boundScrobblers.map(async (scrobbler) => {
@@ -183,7 +184,7 @@ class ScrobbleService {
 			return scrobbler.canLoveSong();
 		});
 		const requestName = flag ? 'love' : 'unlove';
-		console.log(`Send "${requestName}" request: ${scrobblers.length}`);
+		debugLog(`Send "${requestName}" request: ${scrobblers.length}`);
 
 		return Promise.all(
 			scrobblers.map(async (scrobbler) => {

--- a/src/core/object/song.ts
+++ b/src/core/object/song.ts
@@ -366,8 +366,6 @@ export default class Song extends BaseSong {
 		this.connectorLabel = connector.label;
 
 		this.initSongData();
-
-		console.log('creating song');
 	}
 
 	public resetInfo(): void {

--- a/src/core/storage/options.ts
+++ b/src/core/storage/options.ts
@@ -1,5 +1,6 @@
 import connectors, { ConnectorMeta } from '@/core/connectors';
 import * as BrowserStorage from '@/core/storage/browser-storage';
+import { debugLog } from '../content/util';
 
 const options = BrowserStorage.getStorage(BrowserStorage.OPTIONS);
 const connectorsOptions = BrowserStorage.getStorage(
@@ -172,7 +173,7 @@ async function cleanupConfigValues() {
 
 		if (!isFound) {
 			delete data[DISABLED_CONNECTORS][connectorId];
-			console.log(`Remove ${connectorId} from storage`);
+			debugLog(`Remove ${connectorId} from storage`);
 		}
 	}
 }

--- a/src/core/storage/wrapper.ts
+++ b/src/core/storage/wrapper.ts
@@ -239,10 +239,13 @@ export default class StorageWrapper<K extends keyof DataModels> {
 		};
 
 		const text = JSON.stringify(data, hideSensitiveDataFn, 2);
+
+		// #v-ifndef VITE_TEST
 		// dont log in content script
-		if (location.protocol === 'chrome-extension:') {
+		if (location?.protocol === 'chrome-extension:') {
 			debugLog(`storage.${this.namespace} = ${text}`, 'info');
 		}
+		// #v-endif
 	}
 
 	/**

--- a/src/core/storage/wrapper.ts
+++ b/src/core/storage/wrapper.ts
@@ -238,7 +238,10 @@ export default class StorageWrapper<K extends keyof DataModels> {
 		};
 
 		const text = JSON.stringify(data, hideSensitiveDataFn, 2);
-		console.info(`storage.${this.namespace} = ${text}`);
+		// dont log in content script
+		if (location.protocol === 'chrome-extension:') {
+			console.info(`storage.${this.namespace} = ${text}`);
+		}
 	}
 
 	/**

--- a/src/core/storage/wrapper.ts
+++ b/src/core/storage/wrapper.ts
@@ -24,6 +24,7 @@ import { CloneableSong } from '@/core/object/song';
 import EventEmitter from '@/util/emitter';
 import connectors from '@/core/connectors';
 import { RegexEdit } from '@/util/regex';
+import { debugLog } from '../content/util';
 
 export interface CustomPatterns {
 	[connectorId: string]: string[];
@@ -204,7 +205,7 @@ export default class StorageWrapper<K extends keyof DataModels> {
 		try {
 			await this.set(data);
 		} catch (err) {
-			console.warn(err);
+			debugLog(err, 'warn');
 		}
 		this.unlock();
 	}
@@ -240,7 +241,7 @@ export default class StorageWrapper<K extends keyof DataModels> {
 		const text = JSON.stringify(data, hideSensitiveDataFn, 2);
 		// dont log in content script
 		if (location.protocol === 'chrome-extension:') {
-			console.info(`storage.${this.namespace} = ${text}`);
+			debugLog(`storage.${this.namespace} = ${text}`, 'info');
 		}
 	}
 

--- a/src/util/notifications.ts
+++ b/src/util/notifications.ts
@@ -5,6 +5,7 @@ import { getPlatformName, isFullscreenMode } from '@/util/util-browser';
 import * as Options from '@/core/storage/options';
 import { ConnectorMeta } from '@/core/connectors';
 import { Scrobbler } from '@/core/object/scrobble-service';
+import { debugLog } from '@/core/content/util';
 
 /**
  * Notification service.
@@ -214,7 +215,8 @@ export async function showNowPlaying(
 				song.metadata.notificationId = notificationId;
 			})
 			.catch((err) => {
-				console.warn('Unable to show now playing notification: ', err);
+				debugLog('Unable to show now playing notification: ', 'warn');
+				debugLog(err, 'warn');
 			});
 	}, NOW_PLAYING_NOTIFICATION_DELAY);
 }
@@ -324,7 +326,7 @@ function clearNotificationTimeout() {
 }
 
 browser.notifications?.onClicked.addListener((notificationId) => {
-	console.log(`Notification onClicked: ${notificationId}`);
+	debugLog(`Notification onClicked: ${notificationId}`);
 
 	if (clickListeners[notificationId]) {
 		clickListeners[notificationId](notificationId);

--- a/tests/background/saved-edits.test.ts
+++ b/tests/background/saved-edits.test.ts
@@ -1,7 +1,6 @@
 import { expect, describe, it, beforeAll } from 'vitest';
 
 import webextensionPolyfill from '#/mocks/webextension-polyfill';
-('#/mocks/webextension-polyfill');
 
 import Song from '@/core/object/song';
 import { getConnectorById } from '@/util/util-connector';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,6 @@
 import { resolvePath } from './scripts/util';
+import './scripts/set-test-env';
+import ConditionalCompile from 'vite-plugin-conditional-compiler';
 export default {
 	resolve: {
 		alias: {
@@ -6,4 +8,5 @@ export default {
 			'#': resolvePath(__dirname, './tests'),
 		},
 	},
+	plugins: [ConditionalCompile()],
 };


### PR DESCRIPTION
Small patch that more or less completes the process of reducing our logging verbosity and prefixing logs.
Does modify the loading behavior of the content script, but shouldn't be in a meaningful way (other than for reducing logs).
Completely eliminates all logs on non-supported websites, hence closes #3828 