### PR TITLE
Fix Globalplayer (RadioX, Smooth) Connector

### DIFF
--- a/src/connectors/globalplayer.ts
+++ b/src/connectors/globalplayer.ts
@@ -1,14 +1,16 @@
 export {};
 
-const showNameSelector = '.show-info-with-image__text__title';
+const showNameSelector =
+	'div[class^="style_playbarInfo"] div[data-testid="show-info-title"]';
 
-Connector.playerSelector = '.track-container';
-
-Connector.trackSelector = '.track-container .show-info__text__title';
-
-Connector.artistSelector = '.track-container .show-info__text__subtitle';
-
-Connector.playButtonSelector = '.circular-play-button';
+Connector.playerSelector = ".globalplayer";
+Connector.trackSelector =
+	'div[data-testid="show-info-card"] h1[data-testid="show-info-title"]';
+Connector.artistSelector =
+	'div[data-testid="show-info-card"] h2[data-testid="show-info-subtitle"]';
+Connector.playButtonSelector =
+	'button[data-testid="play-pause-button"][aria-pressed="false"]';
+Connector.trackArtSelector = 'div[class^="style_showInfoCard"] img.current-img';
 
 Connector.isScrobblingAllowed = () => {
 	return Connector.getTrack() !== getShowName();


### PR DESCRIPTION
From what I can tell Global Player has been broken for awhile. This connector powers a bunch of UK radio stations like https://radiox.co.uk, https://smoothradio.com and https://heart.co.uk/ and I believe there was a big redesign in the last 6 months that was never addressed by the connector. 

I was able to get the connector working again with live radio, as well as being able to scrobble the curated playlists the site has. The radio archives don't have the tracks split up, so those can't be scrobbled. 

## Known Issues
The one caveat about getting this site to work is that scrobbling will stop working if you navigate away from the particular playlist or live show you're listening to. The site doesn't use the persistent bottom bar to show the track meta (only the show or playlist name), so it's possible to have the music still playing while you navigate the site, but it will only scrobble correctly if you're on the show page because that's the only place that track meta exists to pull in. I attempted to pull it from the `<title>` tag, but that stops updating if you navigate away from the page you're listening on. So it's imperfect based on how the site is constructed. 

## Live Radio
![image](https://github.com/web-scrobbler/web-scrobbler/assets/2962327/033de5cf-ad2d-483a-af62-d203f9510aa8)

## Playlist Playback
![image](https://github.com/web-scrobbler/web-scrobbler/assets/2962327/29b32f2d-50c8-4dd6-b42d-b504f01b3b56)

