### PR TITLE
Remove "Sign in" button for accounts not using it

### DIFF
--- a/src/core/scrobbler/audio-scrobbler/audio-scrobbler.ts
+++ b/src/core/scrobbler/audio-scrobbler/audio-scrobbler.ts
@@ -29,6 +29,7 @@ interface AudioScrobblerScrobbleParams extends AudioScrobblerParams {
 }
 
 export default abstract class AudioScrobbler extends BaseScrobbler<'LastFM'> {
+	public isLocalOnly = false;
 	protected abstract getApiKey(): string;
 	protected abstract getApiSecret(): string;
 	protected abstract getApiUrl(): string;

--- a/src/core/scrobbler/base-scrobbler.ts
+++ b/src/core/scrobbler/base-scrobbler.ts
@@ -66,6 +66,7 @@ export default abstract class BaseScrobbler<K extends keyof ScrobblerModels> {
 	public userApiUrl: string | null = null;
 	public userToken: string | null = null;
 	public arrayProperties: ArrayProperties | null = null;
+	abstract isLocalOnly: boolean;
 
 	constructor() {
 		this.storage = this.initStorage();

--- a/src/core/scrobbler/lastfm/lastfm-scrobbler.ts
+++ b/src/core/scrobbler/lastfm/lastfm-scrobbler.ts
@@ -81,7 +81,7 @@ export default class LastFmScrobbler extends AudioScrobbler {
 		const responseData = await this.sendRequest<LastFmTrackInfo>(
 			{ method: 'GET' },
 			params,
-			false
+			false,
 		);
 
 		const result = this.processResponse(responseData);
@@ -145,10 +145,13 @@ export default class LastFmScrobbler extends AudioScrobbler {
 				 * Convert an array from response to an object.
 				 * Format is the following: { size: "url", ... }.
 				 */
-				const images = albumInfo.image.reduce((result, image) => {
-					result[image.size] = image['#text'];
-					return result;
-				}, {} as Record<string, string>);
+				const images = albumInfo.image.reduce(
+					(result, image) => {
+						result[image.size] = image['#text'];
+						return result;
+					},
+					{} as Record<string, string>,
+				);
 
 				const imageSizes = ['extralarge', 'large', 'medium'];
 

--- a/src/core/scrobbler/listenbrainz/listenbrainz-scrobbler.ts
+++ b/src/core/scrobbler/listenbrainz/listenbrainz-scrobbler.ts
@@ -22,6 +22,7 @@ const apiUrl = `${baseUrl}/submit-listens`;
 export default class ListenBrainzScrobbler extends BaseScrobbler<'ListenBrainz'> {
 	public userApiUrl!: string;
 	public userToken!: string;
+	public isLocalOnly = false;
 
 	public async getSongInfo(): Promise<Record<string, never>> {
 		return Promise.resolve({});

--- a/src/core/scrobbler/maloja/maloja-scrobbler.ts
+++ b/src/core/scrobbler/maloja/maloja-scrobbler.ts
@@ -13,6 +13,7 @@ import { MalojaTrackMetadata } from '@/core/scrobbler/maloja/maloja.types';
 export default class MalojaScrobbler extends BaseScrobbler<'Maloja'> {
 	public userToken!: string;
 	public userApiUrl!: string;
+	public isLocalOnly = true;
 
 	/** @override */
 	protected getStorageName(): 'Maloja' {

--- a/src/core/scrobbler/webhook-scrobbler.ts
+++ b/src/core/scrobbler/webhook-scrobbler.ts
@@ -22,6 +22,7 @@ type WebhookRequest = {
 
 export default class WebhookScrobbler extends BaseScrobbler<'Webhook'> {
 	public userApiUrl!: string;
+	public isLocalOnly = true;
 
 	/** @override */
 	protected getBaseProfileUrl(): string {

--- a/src/ui/options/components/accounts.tsx
+++ b/src/ui/options/components/accounts.tsx
@@ -6,6 +6,7 @@ import ScrobbleService, {
 import {
 	For,
 	Match,
+	Show,
 	Switch,
 	createResource,
 	createSignal,
@@ -124,7 +125,14 @@ function ScrobblerDisplay(props: { label: ScrobblerLabel }) {
 			<h2>{rawScrobbler.getLabel()}</h2>
 			<Switch fallback={<SignedOut scrobbler={rawScrobbler} />}>
 				<Match when={rawScrobbler.isLocalOnly}>
-					<></>
+					<Show when={!session.error && session()}>
+						<p>
+							{t(
+								'accountsSignedInAs',
+								session()?.sessionName || 'anonymous',
+							)}
+						</p>
+					</Show>
 				</Match>
 				<Match when={!session.error && session()}>
 					<p>


### PR DESCRIPTION
This just adds noise, and makes things more confusing for users.

Before:
<img width="383" alt="image" src="https://github.com/web-scrobbler/web-scrobbler/assets/69117606/fc5da74e-7ed6-44c7-8bf5-3ed427548430">


After:
<img width="350" alt="image" src="https://github.com/web-scrobbler/web-scrobbler/assets/69117606/c8d23f34-9895-4020-9e1a-823c7f18ff49">

It still shows the signed in label:
<img width="318" alt="image" src="https://github.com/web-scrobbler/web-scrobbler/assets/69117606/d70bdb4b-21b8-484a-af4e-cfb8dc494038">
