### PR TITLE
Add connector for WDR

### DIFF
--- a/src/connectors/wdr.ts
+++ b/src/connectors/wdr.ts
@@ -2,6 +2,10 @@ export {};
 
 // Connector for the WDR radio stations (1Live, WDR2, WDR3, WDR4, WDR5, COSMO, etc.)
 
+const filter = MetadataFilter.createFilter({
+	artist: cleanupArtist,
+});
+
 Connector.playerSelector = '.wdrrCurrentChannels';
 
 Connector.artistTrackSelector = '.wdrrCurrentShowTitleTitle';
@@ -34,3 +38,16 @@ Connector.isScrobblingAllowed = () => {
 	// Scrobble only if none of the disallowed strings are included
 	return !containsDisallowedString;
 };
+
+function cleanupArtist(artist: any) {
+	// Define patterns to find additional artists or features.
+	const patterns = [/ & .*/, / x .*/, / feat\..*/];
+
+	let cleanedArtist = artist;
+
+	patterns.forEach((pattern) => {
+		cleanedArtist = cleanedArtist.replace(pattern, '');
+	});
+
+	return cleanedArtist.trim();
+}

--- a/src/connectors/wdr.ts
+++ b/src/connectors/wdr.ts
@@ -36,7 +36,7 @@ Connector.isScrobblingAllowed = () => {
 	return !containsDisallowedString;
 };
 
-function cleanupArtist(artist: any) {
+function cleanupArtist(artist: string) {
 	// Define patterns to find additional artists or features.
 	const patterns = [/ & .*/, / x .*/, / feat\..*/];
 

--- a/src/connectors/wdr.ts
+++ b/src/connectors/wdr.ts
@@ -2,9 +2,9 @@ export {};
 
 // Connector for the WDR radio stations (1Live, WDR2, WDR3, WDR4, WDR5, COSMO, etc.)
 
-const filter = MetadataFilter.createFilter({
-	artist: cleanupArtist,
-});
+const filter = MetadataFilter.createFilter({ artist: cleanupArtist });
+
+Connector.applyFilter(filter);
 
 Connector.playerSelector = '.wdrrCurrentChannels';
 

--- a/src/connectors/wdr.ts
+++ b/src/connectors/wdr.ts
@@ -1,0 +1,14 @@
+export {};
+
+// Connector for the WDR radio stations (1Live, WDR2, WDR3, WDR4, WDR5, COSMO, etc.)
+
+Connector.playerSelector = '.wdrrCurrentChannels';
+
+Connector.artistTrackSelector = '.wdrrCurrentShowTitleTitle';
+
+Connector.isPlaying = () => {
+	const playButton = document.querySelector('#playCtrl');
+	return playButton !== null && playButton.classList.contains('playing');
+};
+
+// Don't scrobble if special strings like "WDR 5 Quarks - Wissenschaft und mehr mit Sebastian Sonntag"

--- a/src/connectors/wdr.ts
+++ b/src/connectors/wdr.ts
@@ -11,4 +11,26 @@ Connector.isPlaying = () => {
 	return playButton !== null && playButton.classList.contains('playing');
 };
 
-// Don't scrobble if special strings like "WDR 5 Quarks - Wissenschaft und mehr mit Sebastian Sonntag"
+Connector.isScrobblingAllowed = () => {
+	const artistTrack = Util.getTextFromSelectors(
+		Connector.artistTrackSelector,
+	);
+	const disallowedStrings = [
+		'1Live',
+		'WDR 2',
+		'WDR 3',
+		'WDR 4',
+		'WDR 5',
+		'COSMO',
+	];
+
+	// Check if the artistTrack includes any of the disallowed strings
+	const containsDisallowedString =
+		artistTrack !== null &&
+		disallowedStrings.some((disallowedString) =>
+			artistTrack.includes(disallowedString),
+		);
+
+	// Scrobble only if none of the disallowed strings are included
+	return !containsDisallowedString;
+};

--- a/src/connectors/wdr.ts
+++ b/src/connectors/wdr.ts
@@ -10,7 +10,7 @@ Connector.playerSelector = '.wdrrCurrentChannels';
 
 Connector.artistTrackSelector = '.wdrrCurrentShowTitleTitle';
 
-Connector.isPlaying = () => {
+Connector.pauseButtonSelector = '#playCtrl.playing';
 	const playButton = document.querySelector('#playCtrl');
 	return playButton !== null && playButton.classList.contains('playing');
 };

--- a/src/connectors/wdr.ts
+++ b/src/connectors/wdr.ts
@@ -11,9 +11,6 @@ Connector.playerSelector = '.wdrrCurrentChannels';
 Connector.artistTrackSelector = '.wdrrCurrentShowTitleTitle';
 
 Connector.pauseButtonSelector = '#playCtrl.playing';
-	const playButton = document.querySelector('#playCtrl');
-	return playButton !== null && playButton.classList.contains('playing');
-};
 
 Connector.isScrobblingAllowed = () => {
 	const artistTrack = Util.getTextFromSelectors(

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2227,4 +2227,10 @@ export default <ConnectorMeta[]>[
 		js: 'khinsider.js',
 		id: 'khinsider',
 	},
+	{
+		label: 'WDR',
+		matches: ['*://*.wdr.de/radio/*'],
+		js: 'wdr.js',
+		id: 'wdr',
+	},
 ];


### PR DESCRIPTION
I created a connector for the wdr stations. I used this new connector today while listening to 1Live and couldn't experience any errors.


**Describe the changes you made**
Added a connector for the WDR radio stations (1Live, WDR2, WDR3, WDR4, WDR5, COSMO, etc.)


I faced some problems with the station WDR5 because the track information was like this: "WDR 5 Quarks - Wissenschaft und mehr mit Sebastian Sonntag". But I were not able to filter strings like this with the following code:
`
Connector.isScrobblingAllowed = () => {
	const artistTrack = Util.getTextFromSelectors(
		Connector.artistTrackSelector,
	);
	const disallowedStrings = [
		'1Live',
		'WDR2',
		'WDR3',
		'WDR4',
		'WDR5',
		'COSMO',
	];

	// Check if the artistTrack includes any of the disallowed strings
	const containsDisallowedString =
		artistTrack !== null &&
		disallowedStrings.some((disallowedString) =>
			artistTrack.includes(disallowedString),
		);

	// Scrobble only if none of the disallowed strings are included
	return !containsDisallowedString;
};
`

Maybe there is a nicer solution...