### PR TITLE
Allow multiple webhooks and general improvements

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -187,6 +187,18 @@
         "message": "Custom token",
         "description": "Input label"
     },
+    "accountsApplicationName": {
+        "message": "Application name",
+        "description": "Input label"
+    },
+    "accountsApplicationNamePlaceholder": {
+        "message": "Custom webhook label",
+        "description": "Input label"
+    },
+    "accountsAddWebhook": {
+        "message": "Add Webhook",
+        "description": "Button label"
+    },
     "optionsOptions": {
         "message": "Options",
         "description": "'Options' section"

--- a/src/core/background/scrobble.ts
+++ b/src/core/background/scrobble.ts
@@ -36,7 +36,7 @@ export async function getSongInfo(
 }
 
 export async function toggleLove(
-	song: BaseSong,
+	song: ClonedSong,
 	isLoved: boolean,
 ): Promise<(ServiceCallResult | Record<string, never>)[]> {
 	await scrobbleService.bindAllScrobblers();

--- a/src/core/object/scrobble-service.ts
+++ b/src/core/object/scrobble-service.ts
@@ -248,7 +248,7 @@ class ScrobbleService {
 	 * @returns Promise that will be resolved then the task will complete
 	 */
 	async toggleLove(
-		song: BaseSong,
+		song: ClonedSong,
 		flag: boolean,
 	): Promise<(ServiceCallResult | Record<string, never>)[]> {
 		const scrobblers = registeredScrobblers.filter((scrobbler) => {

--- a/src/core/scrobbler/audio-scrobbler/audio-scrobbler.ts
+++ b/src/core/scrobbler/audio-scrobbler/audio-scrobbler.ts
@@ -57,7 +57,7 @@ export default abstract class AudioScrobbler extends BaseScrobbler<'LastFM'> {
 			const responseData = await this.sendRequest<{ token: string }>(
 				{ method: 'GET' },
 				params,
-				false
+				false,
 			);
 			token = responseData.token;
 		} catch (err) {
@@ -183,6 +183,16 @@ export default abstract class AudioScrobbler extends BaseScrobbler<'LastFM'> {
 	}
 
 	/** @override */
+	async sendPaused(): Promise<ServiceCallResult> {
+		return ServiceCallResult.RESULT_OK;
+	}
+
+	/** @override */
+	async sendResumedPlaying(): Promise<ServiceCallResult> {
+		return ServiceCallResult.RESULT_OK;
+	}
+
+	/** @override */
 	async scrobble(song: BaseSong): Promise<ServiceCallResult> {
 		const { sessionID } = await this.getSession();
 		const params: AudioScrobblerScrobbleParams = {
@@ -204,7 +214,7 @@ export default abstract class AudioScrobbler extends BaseScrobbler<'LastFM'> {
 		const response =
 			await this.sendRequest<AudioScrobblerTrackScrobbleResponse>(
 				{ method: 'POST' },
-				params
+				params,
 			);
 		const result = this.processResponse(response);
 
@@ -228,7 +238,7 @@ export default abstract class AudioScrobbler extends BaseScrobbler<'LastFM'> {
 	/** @override */
 	async toggleLove(
 		song: BaseSong,
-		isLoved: boolean
+		isLoved: boolean,
 	): Promise<ServiceCallResult> {
 		const { sessionID } = await this.getSession();
 		const params = {
@@ -262,11 +272,11 @@ export default abstract class AudioScrobbler extends BaseScrobbler<'LastFM'> {
 	 */
 
 	protected async sendRequest<
-		T extends Record<string, unknown> = Record<string, unknown>
+		T extends Record<string, unknown> = Record<string, unknown>,
 	>(
 		options: RequestInit,
 		params: AudioScrobblerParams,
-		signed = true
+		signed = true,
 	): Promise<T> {
 		const url = this.makeRequestUrl(params, signed);
 
@@ -307,7 +317,7 @@ export default abstract class AudioScrobbler extends BaseScrobbler<'LastFM'> {
 
 		const response = await this.sendRequest<AudioScrobblerSessionResponse>(
 			{ method: 'GET' },
-			params
+			params,
 		);
 
 		const result = this.processResponse(response);
@@ -330,7 +340,7 @@ export default abstract class AudioScrobbler extends BaseScrobbler<'LastFM'> {
 	 */
 	private makeRequestUrl(
 		params: AudioScrobblerParams,
-		signed: boolean
+		signed: boolean,
 	): string {
 		params.api_key = this.getApiKey();
 		params.format = 'json';
@@ -370,7 +380,7 @@ export default abstract class AudioScrobbler extends BaseScrobbler<'LastFM'> {
 	 * @returns Response result
 	 */
 	protected processResponse(
-		responseData: Record<string, unknown>
+		responseData: Record<string, unknown>,
 	): ServiceCallResult {
 		if (responseData.error) {
 			return ServiceCallResult.ERROR_OTHER;

--- a/src/core/scrobbler/listenbrainz/listenbrainz-scrobbler.ts
+++ b/src/core/scrobbler/listenbrainz/listenbrainz-scrobbler.ts
@@ -169,6 +169,16 @@ export default class ListenBrainzScrobbler extends BaseScrobbler<'ListenBrainz'>
 	}
 
 	/** @override */
+	async sendPaused(): Promise<ServiceCallResult> {
+		return ServiceCallResult.RESULT_OK;
+	}
+
+	/** @override */
+	async sendResumedPlaying(): Promise<ServiceCallResult> {
+		return ServiceCallResult.RESULT_OK;
+	}
+
+	/** @override */
 	public async scrobble(song: BaseSong): Promise<ServiceCallResult> {
 		const { sessionID } = await this.getSession();
 
@@ -191,7 +201,7 @@ export default class ListenBrainzScrobbler extends BaseScrobbler<'ListenBrainz'>
 		const artist = song.getArtist();
 		if (typeof track !== 'string' || typeof artist !== 'string') {
 			throw new Error(
-				`Invalid track ${JSON.stringify({ artist, track })}`
+				`Invalid track ${JSON.stringify({ artist, track })}`,
 			);
 		}
 		const lookupRequestParams = new URLSearchParams({
@@ -206,14 +216,14 @@ export default class ListenBrainzScrobbler extends BaseScrobbler<'ListenBrainz'>
 				'GET',
 				`${baseUrl}/metadata/lookup?${lookupRequestParams}`,
 				null,
-				null
+				null,
 			);
 		} catch (e) {
 			// ignore error
 		}
 
 		this.debugLog(
-			`lookup result: ${JSON.stringify(lookupResult, null, 2)}`
+			`lookup result: ${JSON.stringify(lookupResult, null, 2)}`,
 		);
 
 		if (!lookupResult.recording_mbid) {
@@ -231,7 +241,7 @@ export default class ListenBrainzScrobbler extends BaseScrobbler<'ListenBrainz'>
 			'POST',
 			`${baseUrl}/feedback/recording-feedback`,
 			loveRequestBody,
-			sessionID
+			sessionID,
 		);
 
 		return this.processResult(loveResult);
@@ -245,12 +255,12 @@ export default class ListenBrainzScrobbler extends BaseScrobbler<'ListenBrainz'>
 	/** Private methods. */
 
 	private async listenBrainzApi<
-		T extends Record<string, unknown> = Record<string, unknown>
+		T extends Record<string, unknown> = Record<string, unknown>,
 	>(
 		method: string,
 		url: string,
 		body: ListenBrainzParams | null,
-		sessionID: string | null
+		sessionID: string | null,
 	): Promise<T> {
 		const requestInfo: RequestInit = {
 			method,
@@ -298,13 +308,13 @@ export default class ListenBrainzScrobbler extends BaseScrobbler<'ListenBrainz'>
 
 	async sendScrobbleRequest(
 		params: ListenBrainzParams,
-		sessionID: string
+		sessionID: string,
 	): Promise<ServiceCallResult> {
 		const result = await this.listenBrainzApi(
 			'POST',
 			this.userApiUrl || apiUrl,
 			params,
-			sessionID
+			sessionID,
 		);
 		return this.processResult(result);
 	}

--- a/src/core/scrobbler/maloja/maloja-scrobbler.ts
+++ b/src/core/scrobbler/maloja/maloja-scrobbler.ts
@@ -77,6 +77,16 @@ export default class MalojaScrobbler extends BaseScrobbler<'Maloja'> {
 	}
 
 	/** @override */
+	async sendPaused(): Promise<ServiceCallResult> {
+		return ServiceCallResult.RESULT_OK;
+	}
+
+	/** @override */
+	async sendResumedPlaying(): Promise<ServiceCallResult> {
+		return ServiceCallResult.RESULT_OK;
+	}
+
+	/** @override */
 	public async scrobble(song: BaseSong): Promise<ServiceCallResult> {
 		const songData = this.makeTrackMetadata(song);
 
@@ -87,7 +97,7 @@ export default class MalojaScrobbler extends BaseScrobbler<'Maloja'> {
 
 	async sendRequest(
 		params: MalojaTrackMetadata,
-		sessionID: string
+		sessionID: string,
 	): Promise<ServiceCallResult> {
 		params.key = sessionID;
 

--- a/src/core/scrobbler/webhook-scrobbler.ts
+++ b/src/core/scrobbler/webhook-scrobbler.ts
@@ -44,13 +44,10 @@ export default class WebhookScrobbler extends BaseScrobbler<'Webhook'> {
 
 	/** @override */
 	getSession(): Promise<SessionData> {
-		console.log('getting session');
 		if (!this.arrayProperties || this.arrayProperties.length === 0) {
-			console.log('fail');
 			return Promise.reject('');
 		}
 		// Webhook connection doesn't have a session.
-		console.log('success');
 		return Promise.resolve({ sessionID: 'webhook' });
 	}
 
@@ -107,6 +104,7 @@ export default class WebhookScrobbler extends BaseScrobbler<'Webhook'> {
 			);
 			for (const response of responses) {
 				if (response.status !== 200) {
+					this.debugLog(`Error in ${response.url}.`, 'error');
 					return ServiceCallResult.ERROR_OTHER;
 				}
 			}

--- a/src/core/scrobbler/webhook-scrobbler.ts
+++ b/src/core/scrobbler/webhook-scrobbler.ts
@@ -23,27 +23,7 @@ export default class WebhookScrobbler extends BaseScrobbler<'Webhook'> {
 	public userApiUrl!: string;
 
 	/** @override */
-	getApiUrl(): string {
-		return '';
-	}
-
-	/** @override */
-	getApiKey(): string {
-		return '';
-	}
-
-	/** @override */
-	getApiSecret(): string {
-		return '';
-	}
-
-	/** @override */
-	getBaseAuthUrl(): string {
-		return '';
-	}
-
-	/** @override */
-	getBaseProfileUrl(): string {
+	protected getBaseProfileUrl(): string {
 		return '';
 	}
 
@@ -64,23 +44,34 @@ export default class WebhookScrobbler extends BaseScrobbler<'Webhook'> {
 
 	/** @override */
 	getSession(): Promise<SessionData> {
+		console.log('getting session');
+		if (!this.arrayProperties || this.arrayProperties.length === 0) {
+			console.log('fail');
+			return Promise.reject('');
+		}
 		// Webhook connection doesn't have a session.
+		console.log('success');
 		return Promise.resolve({ sessionID: 'webhook' });
 	}
 
 	/** @override */
 	public getAuthUrl(): Promise<string> {
-		throw new Error('Method not implemented.');
+		return Promise.resolve('');
 	}
 
 	/** @override */
 	public isReadyForGrantAccess(): Promise<boolean> {
-		throw new Error('Method not implemented.');
+		return Promise.resolve(false);
 	}
 
 	/** @override */
-	public getUsedDefinedProperties(): string[] {
-		return ['userApiUrl'];
+	public async getProfileUrl(): Promise<string> {
+		return Promise.resolve('');
+	}
+
+	/** @override */
+	public getUserDefinedArrayProperties(): string[] {
+		return ['applicationName', 'userApiUrl'];
 	}
 
 	public async getSongInfo(): Promise<Record<string, never>> {
@@ -89,6 +80,9 @@ export default class WebhookScrobbler extends BaseScrobbler<'Webhook'> {
 
 	/** @override */
 	async sendRequest(request: WebhookRequest): Promise<ServiceCallResult> {
+		if (!this.arrayProperties || this.arrayProperties.length === 0) {
+			return ServiceCallResult.ERROR_AUTH;
+		}
 		this.debugLog(
 			`Webhook - sendRequest: ${JSON.stringify(request, null, 2)}`,
 		);
@@ -100,15 +94,21 @@ export default class WebhookScrobbler extends BaseScrobbler<'Webhook'> {
 			body: JSON.stringify(request),
 		};
 
-		const promise = fetch(this.userApiUrl, requestInfo);
-
+		const promises: Promise<Response>[] = [];
+		for (const props of this.arrayProperties) {
+			promises.push(fetch(props.userApiUrl, requestInfo));
+		}
 		const timeout = this.REQUEST_TIMEOUT;
 
-		let response = null;
 		try {
-			response = await timeoutPromise(timeout, promise);
-			if (response.status !== 200) {
-				return ServiceCallResult.ERROR_OTHER;
+			const responses = await timeoutPromise(
+				timeout,
+				Promise.all(promises),
+			);
+			for (const response of responses) {
+				if (response.status !== 200) {
+					return ServiceCallResult.ERROR_OTHER;
+				}
 			}
 		} catch (e) {
 			this.debugLog('Error while sending request', 'error');

--- a/src/core/storage/wrapper.ts
+++ b/src/core/storage/wrapper.ts
@@ -50,7 +50,19 @@ export type ListenBrainzModel =
 	| ListenBrainzAuthStarted
 	| ListenBrainzAuthFinished;
 
-export type WebhookModel = { userApiUrl?: string };
+export type WebhookModel = {
+	arrayProperties?: {
+		applicationName: string;
+		userApiUrl: string;
+	}[];
+};
+
+export type ArrayProperty = {
+	applicationName: string;
+	userApiUrl: string;
+};
+
+export type ArrayProperties = ArrayProperty[];
 
 export interface ScrobblerModels {
 	LastFM?: { token?: string } | { sessionID?: string; sessionName?: string };

--- a/src/ui/options/components/components.module.scss
+++ b/src/ui/options/components/components.module.scss
@@ -414,6 +414,21 @@ summary {
 	width: 80%;
 }
 
+.arrayPropWrapper {
+	margin-bottom: 1rem;
+	margin-top: 0.5rem;
+
+	.arrayProps {
+		align-items: center;
+		display: flex;
+		margin-bottom: 0.2rem;
+	}
+
+	.arrayProp:not(:last-child) {
+		margin-right: 2rem;
+	}
+}
+
 .regexDeleteContent {
 	align-items: center;
 	background: repeating-linear-gradient(var(--last-fm-bg) 0 2.5em,transparent 2.5em 5em);

--- a/src/ui/options/components/edit-options/edited-tracks.tsx
+++ b/src/ui/options/components/edit-options/edited-tracks.tsx
@@ -47,7 +47,7 @@ export function EditsModal() {
 			<h1>
 				{t(
 					'optionsEditedTracksPopupTitle',
-					Object.keys(edits() ?? {}).length.toString()
+					Object.keys(edits() ?? {}).length.toString(),
 				)}
 			</h1>
 			<ul>
@@ -67,9 +67,13 @@ export function EditsModal() {
 function TrackInfo(props: {
 	key: string;
 	track: Options.SavedEdit;
-	mutate: Setter<{
-		[key: string]: Options.SavedEdit;
-	} | null>;
+	mutate: Setter<
+		| {
+				[key: string]: Options.SavedEdit;
+		  }
+		| null
+		| undefined
+	>;
 }) {
 	return (
 		<li class={styles.deleteListing}>

--- a/src/ui/options/components/edit-options/util.tsx
+++ b/src/ui/options/components/edit-options/util.tsx
@@ -17,9 +17,7 @@ type EditSetter = Setter<
 	| {
 			[key: string]: Options.SavedEdit;
 	  }
-	| {
-			[key: string]: RegexEdit[];
-	  }
+	| RegexEdit[]
 	| null
 	| undefined
 >;
@@ -72,7 +70,7 @@ async function downloadEdits(editWrapper: EditWrapper, filename: string) {
 	const edits = await editWrapper.get();
 	if (!edits) return;
 	const data = `data:text/json;charset=UTF-8,${encodeURIComponent(
-		JSON.stringify(edits)
+		JSON.stringify(edits),
 	)}`;
 	const a = document.createElement('a');
 	a.download = filename;
@@ -112,7 +110,7 @@ function pushEdits(
 		target: Element;
 	},
 	editWrapper: EditWrapper,
-	mutate: EditSetter
+	mutate: EditSetter,
 ) {
 	const file = e.currentTarget.files?.[0];
 	if (!file) return;


### PR DESCRIPTION
Allows the webhook scrobbler to have multiple webhooks set up for multiple different applications.
Also makes some small changes to make UX consistent.
Also fixes some random type errors and such from elsewhere in the code.
This is pretty scuffed, but it needs to be pushed with next update imo, and we have an urgent hotfix pending.
I don't think this should impact functionality of existing scrobblers.