### PR TITLE
add technobase.fm connector

### DIFF
--- a/src/connectors/technobase.fm.ts
+++ b/src/connectors/technobase.fm.ts
@@ -1,0 +1,19 @@
+export {};
+
+const filter = MetadataFilter.createFilter({
+	track: replaceWith,
+});
+Connector.applyFilter(filter);
+
+Connector.isPlaying = () =>
+	Util.hasElementClass('.streamplayer-button', 'playing');
+
+Connector.playerSelector = '.stream-wrapper';
+Connector.artistSelector = '.streamplayer-artist .streamplayer-link';
+Connector.trackSelector = '.streamplayer-title .streamplayer-link';
+
+function replaceWith(text: string) {
+	// some DJs choose to use "Artist A with Artist B"
+	// instead of "Artist A & Artist B"
+	return text.replace(/\swith\s/, ' & ');
+}

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2124,4 +2124,19 @@ export default <ConnectorMeta[]>[
 		js: 'stationhead.js',
 		id: 'stationhead',
 	},
+	{
+		label: 'TECHNOBASE.FM',
+		matches: [
+			'*://*technobase.fm/*',
+			'*://*housetime.fm/*',
+			'*://*hardbase.fm/*',
+			'*://*trancebase.fm/*',
+			'*://*coretime.fm/*',
+			'*://*clubtime.fm/*',
+			'*://*teatime.fm/*',
+			'*://*replay.fm/*',
+		],
+		js: 'technobase.fm.js',
+		id: 'technobase.fm',
+	},
 ];


### PR DESCRIPTION
**Describe the changes you made**
Added a connector for technobase.fm and other We aRe oNe radio stations. 

**Additional context**
- technobase.fm, housebase.fm etc. all work the same, so different connectors are not needed despite it being different domains. 
- There is a popup player, but it is rather buggy and consistently fails to display the artist and refresh on track changes. Therefore I've ignored it in the implementation.
- Mobile and desktop DOM are identical.
- I've chosen to use technobase.fm as the blanket naming for all adjacent radios since it is by far the most well known one.
