### PR TITLE
Add Gensokyo Radio connector

### DIFF
--- a/src/connectors/gensokyoradio-dom-inject.ts
+++ b/src/connectors/gensokyoradio-dom-inject.ts
@@ -1,0 +1,31 @@
+/**
+ * This script runs in non-isolated environments (gensokyoradio.net) so that we
+ * have access to the global `audio` player.
+ */
+
+interface GensokyoWindow {
+	audio: HTMLAudioElement;
+}
+
+gensokyoSetupEventListener();
+
+function gensokyoSendUpdateEvent(type: string) {
+	window.postMessage(
+		{
+			sender: 'web-scrobbler',
+			type,
+			isPlaying: (window as unknown as GensokyoWindow).audio.paused
+				? false
+				: true,
+		},
+		'*',
+	);
+}
+
+function gensokyoSetupEventListener() {
+	const audio = (window as unknown as GensokyoWindow).audio;
+
+	for (const e of ['play', 'pause', 'ended', 'emptied', 'suspend']) {
+		audio.addEventListener(e, gensokyoSendUpdateEvent.bind(null, e));
+	}
+}

--- a/src/connectors/gensokyoradio.ts
+++ b/src/connectors/gensokyoradio.ts
@@ -1,0 +1,31 @@
+export {};
+
+let isPlaying = false;
+
+Connector.playerSelector = '#heroMain';
+
+Connector.artistSelector = '#playerArtist';
+
+Connector.trackSelector = '#playerTitle';
+
+Connector.albumSelector = '#playerAlbum';
+
+Connector.trackArtSelector = '#playerArt';
+
+Connector.timeInfoSelector = '#playerCounter';
+
+Connector.isPlaying = () => isPlaying;
+
+Connector.isTrackArtDefault = (trackArtUrl) => {
+	return (
+		trackArtUrl == 'https://gensokyoradio.net/images/assets/no-albumart.png'
+	);
+};
+
+Connector.onScriptEvent = (event) => {
+	isPlaying = !!event.data.isPlaying;
+
+	Connector.onStateChanged();
+};
+
+Connector.injectScript('connectors/gensokyoradio-dom-inject.js');

--- a/src/connectors/gensokyoradio.ts
+++ b/src/connectors/gensokyoradio.ts
@@ -20,7 +20,8 @@ Connector.isPlaying = () => isPlaying;
 
 Connector.isTrackArtDefault = (trackArtUrl) => {
 	return (
-		trackArtUrl == 'https://gensokyoradio.net/images/assets/no-albumart.png'
+		!!trackArtUrl &&
+		/(gr-logo-placeholder|no-albumart)\.png$/i.test(trackArtUrl)
 	);
 };
 

--- a/src/connectors/gensokyoradio.ts
+++ b/src/connectors/gensokyoradio.ts
@@ -10,6 +10,8 @@ Connector.trackSelector = '#playerTitle';
 
 Connector.albumSelector = '#playerAlbum';
 
+Connector.albumArtistSelector = '#playerCircle';
+
 Connector.trackArtSelector = '#playerArt';
 
 Connector.timeInfoSelector = '#playerCounter';

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2112,4 +2112,10 @@ export default <ConnectorMeta[]>[
 		js: 'trackerhub.js',
 		id: 'trackerhub',
 	},
+	{
+		label: 'Gensokyo Radio',
+		matches: ['*://gensokyoradio.net/*'],
+		js: 'gensokyoradio.js',
+		id: 'gensokyoradio',
+	},
 ];


### PR DESCRIPTION
**Describe the changes you made**
Added a new connector and injected script for Gensokyo Radio (https://gensokyoradio.net)

**Additional context**
Gensokyo Radio's player is a bit weird; while all metadata can easily be grabbed via HTML selectors, the actual playback state isn't displayed anywhere and can only be grabbed off of the audio element, which is never inserted into the DOM. We're able to grab the element off of a global `window.audio`, but this requires an injected script. Seems more complicated than it needs to be.

Manually tested against a personal last.fm account in Firefox 117 and Chrome 116, both on Windows 11.
