### PR TITLE
Remove minification

### DIFF
--- a/vite.configs.ts
+++ b/vite.configs.ts
@@ -38,7 +38,7 @@ function distRoot() {
 export const buildBackground: UserConfig = {
 	...common,
 	build: {
-		minify: !isDev(),
+		minify: false,
 		outDir: resolvePath(distRoot(), 'background'),
 		emptyOutDir: true,
 		watch: isDev() ? {} : null,
@@ -60,7 +60,7 @@ export const buildBackground: UserConfig = {
 export const buildContent: UserConfig = {
 	...common,
 	build: {
-		minify: !isDev(),
+		minify: false,
 		outDir: resolvePath(distRoot(), 'content'),
 		emptyOutDir: true,
 		watch: isDev() ? {} : null,
@@ -82,7 +82,7 @@ export const buildContent: UserConfig = {
 export const buildStart: UserConfig = {
 	...common,
 	build: {
-		minify: !isDev(),
+		minify: false,
 		outDir: distRoot(),
 		emptyOutDir: false,
 		watch: isDev() ? {} : null,


### PR DESCRIPTION
Not convinced this is worth it.
Would take us from ~640kb to ~690kb zipped, and from ~1.3mb to ~1.7mb unpacked.
However, also allows gleaning a lot more information from production logs.