### PR TITLE
Fix beatbump connector by updating url

### DIFF
--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -1926,7 +1926,7 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'Beatbump',
-		matches: ['*://beatbump.ml/*'],
+		matches: ['*://beatbump.io/*'],
 		js: 'beatbump.js',
 		id: 'beatbump',
 	},


### PR DESCRIPTION
**Describe the changes you made**
Since beatbump changed their domain from `beatbump.ml` to `beatbump.io` the connector was no longer picking up on it's own and needed an additional URL pattern to be added to the settings. The issue was already noticed by another user in #4018. This PR fixes this issue by replacing the default pattern `*://beatbump.ml/*` with `*://beatbump.io/*`.

**Additional context**
I have already run linter, test suite, and tested it myself as a temporary add-on in Firefox
