### PR TITLE
Silence console logs from content scripts by default

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -39,6 +39,14 @@
         "message": "Scrobble podcast episodes",
         "description": "Option title"
     },
+    "optionDebugLoggingEnabled": {
+        "message": "Enable debug logging",
+        "description": "Option label"
+    },
+    "optionDebugLoggingEnabledTitle": {
+        "message": "Allow the extension to log debug messages to the browser console",
+        "description": "Option title"
+    },
     "optionsScrobbleBehavior": {
         "message": "Scrobble behavior",
         "description": "'Scrobble behavior' section"

--- a/src/core/content/util.ts
+++ b/src/core/content/util.ts
@@ -746,27 +746,69 @@ export function injectScriptIntoDocument(scriptUrl: string): void {
 }
 
 /**
+ * Handle async checks for DEBUG_LOGGING_ENABLED option while ensuring
+ * that logs are still printed in a predictable order.
+ */
+class DebugLogQueue {
+  private queue: {text: unknown, logType: DebugLogType}[] = [];
+  private isActive = false;
+
+  /**
+   * Enqueue a log message to be printed.
+   * @param text - Debug message
+   * @param logType - Log type
+   */
+  public push(text: unknown, logType: DebugLogType): void {
+    this.queue.push({text, logType});
+    this.start();
+  }
+
+  /**
+   * Process the queue to print logs in order.
+   */
+  private async start(): Promise<void> {
+    if (this.isActive) return;
+    this.isActive = true;
+
+    try {
+      for (let i = 0; i < 100 && this.queue.length > 0; i++) {
+        const currentMessage = this.queue.shift();
+        if (currentMessage && await this.shouldPrint()) {
+          const logFunc = console[currentMessage.logType];
+
+          if (typeof logFunc !== 'function') {
+            throw new TypeError(`Unknown log type: ${currentMessage.logType}`);
+          }
+
+          const message = `Web Scrobbler: ${currentMessage.text}`;
+          logFunc(message);
+        }
+      }
+      this.isActive = false;
+    } catch(err) {
+      this.isActive = false;
+    }
+  }
+
+  /**
+   * Check if the user has enabled debug logging in the extension options.
+   */
+  private async shouldPrint(): Promise<boolean> {
+    const awaitedOptions = await Options;
+    const debugLoggingEnabled = await awaitedOptions.getOption(awaitedOptions.DEBUG_LOGGING_ENABLED);
+    return !!debugLoggingEnabled;
+  }
+}
+const debugLogQueue = new DebugLogQueue();
+
+/**
  * Print debug message with prefixed "Web Scrobbler" string.
  * @param text - Debug message
  * @param logType - Log type
  */
 /* istanbul ignore next */
-export async function debugLog(text: unknown, logType: DebugLogType = 'log'): Promise<void> {
-	const awaitedOptions = await Options;
-	const loggingEnabled = await awaitedOptions.getOption(awaitedOptions.DEBUG_LOGGING_ENABLED);
-
-	if (!loggingEnabled) {
-		return;
-	}
-
-	const logFunc = console[logType];
-
-	if (typeof logFunc !== 'function') {
-		throw new TypeError(`Unknown log type: ${logType}`);
-	}
-
-	const message = `Web Scrobbler: ${text}`;
-	logFunc(message);
+export function debugLog(text: unknown, logType: DebugLogType = 'log'): void {
+  debugLogQueue.push(text, logType)
 }
 
 /** YouTube section. */

--- a/src/core/content/util.ts
+++ b/src/core/content/util.ts
@@ -752,6 +752,7 @@ export function injectScriptIntoDocument(scriptUrl: string): void {
 class DebugLogQueue {
   private queue: {text: unknown, logType: DebugLogType}[] = [];
   private isActive = false;
+  private shouldPrint = Options.then((awaitedOptions) => awaitedOptions.getOption(awaitedOptions.DEBUG_LOGGING_ENABLED));
 
   /**
    * Enqueue a log message to be printed.
@@ -773,7 +774,7 @@ class DebugLogQueue {
     try {
       for (let i = 0; i < 100 && this.queue.length > 0; i++) {
         const currentMessage = this.queue.shift();
-        if (currentMessage && await this.shouldPrint()) {
+        if (currentMessage && await this.shouldPrint) {
           const logFunc = console[currentMessage.logType];
 
           if (typeof logFunc !== 'function') {
@@ -788,15 +789,6 @@ class DebugLogQueue {
     } catch(err) {
       this.isActive = false;
     }
-  }
-
-  /**
-   * Check if the user has enabled debug logging in the extension options.
-   */
-  private async shouldPrint(): Promise<boolean> {
-    const awaitedOptions = await Options;
-    const debugLoggingEnabled = await awaitedOptions.getOption(awaitedOptions.DEBUG_LOGGING_ENABLED);
-    return !!debugLoggingEnabled;
   }
 }
 const debugLogQueue = new DebugLogQueue();

--- a/src/core/storage/options.ts
+++ b/src/core/storage/options.ts
@@ -19,6 +19,7 @@ export const SCROBBLE_RECOGNIZED_TRACKS = 'scrobbleRecognizedTracks';
 export const SCROBBLE_EDITED_TRACKS_ONLY = 'scrobbleEditedTracksOnly';
 export const SCROBBLE_PERCENT = 'scrobblePercent';
 export const DISABLED_CONNECTORS = 'disabledConnectors';
+export const DEBUG_LOGGING_ENABLED = 'debugLoggingEnabled';
 
 export interface GlobalOptions {
 	/**
@@ -62,6 +63,11 @@ export interface GlobalOptions {
 	 * Scrobble podcast episodes.
 	 */
 	[SCROBBLE_PODCASTS]: boolean;
+
+	/**
+	 * Allow debug messages to be logged to the browser console.
+	 */
+	[DEBUG_LOGGING_ENABLED]: boolean;
 }
 
 /**
@@ -74,6 +80,7 @@ const DEFAULT_OPTIONS: GlobalOptions = {
 	[USE_UNRECOGNIZED_SONG_NOTIFICATIONS]: false,
 	[SCROBBLE_RECOGNIZED_TRACKS]: true,
 	[SCROBBLE_EDITED_TRACKS_ONLY]: false,
+	[DEBUG_LOGGING_ENABLED]: false,
 	[SCROBBLE_PERCENT]: 50,
 	[DISABLED_CONNECTORS]: {},
 };

--- a/src/ui/options/components/options/global-options.tsx
+++ b/src/ui/options/components/options/global-options.tsx
@@ -57,6 +57,14 @@ export default function GlobalOptionsList(props: {
 					i18nlabel="optionScrobblePodcasts"
 					key={Options.SCROBBLE_PODCASTS}
 				/>
+				<GlobalOptionEntry
+					options={props.options}
+					setOptions={props.setOptions}
+					globalOptions={globalOptions}
+					i18ntitle="optionDebugLoggingEnabledTitle"
+					i18nlabel="optionDebugLoggingEnabled"
+					key={Options.DEBUG_LOGGING_ENABLED}
+				/>
 			</ul>
 		</>
 	);


### PR DESCRIPTION
## Changes

Adds a new "Enable debug logging" option to the extension's global options (default: `false`). All logging from content scripts to the browser console is silenced unless the user manually enables the option.

## Context

Web Scrobbler can sometimes print a _lot_ of messages to the user's browser console, even on websites that don't have a connector. For example:

<img width="1029" alt="image" src="https://github.com/web-scrobbler/web-scrobbler/assets/1564277/4f7de57c-f516-421b-8999-ae58e3282755">

This can be very annoying for users who frequently use their browser console, since it can make it hard to find other messages printed there, and there's currently no way to silence console messages from Web Scrobbler other than disabling/uninstalling the extension. There are a few existing issues about this: #3828, #3110

This PR adds a new "Enable debug logging" option to Web Scrobbler's global options, sets it to `false` by default, and only allows the extension to print messages to the browser console if the user has switched it to `true`.

This doesn't affect any of the logging to the extension's service worker console or the console on the extension's options pages, just logs from content scripts to the user's main browser console when they're on a regular web page.

## Screenshots

New "Enable debug logging" option added to the global options UI:

<img width="890" alt="image" src="https://github.com/web-scrobbler/web-scrobbler/assets/1564277/53cb508f-aba9-4a0b-bb9c-91fb9167b7d8">

## Considerations

[The instructions for collecting logs from content scripts](https://github.com/web-scrobbler/web-scrobbler/wiki/Debug-the-extension#logs-of-content-scripts) would need to be updated once this change is released, since users will now need to switch on "Enable debug logging" before any logs will appear.

There are a few aspects of this PR that could use some improvement, I'd love any help making these better since they're a bit beyond my skills with TypeScript:

- ~~I've added a new `getGlobalOption()` function that has a return type of `Promise<unknown>`. The Promise should only ever resolve to one of the value types of [the `GlobalOptions` interface](https://github.com/web-scrobbler/web-scrobbler/blob/1f455fd/src/core/storage/options.ts#L23), but I couldn't work out the syntax for that so I've left it as `unknown`.~~ Now resolved as of a1101ef.
- ~~The new `getGlobalOption()` function duplicates a lot of code from the existing `getOption()` function above it, so they could probably be combined or refactored to share some code. I couldn't reuse `getOption()` in its current state because it calls `debugLog()`, which could lead to an infinite loop if it's called from within `debugLog()`. If maintainers would be okay with removing that `debugLog()` call, then the functions would become easier to refactor.~~ Now resolved as of a1101ef.
- I haven't added any tests for this new behaviour because there are no existing tests for `debugLog()` or `getOption()` for me to extend, and I'm not familiar enough with TypeScript or vitest to confidently add new tests.