### PR TITLE
Increae vitest timeout from 5000ms to 10000ms

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,4 +9,5 @@ export default {
 		},
 	},
 	plugins: [ConditionalCompile()],
+	testTimeout: 10000,
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,5 +9,7 @@ export default {
 		},
 	},
 	plugins: [ConditionalCompile()],
-	testTimeout: 10000,
+	test: {
+		testTimeout: 10000,
+	},
 };


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->

Workaround for the latency in doing network IO to make tests past for regex-edit

**Additional context**
<!-- Add any other context or screenshots here. -->
