### PR TITLE
Add TrackerHub scrobble support

### DIFF
--- a/src/connectors/trackerhub.ts
+++ b/src/connectors/trackerhub.ts
@@ -1,0 +1,4 @@
+export {};
+
+Connector.useMediaSessionApi();
+Connector.playerSelector = '#player';

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2111,5 +2111,5 @@ export default <ConnectorMeta[]>[
 		matches: ['*://trackerhub.vercel.app/*'],
 		js: 'trackerhub.js',
 		id: 'trackerhub',
-	}.
+	},
 ];

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2106,4 +2106,9 @@ export default <ConnectorMeta[]>[
 		js: 'radcap.js',
 		id: 'radcap',
 	},
+	{
+		label: 'TrackerHub',
+		matches: ['*://trackerhub.vercel.app/*'],
+		js: 'trackerhub.js',
+		id: 'trackerhub'
 ];

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2110,5 +2110,6 @@ export default <ConnectorMeta[]>[
 		label: 'TrackerHub',
 		matches: ['*://trackerhub.vercel.app/*'],
 		js: 'trackerhub.js',
-		id: 'trackerhub'
+		id: 'trackerhub',
+	}.
 ];


### PR DESCRIPTION
**Describe the changes you made**
Adds support for https://trackerhub.vercel.app (dynamic music website)

**Additional context**
it uses the mediasession api with action handlers
![image](https://github.com/web-scrobbler/web-scrobbler/assets/68407783/f6e1f77c-9f07-4a49-9570-2b3982019145)
and heres the player element
![image](https://github.com/web-scrobbler/web-scrobbler/assets/68407783/3819694a-8362-43a3-a78c-9d261161a866)
tested ✅
![image](https://github.com/web-scrobbler/web-scrobbler/assets/68407783/9b2e508f-d2d1-46cd-9e36-757c93ec38d1)

