### PR TITLE
Fix popup links width

### DIFF
--- a/src/ui/popup/popup.module.scss
+++ b/src/ui/popup/popup.module.scss
@@ -90,6 +90,7 @@ a {
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
+			width: fit-content;
 		}
 
 		@supports (-webkit-touch-callout: none) {

--- a/src/ui/popup/popup.module.scss
+++ b/src/ui/popup/popup.module.scss
@@ -103,6 +103,7 @@ a {
 	.playDetails {
 		display: flex;
 		gap: 0.5em;
+		width: fit-content;
 	}
 
 	.playCount {
@@ -127,6 +128,7 @@ a {
 	.controlButtons {
 		display: flex;
 		margin-top: 0.5em;
+		width: fit-content;
 
 		.controlButton {
 			background-color: transparent;


### PR DESCRIPTION
**Describe the changes you made**
Added `width: fit-content` to `PopupAnchor`, `TrackMetadata` and `TrackControls` component styles.

**Additional context**
Until the recent 3.0 update, the links (track, artist, album) in the popup took up just enough space for the text inside them, but since the update these links have started to take up all available space. Because of this, users can't double-click on the nearby empty space right to the links to quickly select a track or artist or album link and copy its text to the clipboard for a fast googling.

Before 3.0:
For example, I was able to double click on the space marked with the yellow circle and quickly select the artist name. Then I could press Ctrl+N to open a new window, Ctrl+V to paste the artist name from the clipboard, and Enter to google.
![2023-06-30_231049](https://github.com/web-scrobbler/web-scrobbler/assets/7773972/73015598-5e13-46ca-861f-7b6371380114)

After 3.0:
If there is a cursor over the space marked with the yellow circle, the cursor appears to be of pointer style and clicking here opens a new tab.
![2023-06-30_231448](https://github.com/web-scrobbler/web-scrobbler/assets/7773972/38133f47-6524-4f28-9dc5-c50ad06eada8)

Here we can see that the artist link takes up all available space:
![2023-06-30_232205](https://github.com/web-scrobbler/web-scrobbler/assets/7773972/36313179-3ab8-4986-bf28-c0b006d94a30)


 