### PR TITLE
Fix Tidal Multiple Artists Scrobbling

### DIFF
--- a/src/connectors/tidal.ts
+++ b/src/connectors/tidal.ts
@@ -25,7 +25,12 @@ Connector.getUniqueID = () => {
 	return null;
 };
 
-Connector.artistSelector = `${Connector.playerSelector} span.artist-link`;
+const artistSelector = `${Connector.playerSelector} span.artist-link a`;
+
+Connector.getArtist = () => {
+	const artistNodes = document.querySelectorAll(artistSelector);
+	return Util.joinArtists(Array.from(artistNodes));
+};
 
 Connector.albumSelector = [
 	'#nowPlaying div.react-tabs a[href^="/album/"]',
@@ -39,7 +44,8 @@ Connector.getAlbumArtist = () => {
 		'href'
 	);
 	if (albumUrl && canonicalUrl && canonicalUrl.endsWith(albumUrl)) {
-		return Util.getTextFromSelectors('#main .header-details .artist-link');
+		const albumArtistNode = document.querySelectorAll('#main .header-details .artist-link a');
+		return Util.joinArtists(Array.from(albumArtistNode));
 	}
 	return null;
 };


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
Manual adding `, ` sparator when multiple artist from tidal. This happen because new tidal website using CSS pseudo-elements to add the sparator, so when use `Connector.artistSelector` will get text content without the sparator.
Fix #3686

**Additional context**
<!-- Add any other context or screenshots here. -->
Testing 
1. Only Multiple track artist 
![multiple_artist](https://github.com/web-scrobbler/web-scrobbler/assets/18456011/63b2e1fb-1f13-46d5-8845-046d9401de12)
2.  Multiple track artist and album artist
![multiple_artist_n_album_artist](https://github.com/web-scrobbler/web-scrobbler/assets/18456011/4283968b-ca84-447f-b8ed-308c90404298)
3.  Multiple track artist and one album artist
![multiple_artist_n_single_album_artist](https://github.com/web-scrobbler/web-scrobbler/assets/18456011/772d68c4-beda-4d0f-984d-af732fe8a61f)
4.  Single Artist
![single_artist](https://github.com/web-scrobbler/web-scrobbler/assets/18456011/f070c44d-5caf-4145-832e-5ccb841e5861)

