### PR TITLE
Ignore search parameters when getting a unique ID for SoundCloud

### DIFF
--- a/src/connectors/soundcloud.ts
+++ b/src/connectors/soundcloud.ts
@@ -43,11 +43,12 @@ Connector.getRemainingTime = () => {
 Connector.isPlaying = () => Util.hasElementClass('.playControl', 'playing');
 
 Connector.getUniqueID = () => {
-	return (
+	const url = new URL((
 		document.querySelector(
 			'.playbackSoundBadge__titleLink'
 		) as HTMLAnchorElement
-	).href;
+	).href);
+	return url.origin + url.pathname;
 };
 
 Connector.getOriginUrl = () => {


### PR DESCRIPTION
This patch makes it so that the SoundCloud connector doesn't include the search
parameters when it's asked for a unique ID.

This fixes the problem of having to re-edit your scrobble if you're listening from
an album or playlist.

**Describe the changes you made**
`src/connectors/soundcloud.ts`: Made it so when getUniqueID() is called it doesn't return a URL with search parameters so you don't have to re-edit a scrobble if you're listening to the same song in a different playlist/album.

**Additional context**
Made this change because it was slightly annoying having to edit my scrobble every time I listened to a playlist or an album.
