### PR TITLE
Fix poolsuite.net not scrobbling

### DIFF
--- a/src/connectors/poolsuite.ts
+++ b/src/connectors/poolsuite.ts
@@ -2,7 +2,9 @@ export {};
 
 Connector.playButtonSelector = '.middle.paused';
 Connector.playerSelector = '.inner-size';
-Connector.trackSelector = '.current-track a:first';
-Connector.artistSelector = '.current-track a:last';
-Connector.currentTimeSelector = '.timer span:first';
-Connector.durationSelector = '.timer span:last';
+Connector.trackSelector = '.current-track h3';
+Connector.artistSelector = '.current-track h2';
+Connector.currentTimeSelector = '.timer span:nth-child(1)';
+Connector.durationSelector = '.timer span:nth-child(2)';
+
+Connector.isScrobblingAllowed = () => Connector.getTrack() !== 'Loading...';


### PR DESCRIPTION
**Describe the changes you made**
Change the poolsuite selector and add condition `isScrobblingAllowed `when title is not `Loading...`.
This PR will fix #3921

**Additional context**
Testing

![2023-06-29_22-27](https://github.com/web-scrobbler/web-scrobbler/assets/18456011/d1e30843-fab0-45c8-9b70-3129043cd30e)
