### PR TITLE
Add connector for RTL+ Musik

### DIFF
--- a/src/connectors/rtl-plus-musik.ts
+++ b/src/connectors/rtl-plus-musik.ts
@@ -1,0 +1,20 @@
+export {};
+
+Connector.playerSelector = 'plus-player-container';
+
+Connector.trackSelector = 'plus-player-container .album';
+
+Connector.artistSelector = 'plus-player-container .artist';
+
+Connector.currentTimeSelector = 'plus-player-container music-progress .current-time';
+
+Connector.remainingTimeSelector = 'plus-player-container music-progress .duration';
+
+Connector.isPlaying = () => {
+    const titleElements = Util.queryElements('plus-player-container .play-icon > svg > title');
+    if (titleElements && titleElements[0].textContent) {
+        const isPaused = titleElements[0].textContent.indexOf('Abspielen') >= 0;
+        return !isPaused;
+    }
+    return false;
+};

--- a/src/connectors/rtl-plus-musik.ts
+++ b/src/connectors/rtl-plus-musik.ts
@@ -2,7 +2,10 @@ export {};
 
 Connector.playerSelector = 'plus-player-container';
 
-Connector.trackSelector = 'plus-player-container .album';
+Connector.trackSelector = [
+        'music-currently-playing .title',
+        'plus-player-container .album' // for tracks with available album, track name is in link to album
+    ];
 
 Connector.artistSelector = 'plus-player-container .artist';
 

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2155,4 +2155,10 @@ export default <ConnectorMeta[]>[
 		js: 'tunegenie.js',
 		id: 'tunegenie',
 	},
+	{
+		label: 'RTL+ Musik',
+		matches: ['*://plus.rtl.de/musik/*'],
+		js: 'rtl-plus-musik.js',
+		id: 'rtl-plus-musik',
+	},
 ];


### PR DESCRIPTION
**Describe the changes you made**
Added connector for _RTL+ Musik_

**Additional context**
_RTL+ Musik_ is a new German music streaming service by media conglomerate RTL Group, which is powered by Deezer.
