### PR TITLE
Add instant local login

### DIFF
--- a/src/core/scrobbler/base-scrobbler.ts
+++ b/src/core/scrobbler/base-scrobbler.ts
@@ -13,6 +13,10 @@ import {
 	getScrobblerStorage,
 } from '../storage/browser-storage';
 import ClonedSong from '../object/cloned-song';
+import {
+	backgroundListener,
+	setupBackgroundListeners,
+} from '@/util/communication';
 
 export interface SessionData {
 	/** ID of a current session */
@@ -66,6 +70,14 @@ export default abstract class BaseScrobbler<K extends keyof ScrobblerModels> {
 	constructor() {
 		this.storage = this.initStorage();
 		void this.initUserProps();
+		setupBackgroundListeners(
+			backgroundListener({
+				type: 'updateScrobblerProperties',
+				fn: () => {
+					void this.initUserProps();
+				},
+			}),
+		);
 	}
 
 	/**
@@ -211,7 +223,7 @@ export default abstract class BaseScrobbler<K extends keyof ScrobblerModels> {
 			data.arrayProperties,
 			this.getUserDefinedArrayProperties(),
 		);
-		this.storage.set(data);
+		await this.storage.set(data);
 	}
 
 	/**
@@ -240,7 +252,7 @@ export default abstract class BaseScrobbler<K extends keyof ScrobblerModels> {
 			data.arrayProperties,
 			this.getUserDefinedArrayProperties(),
 		);
-		this.storage.set(data);
+		await this.storage.set(data);
 	}
 
 	/** Authentication */

--- a/src/ui/options/components/accounts.tsx
+++ b/src/ui/options/components/accounts.tsx
@@ -8,6 +8,7 @@ import styles from './components.module.scss';
 import browser from 'webextension-polyfill';
 import Delete from '@suid/icons-material/DeleteOutlined';
 import { debugLog } from '@/util/util';
+import { sendContentMessage } from '@/util/communication';
 
 /**
  * Properties associated with each scrobbler, and the input type to use for the user to edit them.
@@ -212,7 +213,14 @@ function Properties(props: { scrobbler: Scrobbler }) {
 											data = {};
 										}
 										data[typedKey] = e.currentTarget.value;
-										scrobbler.applyUserProperties(data);
+										scrobbler
+											.applyUserProperties(data)
+											.then(() => {
+												sendContentMessage({
+													type: 'updateScrobblerProperties',
+													payload: void 0,
+												});
+											});
 										return data;
 									});
 								}}
@@ -260,9 +268,14 @@ function ArrayProperties(props: { scrobbler: Scrobbler }) {
 											...data.slice(0, index()),
 											...data.slice(index() + 1),
 										];
-										scrobbler.applyUserArrayProperties(
-											data,
-										);
+										scrobbler
+											.applyUserArrayProperties(data)
+											.then(() => {
+												sendContentMessage({
+													type: 'updateScrobblerProperties',
+													payload: void 0,
+												});
+											});
 										return data;
 									});
 								}}
@@ -305,7 +318,12 @@ function ArrayProperties(props: { scrobbler: Scrobbler }) {
 						if (!data) {
 							data = [];
 						}
-						scrobbler.addUserArrayProperties(newProps);
+						scrobbler.addUserArrayProperties(newProps).then(() => {
+							sendContentMessage({
+								type: 'updateScrobblerProperties',
+								payload: void 0,
+							});
+						});
 						return [...data, newProps];
 					});
 				}}

--- a/src/util/communication.ts
+++ b/src/util/communication.ts
@@ -98,6 +98,10 @@ interface ContentCommunications {
 		};
 		response: Promise<string | null>;
 	};
+	updateScrobblerProperties: {
+		payload: undefined;
+		response: void;
+	};
 }
 
 interface BackgroundCommunications {


### PR DESCRIPTION
Currently, local signins require reload of extension.
This makes that not happen anymore.
Just pings off a message to the background scrobbler telling it to reinitialize props whenever user modifies props.
Should significantly improve onboarding for those using local scrobbling/webhooks.