### PR TITLE
Add disallowed controller state

### DIFF
--- a/scripts/generate-icons.ts
+++ b/scripts/generate-icons.ts
@@ -95,6 +95,10 @@ const monochromeColors = {
 		light: '#adadad',
 		dark: '#727272',
 	},
+	'action_disallowed.svg': {
+		light: '#d51107',
+		dark: '#fc3434',
+	},
 };
 
 /**
@@ -170,7 +174,7 @@ async function createUnmodifiedIcon(
 	folder: string,
 	path: string,
 	size: number,
-	margin?: number
+	margin?: number,
 ): Promise<Buffer> {
 	const canvas = createCanvas(size, size);
 	const ctx = canvas.getContext('2d');
@@ -196,7 +200,7 @@ async function createUnmodifiedIconNoAlpha(
 	folder: string,
 	path: string,
 	size: number,
-	margin?: number
+	margin?: number,
 ): Promise<Buffer> {
 	const canvas = createCanvas(size, size);
 	const ctx = canvas.getContext('2d');
@@ -223,7 +227,7 @@ async function createUnmodifiedIconNoAlpha(
 async function createMacIcon(
 	folder: string,
 	path: string,
-	size: number
+	size: number,
 ): Promise<Buffer> {
 	const sizeModifier = 100 / 114;
 	const canvas = createCanvas(size, size);
@@ -258,7 +262,7 @@ async function createMonochromeIcon(
 	path: string,
 	size: number,
 	color: string,
-	borderColor?: string
+	borderColor?: string,
 ): Promise<Buffer> {
 	// If there is a border, make room for the border
 	const iconSize = borderColor ? size - borderThickness * 2 : size;
@@ -274,7 +278,7 @@ async function createMonochromeIcon(
 		borderThickness,
 		borderThickness,
 		iconSize,
-		iconSize
+		iconSize,
 	);
 	// fill it in with the main icon color
 	iconCtx.globalCompositeOperation = 'source-in';
@@ -295,7 +299,7 @@ async function createMonochromeIcon(
 			adjacency[0] + borderThickness,
 			adjacency[1] + borderThickness,
 			iconSize,
-			iconSize
+			iconSize,
 		);
 	}
 	// fill in
@@ -329,13 +333,13 @@ function getOutputPath(path: string, size: number, type: string) {
  * @param path - filename of svg.
  */
 async function writeMonochromeIcon(
-	path: keyof typeof monochromeColors
+	path: keyof typeof monochromeColors,
 ): Promise<void> {
 	if (releaseTarget === releaseTargets.safari) {
 		for (const res of actionIconResolutions) {
 			await fs.writeFile(
 				getOutputPath(path, res, releaseTargets.safari),
-				await createMonochromeIcon(path, res, safariIconColor)
+				await createMonochromeIcon(path, res, safariIconColor),
 			);
 		}
 		return;
@@ -348,8 +352,8 @@ async function writeMonochromeIcon(
 				path,
 				res,
 				monochromeColors[path].light,
-				borderColor.light
-			)
+				borderColor.light,
+			),
 		);
 		await fs.writeFile(
 			getOutputPath(path, res, themes.dark),
@@ -357,8 +361,8 @@ async function writeMonochromeIcon(
 				path,
 				res,
 				monochromeColors[path].dark,
-				borderColor.dark
-			)
+				borderColor.dark,
+			),
 		);
 	}
 }
@@ -373,7 +377,7 @@ async function writeMainIcon(): Promise<void> {
 		const margin = res >= 128 ? res * marginFactor : 0;
 		await fs.writeFile(
 			resolve(output, `icon_main_${res}.png`),
-			await createUnmodifiedIcon('main', path, res, margin)
+			await createUnmodifiedIcon('main', path, res, margin),
 		);
 	}
 }
@@ -385,7 +389,7 @@ async function writexcodeIcons(): Promise<void> {
 	 */
 	await fs.writeFile(
 		resolve(xcodeApp, 'Resources', 'Icon.png'),
-		await createUnmodifiedIcon('main', mainPath, 512)
+		await createUnmodifiedIcon('main', mainPath, 512),
 	);
 
 	/**
@@ -393,7 +397,7 @@ async function writexcodeIcons(): Promise<void> {
 	 */
 	await fs.writeFile(
 		resolve(xcodeAssets, 'LargeIcon.imageset', 'icon_main_256.png'),
-		await createUnmodifiedIcon('main', mainPath, 256)
+		await createUnmodifiedIcon('main', mainPath, 256),
 	);
 
 	/**
@@ -403,9 +407,9 @@ async function writexcodeIcons(): Promise<void> {
 		resolve(
 			xcodeAssets,
 			'AppIcon.appiconset',
-			'universal-icon-1024@1x.png'
+			'universal-icon-1024@1x.png',
 		),
-		await createUnmodifiedIconNoAlpha('main', mainPath, 1024)
+		await createUnmodifiedIconNoAlpha('main', mainPath, 1024),
 	);
 
 	for (const res of xcodeIconResolutions) {
@@ -413,18 +417,18 @@ async function writexcodeIcons(): Promise<void> {
 			resolve(
 				xcodeAssets,
 				'AppIcon.appiconset',
-				`mac-icon-${res}@1x.png`
+				`mac-icon-${res}@1x.png`,
 			),
-			await createMacIcon('main', 'safarishadow.svg', res)
+			await createMacIcon('main', 'safarishadow.svg', res),
 		);
 
 		await fs.writeFile(
 			resolve(
 				xcodeAssets,
 				'AppIcon.appiconset',
-				`mac-icon-${res}@2x.png`
+				`mac-icon-${res}@2x.png`,
 			),
-			await createMacIcon('main', 'safarishadow.svg', res * 2)
+			await createMacIcon('main', 'safarishadow.svg', res * 2),
 		);
 	}
 }
@@ -463,7 +467,7 @@ async function main(): Promise<void> {
  * @returns true if the file is associated with a target color, false otherwise.
  */
 function assertMonochromePathValid(
-	path: string
+	path: string,
 ): path is keyof typeof monochromeColors {
 	return path in monochromeColors;
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -507,6 +507,22 @@
         "message": "Open options page",
         "description": "Button label"
     },
+    "disallowedHeader": {
+        "message": "Scrobbling is disabled",
+        "description": "The header of 'disallowed' popup"
+    },
+    "disallowedDesc1": {
+        "message": "Web Scrobbler has detected the song $2 by $1, but will not scrobble it.",
+        "description": "The description of 'disallowed' popup. $1 is the artist detected. $2 is the track detected"
+    },
+    "disallowedDesc2": {
+        "message": "This could be caused by your settings, especially on YouTube. Web Scrobbler will still scrobble elsewhere on this website.",
+        "description": "The description of 'disallowed' popup"
+    },
+    "disallowedButton": {
+        "message": "Scrobble anyway",
+        "description": "Button label"
+    },
     "unsupportedWebsiteHeader": {
         "message": "This website is not supported",
         "description": "The header of 'unsupported' popup"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -508,16 +508,48 @@
         "description": "Button label"
     },
     "disallowedHeader": {
-        "message": "Scrobbling is disabled",
+        "message": "This song is not being scrobbled",
         "description": "The header of 'disallowed' popup"
     },
     "disallowedDesc1": {
         "message": "Web Scrobbler has detected the song $2 by $1, but will not scrobble it.",
-        "description": "The description of 'disallowed' popup. $1 is the artist detected. $2 is the track detected"
+        "description": "The description of 'disallowed' popup on all sites including youtube. $1 is the artist detected. $2 is the track detected"
+    },
+    "disallowedDescYoutube": {
+        "message": "On YouTube, the most common causes include:",
+        "description": "The description of 'disallowed' popup on youtube."
+    },
+    "disallowedDescYoutubePoint1": {
+        "message": "Having \"Scrobble videos from \"Music/Entertainment\" category\" enabled and playing a video with a different category.",
+        "description": "Point 1 in example list on youtube"
+    },
+    "disallowedDescYoutubePoint2": {
+        "message": "Having \"Scrobble only videos that are recognized by YouTube Music as music\" enabled and playing a song not recognized by YouTube Music as music.",
+        "description": "Point 2 in example list on youtube"
+    },
+    "disallowedDescYoutubePoint3": {
+        "message": "Ads (even ads being blocked may temporarily show this.)",
+        "description": "Point 3 in example list on youtube"
     },
     "disallowedDesc2": {
-        "message": "This could be caused by your settings, especially on YouTube. Web Scrobbler will still scrobble elsewhere on this website.",
-        "description": "The description of 'disallowed' popup"
+        "message": "This is because the website connector has deemed this not a song to scrobble. Some potential reasons include:",
+        "description": "The description of 'disallowed' popup on sites except youtube"
+    },
+    "disallowedDesc2Point1": {
+        "message": "Web Scrobbler might be interpreting this as an ad.",
+        "description": "Point 1 in example list on sites except youtube"
+    },
+    "disallowedDesc2Point2": {
+        "message": "Web Scrobbler might be identifying this song as being played on a different device.",
+        "description": "Point 2 in example list on sites except youtube"
+    },
+    "disallowedDesc2Point3": {
+        "message": "Web Scrobbler, for some other reason, believes this is not something that should be scrobbled.",
+        "description": "Point 3 in example list on sites except youtube"
+    },
+    "disallowedDesc3": {
+        "message": "Web Scrobbler should still scrobble music from elsewhere on this website.",
+        "description": "The description of 'disallowed' popup on all sites including youtube"
     },
     "disallowedButton": {
         "message": "Scrobble anyway",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -512,7 +512,7 @@
         "description": "The header of 'disallowed' popup"
     },
     "disallowedDesc1": {
-        "message": "Web Scrobbler has detected the song $2 by $1, but will not scrobble it.",
+        "message": "Web Scrobbler has detected the song \"$2\" by \"$1\", but will not scrobble it.",
         "description": "The description of 'disallowed' popup on all sites including youtube. $1 is the artist detected. $2 is the track detected"
     },
     "disallowedDescYoutube": {

--- a/src/core/content/connector.ts
+++ b/src/core/content/connector.ts
@@ -308,7 +308,7 @@ export default class BaseConnector {
 	 * @returns Check result
 	 */
 	public isTrackArtDefault: (
-		trackArtUrl?: string | null | undefined
+		trackArtUrl?: string | null | undefined,
 	) => boolean | null | undefined = () => false;
 
 	/**
@@ -351,7 +351,7 @@ export default class BaseConnector {
 	 * @param event - Event object
 	 */
 	public onScriptEvent: (
-		event: MessageEvent<Record<string, unknown>>
+		event: MessageEvent<Record<string, unknown>>,
 	) => void = () => {
 		// Do nothing
 	};
@@ -362,8 +362,8 @@ export default class BaseConnector {
 	private defaultFilter = MetadataFilter.createFilter(
 		MetadataFilter.createFilterSetForFields(
 			['artist', 'track', 'album', 'albumArtist'],
-			[(text) => text.trim(), MetadataFilter.replaceNbsp]
-		)
+			[(text) => text.trim(), MetadataFilter.replaceNbsp],
+		),
 	);
 
 	/**
@@ -430,7 +430,7 @@ export default class BaseConnector {
 				}
 
 				this.onScriptEvent(event);
-			}
+			},
 		);
 
 		window.webScrobblerScripts[scriptFile] = true;
@@ -495,6 +495,7 @@ export default class BaseConnector {
 		trackArt: null,
 		isPodcast: false,
 		originUrl: null,
+		isScrobblingAllowed: true,
 	};
 
 	// #v-ifdef VITE_DEV
@@ -590,13 +591,13 @@ export default class BaseConnector {
 
 		this.getTimeInfo = () => {
 			return Util.splitTimeInfo(
-				Util.getTextFromSelectors(this.timeInfoSelector)
+				Util.getTextFromSelectors(this.timeInfoSelector),
 			);
 		};
 
 		this.getArtistTrack = () => {
 			return Util.splitArtistTrack(
-				Util.getTextFromSelectors(this.artistTrackSelector)
+				Util.getTextFromSelectors(this.artistTrackSelector),
 			);
 		};
 
@@ -632,7 +633,7 @@ export default class BaseConnector {
 			if (this.controllerCallback !== null) {
 				this.controllerCallback(
 					{},
-					Object.keys(this.defaultState) as (keyof State)[]
+					Object.keys(this.defaultState) as (keyof State)[],
 				);
 			}
 
@@ -662,11 +663,6 @@ export default class BaseConnector {
 		};
 
 		this.stateChangedWorker = () => {
-			if (!this.isScrobblingAllowed()) {
-				this.resetState();
-				return;
-			}
-
 			this.isStateReset = false;
 
 			const changedFields: (keyof State)[] = [];
@@ -701,14 +697,14 @@ export default class BaseConnector {
 					Util.debugLog(
 						`isPlaying state changed to ${
 							newState.isPlaying?.toString() ?? 'undefined'
-						}`
+						}`,
 					);
 				}
 
 				for (const field of this.fieldsToCheckSongChange) {
 					if (changedFields.includes(field)) {
 						Util.debugLog(
-							JSON.stringify(this.filteredState, null, 2)
+							JSON.stringify(this.filteredState, null, 2),
 						);
 						break;
 					}
@@ -726,6 +722,7 @@ export default class BaseConnector {
 				isPlaying: this.isPlaying(),
 				isPodcast: this.isPodcast(),
 				originUrl: this.getOriginUrl(),
+				isScrobblingAllowed: this.isScrobblingAllowed(),
 			};
 
 			let mediaSessionInfo = null;
@@ -745,7 +742,7 @@ export default class BaseConnector {
 			Util.fillEmptyFields(
 				newState,
 				mediaSessionInfo,
-				this.mediaSessionFields
+				this.mediaSessionFields,
 			);
 
 			const remainingTime = Math.abs(this.getRemainingTime() ?? 0);
@@ -770,7 +767,7 @@ export default class BaseConnector {
 				Util.fillEmptyFields(
 					newState,
 					trackInfo,
-					Object.keys(this.defaultState) as (keyof State)[]
+					Object.keys(this.defaultState) as (keyof State)[],
 				);
 			}
 
@@ -802,7 +799,7 @@ export default class BaseConnector {
 						fieldValue =
 							this.metadataFilter.filterField(
 								field,
-								fieldValue as string
+								fieldValue as string,
 							) || this.defaultState[field];
 						break;
 					}
@@ -834,7 +831,7 @@ export default class BaseConnector {
 
 		this.stateChangedWorkerThrottled = Util.throttle(
 			this.stateChangedWorker,
-			500
+			500,
 		);
 	}
 }

--- a/src/core/object/controller/controller-mode.ts
+++ b/src/core/object/controller/controller-mode.ts
@@ -4,6 +4,11 @@
 export const Base = 'Base';
 
 /**
+ * An option is disallowing scrobbling.
+ */
+export const Disallowed = 'Disallowed';
+
+/**
  * A connector attached to a controller is disabled by a user.
  */
 export const Disabled = 'Disabled';

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -817,7 +817,7 @@ export default class Controller {
 	}
 
 	private async setPaused(): Promise<void> {
-		if (!assertSongNotNull(this.currentSong)) {
+		if (!assertSongNotNull(this.currentSong) || !this.shouldScrobble()) {
 			return;
 		}
 		await sendContentMessage({
@@ -829,7 +829,7 @@ export default class Controller {
 	}
 
 	private async setResumedPlaying(): Promise<void> {
-		if (!assertSongNotNull(this.currentSong)) {
+		if (!assertSongNotNull(this.currentSong) || !this.shouldScrobble()) {
 			return;
 		}
 		await sendContentMessage({

--- a/src/core/object/song.ts
+++ b/src/core/object/song.ts
@@ -16,6 +16,7 @@ export interface ParsedSongData extends ProcessedSongData {
 	isPodcast?: boolean | null;
 	isPlaying?: boolean | null;
 	currentTime?: number | null;
+	isScrobblingAllowed?: boolean | null;
 }
 
 export type Flags =
@@ -285,7 +286,7 @@ export abstract class BaseSong {
 		'album',
 		'artist',
 		'albumArtist',
-		'duration'
+		'duration',
 	] {
 		return ['track', 'album', 'artist', 'albumArtist', 'duration'];
 	}
@@ -319,7 +320,7 @@ export default class Song extends BaseSong {
 				album: null,
 				duration: null,
 			},
-			parsedData
+			parsedData,
 		);
 
 		/**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -71,4 +71,9 @@ export interface State extends BaseState {
 	 * Origin URL.
 	 */
 	originUrl?: string | null;
+
+	/**
+	 * Is scrobbling allowed
+	 */
+	isScrobblingAllowed?: boolean | null;
 }

--- a/src/icons/monochrome/action_disallowed.svg
+++ b/src/icons/monochrome/action_disallowed.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiBox-root css-1om0hkc"
+   focusable="false"
+   aria-hidden="true"
+   viewBox="0 0 24 24"
+   data-testid="MusicOffIcon"
+   version="1.1"
+   id="svg1158"
+   sodipodi:docname="action_disallowed.svg"
+   inkscape:version="1.2.2 (b0a84865, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1162" />
+  <sodipodi:namedview
+     id="namedview1160"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-width="1309"
+     inkscape:window-height="456"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1158" />
+  <path
+     d="M 1.6933333,0 0,1.6933333 12,13.693333 v 0.373334 C 11.213333,13.613333 10.306667,13.333333 9.333333,13.333333 6.3866667,13.333333 4,15.72 4,18.666667 4,21.613333 6.3866667,24 9.333333,24 12.28,24 14.666667,21.613333 14.666667,18.666667 V 16.36 l 7.64,7.64 L 24,22.306667 Z M 14.666667,5.3333333 H 20 V 0 h -8 v 6.9066667 l 2.666667,2.6666663 z"
+     id="path1156"
+     style="stroke-width:1.33333" />
+</svg>

--- a/src/ui/options/components/components.module.scss
+++ b/src/ui/options/components/components.module.scss
@@ -126,7 +126,7 @@
 	}
 }
 
-ul {
+.optionList {
 	list-style-type: none;
 	padding-left: 0;
 	width: max-content;

--- a/src/ui/options/components/connector-override.tsx
+++ b/src/ui/options/components/connector-override.tsx
@@ -26,20 +26,20 @@ import { t } from '@/util/i18n';
 
 const globalOptions = BrowserStorage.getStorage(BrowserStorage.OPTIONS);
 const connectorOverrideOptions = BrowserStorage.getStorage(
-	BrowserStorage.CONNECTORS_OVERRIDE_OPTIONS
+	BrowserStorage.CONNECTORS_OVERRIDE_OPTIONS,
 );
 const customPatterns = BrowserStorage.getStorage(
-	BrowserStorage.CUSTOM_PATTERNS
+	BrowserStorage.CUSTOM_PATTERNS,
 );
 
 const [options, setOptions] = createResource(
-	globalOptions.get.bind(globalOptions)
+	globalOptions.get.bind(globalOptions),
 );
 const [overrideOptions, setOverrideOptions] = createResource(
-	connectorOverrideOptions.get.bind(connectorOverrideOptions)
+	connectorOverrideOptions.get.bind(connectorOverrideOptions),
 );
 const [customPatternOptions, setCustomPatternOptions] = createResource(
-	customPatterns.get.bind(customPatterns)
+	customPatterns.get.bind(customPatterns),
 );
 
 /**
@@ -52,7 +52,7 @@ export default function ConnectorOverrideOptions() {
 			<p>{t('optionsEnableDisableHint')}</p>
 			{/* eslint-disable-next-line */}
 			<p innerHTML={t('optionsCustomPatternsHint')} />
-			<ul class={styles.connectorOptionsList}>
+			<ul class={`${styles.connectorOptionsList} ${styles.optionList}`}>
 				<li>
 					<Settings />
 					<Checkbox
@@ -75,7 +75,7 @@ export default function ConnectorOverrideOptions() {
 								});
 							} else {
 								const disabledConnectors = Object.fromEntries(
-									connectors.map((c) => [c.id, true])
+									connectors.map((c) => [c.id, true]),
 								);
 								setOptions.mutate((o) => {
 									if (!o) return o;

--- a/src/ui/options/components/contact.tsx
+++ b/src/ui/options/components/contact.tsx
@@ -12,7 +12,7 @@ export default function ContactComponent() {
 	return (
 		<>
 			<h1>{t('contactTitle')}</h1>
-			<ul class={styles.contactList}>
+			<ul class={`${styles.contactList} ${styles.optionList}`}>
 				<a
 					href="https://github.com/web-scrobbler/web-scrobbler/issues"
 					target="_blank"

--- a/src/ui/options/components/edit-options/edited-tracks.tsx
+++ b/src/ui/options/components/edit-options/edited-tracks.tsx
@@ -50,7 +50,7 @@ export function EditsModal() {
 					Object.keys(edits() ?? {}).length.toString(),
 				)}
 			</h1>
-			<ul>
+			<ul class={styles.optionList}>
 				<For each={Object.entries(edits() ?? {})}>
 					{([key, value]) => (
 						<TrackInfo key={key} track={value} mutate={mutate} />

--- a/src/ui/options/components/edit-options/regex-edits.tsx
+++ b/src/ui/options/components/edit-options/regex-edits.tsx
@@ -47,10 +47,10 @@ export function RegexEditsModal() {
 			<h1>
 				{t(
 					'optionsRegexEditsPopupTitle',
-					(edits() ?? []).length.toString()
+					(edits() ?? []).length.toString(),
 				)}
 			</h1>
-			<ul>
+			<ul class={styles.optionList}>
 				<For each={[...(edits() ?? []).entries()]}>
 					{([index, edit]) => (
 						<EditInfo index={index} edit={edit} mutate={mutate} />

--- a/src/ui/options/components/inputs.tsx
+++ b/src/ui/options/components/inputs.tsx
@@ -21,7 +21,7 @@ export function Checkbox(props: {
 		e: InputEvent & {
 			currentTarget: HTMLInputElement;
 			target: Element;
-		}
+		},
 	) => void;
 }) {
 	const { title, label, isChecked, onInput } = props;
@@ -55,7 +55,7 @@ export function SummaryCheckbox(props: {
 		e: Event & {
 			currentTarget: HTMLInputElement;
 			target: Element;
-		}
+		},
 	) => void;
 }) {
 	const { title, label, id, isChecked, onInput } = props;
@@ -69,7 +69,7 @@ export function SummaryCheckbox(props: {
 						// hacky but it works, hopefully it doesnt stop working
 						e.preventDefault();
 						const checkbox = document.getElementById(
-							id
+							id,
 						) as HTMLInputElement;
 						checkbox.checked = !checkbox.checked;
 						onInput({
@@ -108,18 +108,18 @@ export function RadioButtons(props: {
 		e: Event & {
 			currentTarget: HTMLInputElement;
 			target: Element;
-		}
+		},
 	) => void;
 	reset?: (
 		e: Event & {
 			currentTarget: HTMLButtonElement;
 			target: Element;
-		}
+		},
 	) => void;
 }) {
 	const { buttons, name, value, onChange, reset } = props;
 	return (
-		<ul class={styles.radioButtons}>
+		<ul class={`${styles.radioButtons} ${styles.optionList}`}>
 			<For each={buttons}>
 				{(button) => (
 					<li>
@@ -158,7 +158,7 @@ export function RadioButtons(props: {
  * Checkbox made for connector options
  */
 export function ConnectorOptionEntry<
-	K extends keyof Options.ConnectorOptions
+	K extends keyof Options.ConnectorOptions,
 >(props: {
 	options: Resource<Options.ConnectorOptions | null>;
 	setOptions: ResourceActions<

--- a/src/ui/options/components/options/connector-options.tsx
+++ b/src/ui/options/components/options/connector-options.tsx
@@ -5,11 +5,11 @@ import { ConnectorOptionEntry } from '../inputs';
 import { t } from '@/util/i18n';
 
 const connectorOptions = BrowserStorage.getStorage(
-	BrowserStorage.CONNECTORS_OPTIONS
+	BrowserStorage.CONNECTORS_OPTIONS,
 );
 
 const [options, setOptions] = createResource(
-	connectorOptions.get.bind(connectorOptions)
+	connectorOptions.get.bind(connectorOptions),
 );
 
 /**
@@ -19,7 +19,7 @@ export default function ConnectorOptionsList() {
 	return (
 		<>
 			<h2>YouTube</h2>
-			<ul>
+			<ul class={styles.optionList}>
 				<ConnectorOptionEntry
 					options={options}
 					setOptions={setOptions}

--- a/src/ui/options/components/options/global-options.tsx
+++ b/src/ui/options/components/options/global-options.tsx
@@ -29,7 +29,7 @@ export default function GlobalOptionsList(props: {
 	return (
 		<>
 			<h2>{t('optionsGeneral')}</h2>
-			<ul>
+			<ul class={styles.optionList}>
 				<ThemeSelector />
 				<Show when={browser.notifications}>
 					<GlobalOptionEntry
@@ -91,9 +91,9 @@ function ThemeSelector() {
 								`value ${
 									e.currentTarget.value
 								} not in themelist ${modifiedThemeList.join(
-									','
+									',',
 								)}`,
-								'error'
+								'error',
 							);
 							return;
 						}
@@ -106,8 +106,8 @@ function ThemeSelector() {
 							<option value={`theme-${themeName}`}>
 								{t(
 									`optionTheme${capitalizeFirstLetter(
-										themeName
-									)}`
+										themeName,
+									)}`,
 								)}
 							</option>
 						)}

--- a/src/ui/popup/disallowed.tsx
+++ b/src/ui/popup/disallowed.tsx
@@ -1,0 +1,49 @@
+import ClonedSong from '@/core/object/cloned-song';
+import { ManagerTab } from '@/core/storage/wrapper';
+import { Resource, Show, createMemo, createSignal } from 'solid-js';
+import styles from './popup.module.scss';
+import optionComponentStyles from '../options/components/components.module.scss';
+import { t } from '@/util/i18n';
+import MusicOff from '@suid/icons-material/MusicOffOutlined';
+import Send from '@suid/icons-material/Send';
+import { sendBackgroundMessage } from '@/util/communication';
+
+export default function Disallowed(props: { tab: Resource<ManagerTab> }) {
+	const [isLoading, setLoading] = createSignal(false);
+	const song = createMemo(() => {
+		const rawTab = props.tab();
+		if (!rawTab) return null;
+		const rawSong = rawTab.song;
+		if (!rawSong) return null;
+		return new ClonedSong(rawSong, rawTab.tabId);
+	});
+
+	return (
+		<Show when={!isLoading()} fallback={<></>}>
+			<div class={styles.alertPopup}>
+				<MusicOff class={styles.bigIcon} />
+				<h1>{t('disallowedHeader')}</h1>
+				<p>
+					{t('disallowedDesc1', [
+						song()?.getArtist() ?? '???',
+						song()?.getTrack() ?? '???',
+					])}
+				</p>
+				<p>{t('disallowedDesc2')}</p>
+				<button
+					class={`${optionComponentStyles.resetButton} ${styles.centered}`}
+					onClick={() => {
+						setLoading(true);
+						sendBackgroundMessage(props.tab()?.tabId ?? -1, {
+							type: 'forceScrobbleSong',
+							payload: undefined,
+						});
+					}}
+				>
+					<Send />
+					{t('disallowedButton')}
+				</button>
+			</div>
+		</Show>
+	);
+}

--- a/src/ui/popup/disallowed.tsx
+++ b/src/ui/popup/disallowed.tsx
@@ -19,8 +19,8 @@ export default function Disallowed(props: { tab: Resource<ManagerTab> }) {
 	});
 
 	return (
-		<Show when={!isLoading()} fallback={<></>}>
-			<div class={styles.alertPopup}>
+		<Show when={!isLoading()}>
+			<div class={styles.widePopup}>
 				<MusicOff class={styles.bigIcon} />
 				<h1>{t('disallowedHeader')}</h1>
 				<p>
@@ -29,7 +29,27 @@ export default function Disallowed(props: { tab: Resource<ManagerTab> }) {
 						song()?.getTrack() ?? '???',
 					])}
 				</p>
-				<p>{t('disallowedDesc2')}</p>
+				<Show
+					when={song()?.metadata.label === 'YouTube'}
+					fallback={
+						<>
+							<p>{t('disallowedDesc2')}</p>
+							<ul>
+								<li>{t('disallowedDesc2Point1')}</li>
+								<li>{t('disallowedDesc2Point2')}</li>
+								<li>{t('disallowedDesc2Point3')}</li>
+							</ul>
+						</>
+					}
+				>
+					<p>{t('disallowedDescYoutube')}</p>
+					<ul>
+						<li>{t('disallowedDescYoutubePoint1')}</li>
+						<li>{t('disallowedDescYoutubePoint2')}</li>
+						<li>{t('disallowedDescYoutubePoint3')}</li>
+					</ul>
+				</Show>
+				<p>{t('disallowedDesc3')}</p>
 				<button
 					class={`${optionComponentStyles.resetButton} ${styles.centered}`}
 					onClick={() => {

--- a/src/ui/popup/main.tsx
+++ b/src/ui/popup/main.tsx
@@ -30,6 +30,7 @@ import {
 	Navigator,
 	getMobileNavigatorGroup,
 } from '../options/components/navigator';
+import Disallowed from './disallowed';
 
 /**
  * List of modes that have a settings button in the popup content, dont show supplementary settings icon.
@@ -58,7 +59,7 @@ const contextMenuModes = [
 function Popup() {
 	const [tab, setTab] = createResource(getCurrentTab);
 	const [navigatorResource, { refetch }] = createResource(
-		getMobileNavigatorGroup
+		getMobileNavigatorGroup,
 	);
 
 	createEffect(() => {
@@ -82,7 +83,7 @@ function Popup() {
 			fn: (currentTab) => {
 				setTab.mutate(currentTab);
 			},
-		})
+		}),
 	);
 
 	return (
@@ -110,6 +111,9 @@ function Popup() {
 					}
 				>
 					<NowPlaying tab={tab} />
+				</Match>
+				<Match when={tab()?.mode === ControllerMode.Disallowed}>
+					<Disallowed tab={tab} />
 				</Match>
 				<Match when={tab()?.mode === ControllerMode.Unknown}>
 					<Edit tab={tab} />

--- a/src/ui/popup/nowplaying.tsx
+++ b/src/ui/popup/nowplaying.tsx
@@ -124,7 +124,7 @@ export default function NowPlaying(props: { tab: Resource<ManagerTab> }) {
 							src={
 								song()?.getTrackArt() ??
 								browser.runtime.getURL(
-									'img/cover_art_default.png'
+									'img/cover_art_default.png',
 								)
 							}
 						/>
@@ -256,7 +256,7 @@ function TrackData(props: { song: Accessor<ClonedSong | null> }) {
 			<PopupLink
 				href={createAlbumURL(
 					song()?.getAlbumArtist() || song()?.getArtist(),
-					song()?.getAlbum()
+					song()?.getAlbum(),
 				)}
 				title={t('infoViewAlbumPage', song()?.getAlbum() ?? '')}
 			>
@@ -291,11 +291,11 @@ function TrackMetadata(props: { song: Accessor<ClonedSong | null> }) {
 				href={createTrackLibraryURL(
 					session()?.sessionName,
 					song()?.getArtist(),
-					song()?.getTrack()
+					song()?.getTrack(),
 				)}
 				title={t(
 					'infoYourScrobbles',
-					(song()?.metadata.userPlayCount || 0).toString()
+					(song()?.metadata.userPlayCount || 0).toString(),
 				)}
 			>
 				<LastFMIcon />
@@ -458,7 +458,7 @@ function actionResetSongData(tab: Resource<ManagerTab>) {
  */
 function toggleLove(
 	tab: Resource<ManagerTab>,
-	song: Accessor<ClonedSong | null>
+	song: Accessor<ClonedSong | null>,
 ) {
 	sendBackgroundMessage(tab()?.tabId ?? -1, {
 		type: 'toggleLove',

--- a/src/ui/popup/popup.module.scss
+++ b/src/ui/popup/popup.module.scss
@@ -7,14 +7,23 @@
 	font-size: 1.2em;
 }
 
-.alertPopup {
+.alertPopup,
+.widePopup {
 	padding: 15px;
 	text-align: center;
-	width: 300px;
 
-	p {
+	p,
+	ul {
 		text-align: left;
 	}
+}
+
+.alertPopup {
+	width: 300px;
+}
+
+.widePopup {
+	width: 400px;
 }
 
 .bigIcon:not(table) {

--- a/src/util/communication.ts
+++ b/src/util/communication.ts
@@ -148,6 +148,10 @@ interface BackgroundCommunications {
 		payload: undefined;
 		response: void;
 	};
+	forceScrobbleSong: {
+		payload: undefined;
+		response: void;
+	};
 }
 
 /**

--- a/tests/background/song.test.ts
+++ b/tests/background/song.test.ts
@@ -66,8 +66,7 @@ function createSong(
 	const parsedDataCopy: ParsedSongData = {};
 	for (const prop in defaultParsedData) {
 		const typedProp = prop as keyof ParsedSongData;
-		//@ts-expect-error - it doesnt like this
-		parsedDataCopy[typedProp] =
+		parsedDataCopy[typedProp] = //@ts-expect-error - it doesnt like this
 			parsedData[typedProp] || defaultParsedData[typedProp];
 	}
 


### PR DESCRIPTION
Adds a new controller state for when a song isnt allowed.
For instance, if user sets scrobble music category only, and then plays a video on another category, this will show.
Will also show on ads on some websites for instance, wherever Connector.isScrobblingAllowed() is false.
Allows users to override it and play anyway.
This helps make stricter scrobble settings more attractive, as when the filter is too strict you can actually act on it.
It also hopefully provides clearer feedback for the user.
This should be tested rather carefully as it affects very core functionality.
The wording can probably also be improved for clarity.

<img width="340" alt="image" src="https://github.com/web-scrobbler/web-scrobbler/assets/69117606/69901cea-15ee-49ed-a77e-04bd4f89d1d7">
