### PR TITLE
Add pipeline to test for typescript errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check for typescript errors
+        run: npm run checkts
+
       - name: Run tests
         run: npm run test

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dist": "npm run build dist",
     "dev": "npm run build dev",
     "build": "tsx build.ts",
-    "buildts": "tsc --project tsconfig.connectors.json",
+    "checkts": "tsc --noEmit && tsc --noEmit --project tsconfig.connectors.json",
     "test": "vitest",
     "lint": "eslint . && stylelint \"**/*.scss\" && remark .",
     "translations": "tx pull -m onlytranslated && tsx scripts/translations-prepare.ts"

--- a/scripts/log.ts
+++ b/scripts/log.ts
@@ -1,6 +1,6 @@
 type ColorType = 'success' | 'info' | 'error' | 'warning' | keyof typeof COLORS;
 
-export default function colorLog(message: string, type?: ColorType): void {
+export default function colorLog(message: unknown, type?: ColorType): void {
 	let color: string = type || COLORS.FgBlack;
 
 	switch (type) {

--- a/scripts/translations-prepare.ts
+++ b/scripts/translations-prepare.ts
@@ -2,23 +2,27 @@ import { glob } from 'glob';
 import { readFile, writeFile } from 'fs/promises';
 import colorLog from 'scripts/log';
 
-const translationFiles = await glob('src/_locales/**/messages.json');
+async function main() {
+	const translationFiles = await glob('src/_locales/**/messages.json');
 
-for (const index in translationFiles) {
-	const filePath = translationFiles[index];
+	for (const index in translationFiles) {
+		const filePath = translationFiles[index];
 
-	const json = JSON.parse(await readFile(filePath));
+		const json = JSON.parse(await readFile(filePath, 'utf-8'));
 
-	let modified = false;
-	Object.keys(json).forEach((key) => {
-		if (json[key]['message'] === '') {
-			delete json[key];
-			modified = true;
+		let modified = false;
+		Object.keys(json).forEach((key) => {
+			if (json[key]['message'] === '') {
+				delete json[key];
+				modified = true;
+			}
+		});
+
+		if (modified) {
+			colorLog(`Updating ${filePath}`, 'info');
+			await writeFile(filePath, JSON.stringify(json, null, 4) + '\n');
 		}
-	});
-
-	if (modified) {
-		colorLog(`Updating ${filePath}`, 'info');
-		await writeFile(filePath, JSON.stringify(json, null, 4) + '\n');
 	}
 }
+
+main();

--- a/src/connectors/eggs.ts
+++ b/src/connectors/eggs.ts
@@ -103,6 +103,6 @@ Connector.onScriptEvent = (event: MessageEvent<Record<string, unknown>>) => {
 	}
 };
 
-function removeMV(text: any) {
+function removeMV(text: string) {
 	return text.replace(/(\(MV\)|【MV】|MV)$/, '');
 }

--- a/src/connectors/eggs.ts
+++ b/src/connectors/eggs.ts
@@ -11,7 +11,7 @@ let isPlaying = false;
 Connector.getTimeInfo = () => {
 	const { currentTime, duration } = document.querySelector(
 		'#aPlayer',
-	) as HTMLDivElement;
+	) as HTMLAudioElement;
 	return { currentTime, duration };
 };
 
@@ -103,6 +103,6 @@ Connector.onScriptEvent = (event: MessageEvent<Record<string, unknown>>) => {
 	}
 };
 
-function removeMV(text: string) {
+function removeMV(text: any) {
 	return text.replace(/(\(MV\)|【MV】|MV)$/, '');
 }

--- a/src/connectors/eggs.ts
+++ b/src/connectors/eggs.ts
@@ -11,7 +11,7 @@ let isPlaying = false;
 Connector.getTimeInfo = () => {
 	const { currentTime, duration } = document.querySelector(
 		'#aPlayer',
-	) as HTMLAudioElement;
+	) as HTMLDivElement;
 	return { currentTime, duration };
 };
 

--- a/tests/background/song.test.ts
+++ b/tests/background/song.test.ts
@@ -378,10 +378,12 @@ function testEquals() {
 	});
 
 	it('should not equal null value', () => {
+		// @ts-expect-error we are explicitly testing bad format here
 		expect(songWithUniqueId.equals(null)).to.be.false;
 	});
 
 	it('should not equal non-song object', () => {
+		// @ts-expect-error we are explicitly testing bad format here
 		expect(songWithUniqueId.equals(23)).to.be.false;
 	});
 }

--- a/tests/background/util.test.ts
+++ b/tests/background/util.test.ts
@@ -215,6 +215,8 @@ function runTests() {
 		const description = func.name;
 
 		describe(description, () => {
+			// TODO: type gymnastics
+			// @ts-ignore type gymnastics required on this one. It works.
 			testFunction(func, data);
 		});
 	}
@@ -226,6 +228,7 @@ function runTests() {
 function testDebugLog() {
 	it('should throw an error if type is invalid', () => {
 		function callInvalidDebugLog() {
+			// @ts-expect-error we are explicitly testing bad format here
 			Util.debugLog('Test', 'invalid_type123');
 		}
 

--- a/tests/content/util.test.ts
+++ b/tests/content/util.test.ts
@@ -1126,10 +1126,8 @@ function runTests() {
 		const description = func.name;
 
 		describe(description, () => {
-			/*
 			// TODO: type gymnastics
 			// @ts-ignore type gymnastics required on this one. It works.
-			*/
 			testFunction(func, data);
 		});
 	}

--- a/tests/content/util.test.ts
+++ b/tests/content/util.test.ts
@@ -2,7 +2,7 @@ import { TestData } from '#/types/types';
 import { expect, it, describe } from 'vitest';
 
 // trick webextension polyfill into thinking this is running in the browser
-(globalThis as { chrome: unknown }).chrome = {
+(globalThis as unknown as { chrome: unknown }).chrome = {
 	runtime: {
 		id: 'mock',
 	},
@@ -1126,6 +1126,10 @@ function runTests() {
 		const description = func.name;
 
 		describe(description, () => {
+			/*
+			// TODO: type gymnastics
+			// @ts-ignore type gymnastics required on this one. It works.
+			*/
 			testFunction(func, data);
 		});
 	}

--- a/tests/mocks/webextension-polyfill.ts
+++ b/tests/mocks/webextension-polyfill.ts
@@ -1,3 +1,4 @@
+import type { CloneableSong } from '@/core/object/song';
 import { vi } from 'vitest';
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": ".",
     "module": "ES2020",
     "moduleResolution": "Node",
+    "isolatedModules": true,
     "outDir": "build",
     "jsx": "preserve",
     "jsxImportSource": "solid-js",


### PR DESCRIPTION
Vite doesn't really concern itself with type checking, just transforming.
Add a separate pipeline that checks for typescript errors within the test action.
Draft for now as I test it out a bit with commits to check it's working as intended.

EDIT: Also fixed some hidden ts errors hopefully not breaking the translate pipeline.

EDIT 2: Undrafted, seems to work as intended.