### PR TITLE
Simplify priority

### DIFF
--- a/src/core/background/main.ts
+++ b/src/core/background/main.ts
@@ -23,7 +23,7 @@ import {
 } from './util';
 import {
 	ControllerModeStr,
-	controllerModePriorityObject,
+	isPrioritizedMode,
 } from '@/core/object/controller/controller';
 import { CloneableSong } from '@/core/object/song';
 import {
@@ -112,10 +112,7 @@ async function updateTabList(tabId: number, activated: boolean) {
 
 	const curTab = await getActiveTabDetails(newTabs, tabId);
 
-	if (
-		controllerModePriorityObject[curTab.mode] !== 0 &&
-		curTab.tabId === tabId
-	) {
+	if (isPrioritizedMode[curTab.mode] && curTab.tabId === tabId) {
 		if (activated) {
 			newTabs = [curTab, ...newTabs];
 		} else {

--- a/src/core/background/util.ts
+++ b/src/core/background/util.ts
@@ -3,10 +3,7 @@ import { ManagerTab, StateManagement } from '@/core/storage/wrapper';
 import browser from 'webextension-polyfill';
 import * as ControllerMode from '@/core/object/controller/controller-mode';
 import * as BrowserStorage from '@/core/storage/browser-storage';
-import {
-	controllerModePriority,
-	controllerModePriorityObject,
-} from '@/core/object/controller/controller';
+import { isPrioritizedMode } from '@/core/object/controller/controller';
 import { performUpdateAction } from './action';
 import { sendBackgroundMessage } from '@/util/communication';
 
@@ -107,16 +104,12 @@ export async function getActiveTabDetails(
 	tabs: ManagerTab[],
 	tabId?: number
 ): Promise<ManagerTab> {
-	const tab = getPriorityTabDetails(tabs, tabId);
+	const tab = getPriorityTabDetails(tabs);
 	if (!tabId) {
 		tabId = await getCurrentTabId();
 	}
 	const curTab = await getTabDetails(tabId);
-	if (
-		tab &&
-		controllerModePriorityObject[tab.mode] >
-			controllerModePriorityObject[curTab.mode]
-	) {
+	if (tab && !isPrioritizedMode[curTab.mode]) {
 		return tab;
 	}
 	return curTab;
@@ -159,22 +152,10 @@ async function getTabDetails(tabId: number): Promise<ManagerTab> {
  * @param tabId - Currently active tab id if known
  * @returns the tab that is the current priority for action state
  */
-function getPriorityTabDetails(
-	tabs: ManagerTab[],
-	tabId?: number
-): ManagerTab | null {
-	for (const priorityGroup of controllerModePriority.slice(0, -1)) {
-		let toReturn: ManagerTab | null = null;
-		for (const tab of tabs) {
-			if (priorityGroup.includes(tab.mode)) {
-				if (tabId && tab.tabId === tabId) {
-					return tab;
-				}
-				toReturn = tab;
-			}
-		}
-		if (toReturn) {
-			return toReturn;
+function getPriorityTabDetails(tabs: ManagerTab[]): ManagerTab | null {
+	for (const tab of tabs) {
+		if (isPrioritizedMode[tab.mode]) {
+			return tab;
 		}
 	}
 	return null;

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -37,35 +37,15 @@ export type ControllerModeStr =
 	(typeof ControllerMode)[keyof typeof ControllerMode];
 
 /**
- * States and their priority. earlier indices will be displayed first.
- */
-export const controllerModePriority: ControllerModeStr[][] = [
-	[ControllerMode.Err, ControllerMode.Ignored],
-	[ControllerMode.Unknown],
-	[ControllerMode.Loading],
-	[ControllerMode.Playing, ControllerMode.Scrobbled],
-	[
-		ControllerMode.Base,
-		ControllerMode.Skipped,
-		ControllerMode.Disabled,
-		ControllerMode.Unsupported,
-	],
-];
-
-/**
  * Priorities of each state as an object
  */
-export const controllerModePriorityObject: Record<ControllerModeStr, number> = {
-	[ControllerMode.Base]: 0,
-	[ControllerMode.Skipped]: 0,
-	[ControllerMode.Disabled]: 0,
-	[ControllerMode.Unsupported]: 0,
-	[ControllerMode.Playing]: 1,
-	[ControllerMode.Scrobbled]: 1,
-	[ControllerMode.Loading]: 2,
-	[ControllerMode.Unknown]: 3,
-	[ControllerMode.Ignored]: 4,
-	[ControllerMode.Err]: 4,
+export const isPrioritizedMode: Partial<Record<ControllerModeStr, true>> = {
+	[ControllerMode.Playing]: true,
+	[ControllerMode.Scrobbled]: true,
+	[ControllerMode.Loading]: true,
+	[ControllerMode.Unknown]: true,
+	[ControllerMode.Ignored]: true,
+	[ControllerMode.Err]: true,
 };
 
 type updateEvent = {


### PR DESCRIPTION
It seemed good on paper to have errors take precedence over other prioritized modes.
In practice it seems to cause more confusion than it helps.