### PR TITLE
Fixed RadioParadise connector for small screens

### DIFF
--- a/src/connectors/radioparadise.ts
+++ b/src/connectors/radioparadise.ts
@@ -1,19 +1,24 @@
 export {};
 
-Connector.playerSelector = '.content-wrapper';
+Connector.playerSelector = "#conductor-wrapper";
 
-Connector.albumSelector = '#now_playing .album';
-Connector.artistSelector = '#now_playing .artist';
-Connector.trackSelector = '#now_playing .title';
+Connector.albumSelector = "#now_playing .album";
+Connector.artistSelector = ".player-bar .player-artist";
+Connector.trackSelector = ".player-bar .player-title";
 
-Connector.isPlaying = () => Util.hasElementClass('#play-button', 'active');
+Connector.isPlaying = () => {
+	return (
+		Util.getAttrFromSelectors("#global-player mat-icon", "title") ===
+		"Pause"
+	);
+};
 
-Connector.trackArtSelector = '#now_playing img.album-cover';
+Connector.trackArtSelector = ".player-bar img.player-cover";
 
 Connector.isScrobblingAllowed = () => {
 	return (
-		!Util.getTextFromSelectors('#now_playing .title')?.includes(
-			'Listener-supported'
-		) && !Connector.getArtist()?.startsWith('Commercial-Free')
+		!Util.getTextFromSelectors(".player-bar .player-title")?.includes(
+			"Listener-supported",
+		) && !Connector.getArtist()?.startsWith("Commercial-Free")
 	);
 };

--- a/src/connectors/radioparadise.ts
+++ b/src/connectors/radioparadise.ts
@@ -1,24 +1,24 @@
 export {};
 
-Connector.playerSelector = "#conductor-wrapper";
+Connector.playerSelector = '#conductor-wrapper';
 
-Connector.albumSelector = "#now_playing .album";
-Connector.artistSelector = ".player-bar .player-artist";
-Connector.trackSelector = ".player-bar .player-title";
+Connector.albumSelector = '#now_playing .album';
+Connector.artistSelector = '.player-bar .player-artist';
+Connector.trackSelector = '.player-bar .player-title';
 
 Connector.isPlaying = () => {
 	return (
-		Util.getAttrFromSelectors("#global-player mat-icon", "title") ===
-		"Pause"
+		Util.getAttrFromSelectors('#global-player mat-icon', 'title') ===
+		'Pause'
 	);
 };
 
-Connector.trackArtSelector = ".player-bar img.player-cover";
+Connector.trackArtSelector = '.player-bar img.player-cover';
 
 Connector.isScrobblingAllowed = () => {
 	return (
-		!Util.getTextFromSelectors(".player-bar .player-title")?.includes(
-			"Listener-supported",
-		) && !Connector.getArtist()?.startsWith("Commercial-Free")
+		!Util.getTextFromSelectors('.player-bar .player-title')?.includes(
+			'Listener-supported',
+		) && !Connector.getArtist()?.startsWith('Commercial-Free')
 	);
 };


### PR DESCRIPTION
- I discovered a bug today where the RadioParadise connector wouldn't scrobble on smaller screen sizes. The site did some DOM changes that made some targeted elements disappear between desktop and mobile, so I was able to find some consistent elements to target to make it work properly.
