### PR TITLE
Fix Idagio connector

### DIFF
--- a/src/connectors/idagio.ts
+++ b/src/connectors/idagio.ts
@@ -23,7 +23,7 @@ Connector.currentTimeSelector = '.player-PlayerProgress__progress--2F0qB>span';
 Connector.durationSelector = '.player-PlayerProgress__timeTotal--3aHlj span';
 
 Connector.isPlaying = () =>
-	Util.getTextFromSelectors(pauseButtonSelector) === 'Pause';
+	Util.getTextFromSelectors(pauseButtonSelector)?.toUpperCase() === 'PAUSE';
 
 Connector.isScrobblingAllowed = () =>
 	Util.getTextFromSelectors('.player-PlayerInfo__recordingInfo--15VMv') !==


### PR DESCRIPTION
**Describe the changes you made**
Fixed the Idagio connector not recognizing when a track is playing.

**Additional context**
The Idagio connector was not scrobbling music. The `isPlaying` check expects the play button label to equal "Pause" when a track is playing which is also what is visible in the DOM, however they use a `text-transform: uppercase` CSS styling on it.
I call `toUpper` on the found text, so it doesn't break again should they remove the styling.