### PR TITLE
Fix safari listenbrainz login

### DIFF
--- a/src/core/background/main.ts
+++ b/src/core/background/main.ts
@@ -45,6 +45,7 @@ import {
 	toggleLove,
 } from './scrobble';
 import scrobbleService from '../object/scrobble-service';
+import { fetchListenBrainzProfile } from '@/util/util';
 
 const disabledTabs = BrowserStorage.getStorage(BrowserStorage.DISABLED_TABS);
 
@@ -391,6 +392,15 @@ setupBackgroundListeners(
 				payload.isLoved,
 			);
 		},
+	}),
+
+	/**
+	 * Listener called by a content script to attempt signing into musicbrainz.
+	 * This has to be done in background script, as safari blocks sending necessary cookies in other scripts.
+	 */
+	backgroundListener({
+		type: 'sendListenBrainzRequest',
+		fn: async (payload) => fetchListenBrainzProfile(payload.url),
 	}),
 
 	/**

--- a/src/util/communication.ts
+++ b/src/util/communication.ts
@@ -92,6 +92,12 @@ interface ContentCommunications {
 		};
 		response: Promise<(ServiceCallResult | Record<string, never>)[]>;
 	};
+	sendListenBrainzRequest: {
+		payload: {
+			url: string;
+		};
+		response: Promise<string | null>;
+	};
 }
 
 interface BackgroundCommunications {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -275,3 +275,43 @@ export function createTrackLibraryURL(
 		track,
 	)}`;
 }
+
+/**
+ * Check if script is currently running in a background script.
+ *
+ * @returns true if running in background script, false if running in any other context including popup.
+ */
+export function isBackgroundScript(): boolean {
+	// on chromium, no window in background script.
+	if (!self.window) {
+		return true;
+	}
+	// on firefox and safari, check for being in the generated background script
+	if (
+		(location.href.startsWith('safari-web-extension') ||
+			location.href.startsWith('moz-extension')) &&
+		location.href.endsWith('generated_background_page.html')
+	) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Attempt to fetch listenbrainz profile HTML.
+ *
+ * @param url - URL of listenbrainz instance
+ * @returns html of profile, null if response error
+ */
+export async function fetchListenBrainzProfile(url: string) {
+	const res = await fetch(url, {
+		method: 'GET',
+		// #v-ifdef VITE_FIREFOX
+		credentials: 'same-origin',
+		// #v-endif
+	});
+	if (!res.ok) {
+		return null;
+	}
+	return res.text();
+}


### PR DESCRIPTION
Safari is stripping crucial information from the listenbrainz request everywhere except background script.
Work around this by pushing login requests to background script.
Chrome login is still a little unstable (no domparser API in background script) but handling it probably means adding an entire dom parsing library or offscreen document jank. Don't think the time figuring that out is worth it when its a fairly minor issue compared to the inverse.