### PR TITLE
Add connector for Radio Carpice (radcap.ru)

### DIFF
--- a/src/connectors/radcap.ts
+++ b/src/connectors/radcap.ts
@@ -1,0 +1,39 @@
+export {};
+
+function setupConnector() {
+	if (isDesktopPlayer()) {
+		setupDesktopPlayer();
+	} 
+  else {
+		setupMobilePlayer();
+	}
+}
+
+function isDesktopPlayer() {
+	return Boolean(document.querySelector('.radio'));
+}
+
+function setupDesktopPlayer() {
+	Connector.playerSelector = '.radio';
+
+  Connector.artistTrackSelector = '.stream.stream-signal > tbody > tr > td';
+
+  Connector.playButtonSelector = '#oframeplayer-d > pjsdiv:nth-child(7)';
+}
+
+function setupMobilePlayer() {
+  Connector.playerSelector = '.container';
+
+  Connector.artistTrackSelector = 'table.stream > tbody > tr > td';
+
+  const upperPlayerPlayButton = '#oframeaudioplayer2 > pjsdiv:nth-child(8) > pjsdiv:nth-child(2)';
+
+  const lowerPlayerPlayButton = '#oframeaudioplayer0 > pjsdiv:nth-child(8) > pjsdiv:nth-child(2)';
+
+  Connector.isPlaying = () => {
+    return (Util.isElementVisible(upperPlayerPlayButton) 
+    || Util.isElementVisible(lowerPlayerPlayButton))
+  }
+}
+
+setupConnector();

--- a/src/connectors/radcap.ts
+++ b/src/connectors/radcap.ts
@@ -1,20 +1,20 @@
 export {};
 
 function setupConnector() {
-	if (isDesktopPlayer()) {
-		setupDesktopPlayer();
+  if (isDesktopPlayer()) {
+    setupDesktopPlayer();
 	} 
   else {
-		setupMobilePlayer();
+    setupMobilePlayer();
 	}
 }
 
 function isDesktopPlayer() {
-	return Boolean(document.querySelector('.radio'));
+  return Boolean(document.querySelector('.radio'));
 }
 
 function setupDesktopPlayer() {
-	Connector.playerSelector = '.radio';
+  Connector.playerSelector = '.radio';
 
   Connector.artistTrackSelector = '.stream.stream-signal > tbody > tr > td';
 

--- a/src/connectors/radcap.ts
+++ b/src/connectors/radcap.ts
@@ -31,9 +31,9 @@ function setupMobilePlayer() {
   const lowerPlayerPlayButton = '#oframeaudioplayer0 > pjsdiv:nth-child(8) > pjsdiv:nth-child(2)';
 
   Connector.isPlaying = () => {
-    return (Util.isElementVisible(upperPlayerPlayButton) 
-    || Util.isElementVisible(lowerPlayerPlayButton))
-  }
+    return (Util.getCSSPropertyFromSelectors(upperPlayerPlayButton, 'visibility') === 'hidden'
+    || Util.getCSSPropertyFromSelectors(lowerPlayerPlayButton, 'visibility') === 'hidden')
+  };
 }
 
 setupConnector();

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2100,4 +2100,10 @@ export default <ConnectorMeta[]>[
 		js: 'fungjai.js',
 		id: 'fungjai',
 	},
+	{
+		label: 'Radio Caprice',
+		matches: ['*://radcap.ru/*'],
+		js: 'radcap.js',
+		id: 'radcap',
+	},
 ];


### PR DESCRIPTION
**Describe the changes you made**
Add a connector for Radio Caprice (radcap or http://radcap.ru).

**Additional context**
I had some doubts about the label naming: 

- RADio CAPrice (RADCAP) is the title on their main page,
- but their app's title is Caprice Radio, 
- and throughout their website and on many radio aggregators, it is simply Radio Caprice. 

I opted for the last one because it seemed more widespread.

Other than that, that is my first PR ever - I hope I got everything correctly. 