### PR TITLE
Add ignored state and overhaul control flow

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -563,6 +563,18 @@
         "message": "Scrobble anyway",
         "description": "Button label"
     },
+    "ignoredHeader": {
+        "message": "This scrobble was ignored",
+        "description": "The header of 'ignored' popup"
+    },
+    "ignoredDesc": {
+        "message": "Web Scrobbler tried to scrobble \"$2\" by \"$1\", but the tags were ignored by Last.FM.",
+        "description": "The description of 'ignored' popup. $1 is artist name, and $2 is track name"
+    },
+    "ignoredDescReadMore": {
+        "message": "Read more and ask for the song to be allowlisted here",
+        "description": "The description of 'ignored' popup, links to support.last.fm thread"
+    },
     "unsupportedWebsiteHeader": {
         "message": "This website is not supported",
         "description": "The header of 'unsupported' popup"

--- a/src/ui/popup/ignored.tsx
+++ b/src/ui/popup/ignored.tsx
@@ -1,0 +1,34 @@
+import { ManagerTab } from '@/core/storage/wrapper';
+import { Resource, createMemo } from 'solid-js';
+import styles from './popup.module.scss';
+import { t } from '@/util/i18n';
+import { PopupAnchor } from '../components/util';
+import CancelScheduleSend from '@suid/icons-material/CancelScheduleSendOutlined';
+import ClonedSong from '@/core/object/cloned-song';
+
+export default function Ignored(props: { tab: Resource<ManagerTab> }) {
+	const clonedSong = createMemo(() => {
+		const cloneable = props.tab()?.song;
+		if (cloneable) {
+			return new ClonedSong(cloneable, -1);
+		}
+	});
+	return (
+		<div class={styles.alertPopup}>
+			<CancelScheduleSend class={styles.bigIcon} />
+			<h1>{t('ignoredHeader')}</h1>
+			<p>
+				{t('ignoredDesc', [
+					clonedSong()?.getArtist() ?? '????',
+					clonedSong()?.getTrack() ?? '????',
+				])}
+			</p>
+			<PopupAnchor
+				href="https://support.last.fm/t/track-filter-list-unknown-scrobbles/776"
+				title={t('ignoredDescReadMore')}
+			>
+				{t('ignoredDescReadMore')}
+			</PopupAnchor>
+		</div>
+	);
+}

--- a/src/ui/popup/main.tsx
+++ b/src/ui/popup/main.tsx
@@ -1,12 +1,10 @@
-import { render } from 'solid-js/web';
+import { Dynamic, render } from 'solid-js/web';
 import './popup.module.scss';
 import Unsupported from './unsupported';
 import * as ControllerMode from '@/core/object/controller/controller-mode';
 import { initializeThemes } from '@/theme/themes';
 import '@/theme/themes.scss';
 import {
-	Match,
-	Switch,
 	createResource,
 	Show,
 	createMemo,
@@ -31,6 +29,7 @@ import {
 	getMobileNavigatorGroup,
 } from '../options/components/navigator';
 import Disallowed from './disallowed';
+import Ignored from './ignored';
 
 /**
  * List of modes that have a settings button in the popup content, dont show supplementary settings icon.
@@ -86,44 +85,43 @@ function Popup() {
 		}),
 	);
 
+	const popupContent = {
+		[ControllerMode.Base]: () => <Base />,
+		[ControllerMode.Disabled]: () => <Disabled />,
+		[ControllerMode.Err]: () => <Err />,
+		[ControllerMode.Playing]: () => <NowPlaying tab={tab} />,
+		[ControllerMode.Skipped]: () => <NowPlaying tab={tab} />,
+		[ControllerMode.Scrobbled]: () => <NowPlaying tab={tab} />,
+		[ControllerMode.Disallowed]: () => <Disallowed tab={tab} />,
+		[ControllerMode.Unknown]: () => <Edit tab={tab} />,
+		[ControllerMode.Unsupported]: () => <Unsupported />,
+		[ControllerMode.Ignored]: () => <Ignored tab={tab} />,
+		[ControllerMode.Loading]: () => <></>,
+	};
+
 	return (
 		<>
 			<Show
-				when={!contextMenuModes.includes(tab()?.mode ?? '') && isIos()}
+				when={
+					!contextMenuModes.includes(
+						tab()?.mode ?? ControllerMode.Unsupported,
+					) && isIos()
+				}
 			>
 				<ContextMenu items={items()} />
 			</Show>
-			<Switch fallback={<></>}>
-				<Match when={tab()?.mode === ControllerMode.Base}>
-					<Base />
-				</Match>
-				<Match when={tab()?.mode === ControllerMode.Disabled}>
-					<Disabled />
-				</Match>
-				<Match when={tab()?.mode === ControllerMode.Err}>
-					<Err />
-				</Match>
-				<Match
-					when={
-						tab()?.mode === ControllerMode.Playing ||
-						tab()?.mode === ControllerMode.Skipped ||
-						tab()?.mode === ControllerMode.Scrobbled
-					}
-				>
-					<NowPlaying tab={tab} />
-				</Match>
-				<Match when={tab()?.mode === ControllerMode.Disallowed}>
-					<Disallowed tab={tab} />
-				</Match>
-				<Match when={tab()?.mode === ControllerMode.Unknown}>
-					<Edit tab={tab} />
-				</Match>
-				<Match when={tab()?.mode === ControllerMode.Unsupported}>
-					<Unsupported />
-				</Match>
-			</Switch>
-
-			<Show when={!settingModes.includes(tab()?.mode ?? '') && !isIos()}>
+			<Dynamic
+				component={
+					popupContent[tab()?.mode ?? ControllerMode.Unsupported]
+				}
+			/>
+			<Show
+				when={
+					!settingModes.includes(
+						tab()?.mode ?? ControllerMode.Unsupported,
+					) && !isIos()
+				}
+			>
 				<PopupAnchor
 					href={browser.runtime.getURL('src/ui/options/index.html')}
 					class={styles.settingsIcon}

--- a/src/ui/popup/popup.module.scss
+++ b/src/ui/popup/popup.module.scss
@@ -79,7 +79,9 @@ a {
 	width: max-content;
 
 	.coverArtWrapper {
-		height: 100vh;
+		// set a very low height here. This prevents image from expanding uncontrollably.
+		// The entire image still remains clickable link (overflow).
+		height: 10px;
 
 		.coverArt {
 			width: 100vh;


### PR DESCRIPTION
Does some invisible overhauling of control flow to improve type checking a bit and just generally be a bit less of a mess.
Also adds ignored state popup, as this was necessary to satisfy type checker now.
Also, fallback is now unsupported website, not empty element.
This is relevant on safari on mac, as new tab would trigger fallback.