### PR TITLE
Filter sports broadcasts from SiriusXM

### DIFF
--- a/src/connectors/siriusxm-player.ts
+++ b/src/connectors/siriusxm-player.ts
@@ -48,6 +48,7 @@ Connector.isScrobblingAllowed = () => {
 		'#',
 		'facebook',
 		'twitter',
+		'bdcast',
 	];
 
 	return !filteredTerms.some(


### PR DESCRIPTION
This prevents scrobling most sports broadcasts

Examples scrobles to avoid:
https://www.last.fm/search/tracks?q=bdcast
