### PR TITLE
Fix image url helper

### DIFF
--- a/src/core/content/util.ts
+++ b/src/core/content/util.ts
@@ -496,7 +496,7 @@ export function extractImageUrlFromSelectors(
 		return null;
 	}
 	const elements = queryElements(selectors);
-	if (!elements) {
+	if (!elements || !elements.length) {
 		return null;
 	}
 


### PR DESCRIPTION
Checks off a little edge case that was missed.
Closes #3769 as this was the underlying cause of that connector not working.