### PR TITLE
Updated SiriusXM Connector with more filters

### DIFF
--- a/src/connectors/siriusxm-player.ts
+++ b/src/connectors/siriusxm-player.ts
@@ -48,8 +48,6 @@ Connector.isScrobblingAllowed = () => {
 	return !filteredTerms.some(
 		(term) => artist?.includes(term) || track?.includes(term)
 	);
-
-	return !filteredTerms.track?.includes("@");
 };
 
 Connector.applyFilter(filter);

--- a/src/connectors/siriusxm-player.ts
+++ b/src/connectors/siriusxm-player.ts
@@ -10,34 +10,40 @@ export {};
 const filter = MetadataFilter.createFilter({ track: removeYear });
 const removeYearRe = /\s\(\d{2}\)\s?$/g;
 
-Connector.playerSelector = '.sxm-player-controls';
-
-Connector.artistSelector = '.sxm-player-controls .artist-name';
-
-Connector.trackSelector = '.sxm-player-controls .track-name';
+Connector.playerSelector = ".sxm-player-controls";
+Connector.artistSelector = ".sxm-player-controls .artist-name";
+Connector.trackSelector = ".sxm-player-controls .track-name";
 
 Connector.isPlaying = () => {
 	return (
 		Util.getAttrFromSelectors(
-			'.sxm-player-controls .play-pause-btn',
-			'title'
-		) === 'Pause'
+			".sxm-player-controls .play-pause-btn",
+			"title"
+		) === "Pause"
 	);
 };
 
-Connector.trackArtSelector = '.album-image-cell img';
+Connector.trackArtSelector = ".album-image-cell img.album-image";
 
 Connector.isScrobblingAllowed = () => {
-	const artist = Connector.getArtist();
-	if (artist) {
-		return !artist.toLowerCase().includes('siriusxmu');
-	}
+	const artist = Connector.getArtist()?.toLowerCase();
+	const track = Connector.getTrack()?.toLowerCase();
+	const filteredTerms = [
+		"siriusxmu",
+		"altnation",
+		"sxmhairnation",
+		".c", // will catch .com and .ca URLs
+		"indie 1.0",
+		"#",
+	];
 
-	return false;
+	return !filteredTerms.some(
+		(term) => artist?.includes(term) || track?.includes(term)
+	);
 };
 
 Connector.applyFilter(filter);
 
 function removeYear(track: string) {
-	return track.replace(removeYearRe, '');
+	return track.replace(removeYearRe, "");
 }

--- a/src/connectors/siriusxm-player.ts
+++ b/src/connectors/siriusxm-player.ts
@@ -37,7 +37,8 @@ Connector.isScrobblingAllowed = () => {
 		"1-877-33-sirius",
 		"@sxm", //will broadly catch a bunch of sxm Twitter handles
 		"altnation",
-		".c", // will catch .com and .ca URLs
+		".ca",
+		".com",
 		"indie 1.0",
 		"#",
 		"facebook",
@@ -47,6 +48,8 @@ Connector.isScrobblingAllowed = () => {
 	return !filteredTerms.some(
 		(term) => artist?.includes(term) || track?.includes(term)
 	);
+
+	return !filteredTerms.track?.includes("@");
 };
 
 Connector.applyFilter(filter);

--- a/src/connectors/siriusxm-player.ts
+++ b/src/connectors/siriusxm-player.ts
@@ -29,12 +29,19 @@ Connector.isScrobblingAllowed = () => {
 	const artist = Connector.getArtist()?.toLowerCase();
 	const track = Connector.getTrack()?.toLowerCase();
 	const filteredTerms = [
-		"siriusxmu",
+		"@siriusxm",
+		"@jennylsq",
+		"@radiomadison",
+		"@morningmashup",
+		"josiah",
+		"1-877-33-sirius",
+		"@sxm", //will broadly catch a bunch of sxm Twitter handles
 		"altnation",
-		"sxmhairnation",
 		".c", // will catch .com and .ca URLs
 		"indie 1.0",
 		"#",
+		"facebook",
+		"twitter",
 	];
 
 	return !filteredTerms.some(


### PR DESCRIPTION
Related to #2222 #3319 

Added some improved filtering for station IDs and DJ handles. I did some testing and playing around with finding different criteria for exclusion and found some weird edge cases. 

- My filter now checks the artist and track instead of just artist, as it increases the percentage of properly filtering the station IDs and Twitter handles
- I discovered that filtering by ﹫ tends to be too broad. The character is used sometimes with certain channels to denote the artist, most prominently The Grateful Dead channel using ﹫greatfuldead all the time. Or it can be used in some like "Live ﹫ SiriusXM" which would still be a valid scrobble.
- I added a few Twitter account handles, but found the list tended to be too extensive to filter against them all. We could compile such a list, but I don't readily have that list handy. The good thing is that some of the filters in tandem with the Twitter filters tends to get most of the cases (ie. like where they have a host handle with a URL or hashtag)
- I added a ".c" filter which would catch the vast majority of URLs, both .ca and .com. I'm not sure if there are other regionalizations of SiriusXM that might have URLs that should be filtered. I didn't encounter any others.
- Adding #️⃣ tends to catch a lot of the ones we want to filter. I did note this had a possibility to excluding classical tracks, but looking at the lastfm data I didn't see much indication people were probably scrobbling those channels.
- I tried having "siriusxm" but found that one was way too broad. It would exclude live sessions or some show names. Didn't want to limit how some people might use Web Scrobbler for tracking.
- I also tweaked the trackArtSelector, as it had been pulling null previously

**Scrobbling Data I used to find filter criteria**
- https://www.last.fm/search/tracks?q=%40sxm
- https://www.last.fm/search/tracks?q=siriusxm
- https://www.last.fm/search/tracks?q=fb.com
