### PR TITLE
Add TuneGenie Support

### DIFF
--- a/src/connectors/tunegenie-embed.ts
+++ b/src/connectors/tunegenie-embed.ts
@@ -1,0 +1,13 @@
+export {};
+
+Connector.playerSelector = '#tgmp';
+Connector.artistSelector = '.info .artist';
+Connector.trackSelector = '.info .song';
+Connector.trackArtSelector = '.cover img';
+
+Connector.isPlaying = () => {
+	return (
+		Util.getAttrFromSelectors('.control a svg path', 'd') ===
+		'M400 32c26.5 0 48 21.5 48 48v352c0 26.5-21.5 48-48 48h-352c-26.5 0-48-21.5-48-48v-352c0-26.5 21.5-48 48-48h352z'
+	);
+};

--- a/src/connectors/tunegenie.ts
+++ b/src/connectors/tunegenie.ts
@@ -1,0 +1,8 @@
+export {};
+
+Connector.playerSelector = '#back_matte';
+Connector.trackSelector = 'ul.currentonair li.slot:first-child .song';
+Connector.artistSelector =
+	'.currentonair > li.slot:first-child .left div:not(.song)';
+Connector.trackArtSelector = '.currentonair > li.slot:first-child .disc img';
+Connector.isPlaying = () => Util.hasElementClass('.play.btn i', 'icon-stop');

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2142,4 +2142,17 @@ export default <ConnectorMeta[]>[
 		js: 'technobase.fm.js',
 		id: 'technobase.fm',
 	},
+	{
+		label: 'TuneGenieEmbed',
+		matches: ['*://b3.tunegenie.com/*'],
+		js: 'tunegenie-embed.js',
+		id: 'tunegenie-embed',
+		allFrames: true,
+	},
+	{
+		label: 'TuneGenie',
+		matches: ['*://*.tunegenie.com/*'],
+		js: 'tunegenie.js',
+		id: 'tunegenie',
+	},
 ];


### PR DESCRIPTION
I created 2 new connectors to support radio stations that use [TuneGenie](https://tunegenie.com/) for streaming. In following the model I'd seen for Bandcamp and YouTube connectors, where they have a separate connector for the main website and sites that use an embedded player. 

## Website Connector
There are a ton of sites that use this player straight up, just linking to this player page from their sites. I found the player a bit finicky from station to station though. Some would refresh properly and others wouldn't. Not quite sure if it's an implementation issue on the stations side or not.  Sites tested against [WERS](http://wers.tunegenie.com/), [MYVRadio](http://mvyradio.tunegenie.com/#listenlive) and [KROQ](http://kroq.tunegenie.com/)
![image](https://github.com/web-scrobbler/web-scrobbler/assets/2962327/58edd4e2-57e4-4ab6-9160-c23152ca6bc5)

## Embed Connector
Some sites have a more advanced player embedded in their website. The tough thing is identifying just what sites are using this embed. The few I tested against are [WERS](https://wers.org), [KXT](https://kxt.org) and [WNXP](https://wnxp.org/). The cool thing I found with this implementation is that it functions based on the embed URL, so there's no need to list all the different URLs that it works on, it just connects through the iframe loading. 
![image](https://github.com/web-scrobbler/web-scrobbler/assets/2962327/83285f2e-924c-4d31-bc22-adf6a9554870)


