### PR TITLE
Add save button to local properties

### DIFF
--- a/src/ui/options/components/accounts.tsx
+++ b/src/ui/options/components/accounts.tsx
@@ -3,11 +3,15 @@ import ScrobbleService, {
 	Scrobbler,
 	ScrobblerLabel,
 } from '@/core/object/scrobble-service';
-import { For, Show, createResource, onCleanup } from 'solid-js';
+import { For, Show, createResource, createSignal, onCleanup } from 'solid-js';
 import styles from './components.module.scss';
 import browser from 'webextension-polyfill';
 import Delete from '@suid/icons-material/DeleteOutlined';
+import Save from '@suid/icons-material/SaveOutlined';
+import AutoRenew from '@suid/icons-material/AutorenewOutlined';
+import Check from '@suid/icons-material/CheckOutlined';
 import { debugLog } from '@/util/util';
+import { Dynamic } from 'solid-js/web';
 
 /**
  * Properties associated with each scrobbler, and the input type to use for the user to edit them.
@@ -170,6 +174,45 @@ function SignedOut(props: { scrobbler: Scrobbler }) {
 	);
 }
 
+enum SaveState {
+	BASE = 'base',
+	SAVING = 'saving',
+	SAVED = 'saved',
+}
+
+/**
+ * Save button component.
+ * This button doesn't actually do anything as the extension autosaves, but better user feedback :)
+ */
+function SaveButton() {
+	const [state, setState] = createSignal(SaveState.BASE);
+
+	const icons = {
+		[SaveState.BASE]: Save,
+		[SaveState.SAVING]: AutoRenew,
+		[SaveState.SAVED]: Check,
+	};
+
+	return (
+		<button
+			class={styles.resetButton}
+			onClick={() => {
+				if (state() !== SaveState.SAVING) {
+					setState(SaveState.SAVING);
+					setTimeout(() => {
+						setState(SaveState.SAVED);
+					}, 850);
+				}
+			}}
+		>
+			<div class={`${styles[`${state()}SaveIcon`]} ${styles.saveIcon}`}>
+				<Dynamic component={icons[state()]} />
+			</div>
+			Save
+		</button>
+	);
+}
+
 /**
  * Component that allows the user to edit scrobbler properties for the scrobblers that support them.
  */
@@ -208,6 +251,7 @@ function Properties(props: { scrobbler: Scrobbler }) {
 					);
 				}}
 			</For>
+			<SaveButton />
 		</>
 	);
 }

--- a/src/ui/options/components/components.module.scss
+++ b/src/ui/options/components/components.module.scss
@@ -493,3 +493,13 @@ summary {
 		grid-area: albumartistreplace;
 	}
 }
+
+.saveIcon {
+	transform: rotate(0deg);
+
+	&.savingSaveIcon {
+		transform: rotate(360deg);
+		transform-origin: 41% 42.5%;
+		transition: transform 600ms ease-in-out;
+	}
+}


### PR DESCRIPTION
This button doesn't actually do anything as the extension autosaves.
However, I think it's a good addition for the sake of user feedback.
The user probably only interacts with this once or twice, and when they do they are brand new, let's be as clear as possible.