### PR TITLE
Add fetch album artist from music kit instance

### DIFF
--- a/src/connectors/musickit-dom-inject.ts
+++ b/src/connectors/musickit-dom-inject.ts
@@ -63,6 +63,7 @@ async function musicKitGetTrackInfo() {
 		album: item.albumName,
 		track: item.title,
 		artist: item.artistName,
+		albumArtist: item.container?.attributes?.artistName,
 		trackArt: musicKitArtwork(item.artworkURL),
 		duration: instance.currentPlaybackDuration,
 		uniqueID: item.id,


### PR DESCRIPTION
**Describe the changes you made**
Add optional fetch album artist to  track info when available. Album artist will availabe on container attributes when song play from Album or queue as Full Album.

**Additional context**

_Album Attributes_
 
![container](https://github.com/web-scrobbler/web-scrobbler/assets/18456011/a028213f-c828-4933-a837-cc7ee80737c9)

_Song Play From Album_

![album](https://github.com/web-scrobbler/web-scrobbler/assets/18456011/29e53d78-8e91-4b7a-95f1-c83fe5d397bf)

_Song Play Not from album (search result or playlist)_

![song](https://github.com/web-scrobbler/web-scrobbler/assets/18456011/ef2de418-db2b-4683-884e-9c31c5d07469)
