### PR TITLE
fix for #3893, missing scrobbles on deezer connector

### DIFF
--- a/src/connectors/deezer-dom-inject.ts
+++ b/src/connectors/deezer-dom-inject.ts
@@ -56,9 +56,6 @@ if ('cleanup' in window && typeof window.cleanup === 'function') {
 		const ev = window.Events as Events;
 		ev.subscribe(ev.player.play, sendEvent);
 		ev.subscribe(ev.player.playing, sendEvent);
-		ev.subscribe(ev.player.paused, sendEvent);
-		ev.subscribe(ev.player.resume, sendEvent);
-		ev.subscribe(ev.player.finish, sendEvent);
 		sendEvent();
 	}
 
@@ -69,22 +66,23 @@ if ('cleanup' in window && typeof window.cleanup === 'function') {
 		const ev = window.Events as Events;
 		ev.unsubscribe(ev.player.play, sendEvent);
 		ev.unsubscribe(ev.player.playing, sendEvent);
-		ev.unsubscribe(ev.player.paused, sendEvent);
-		ev.unsubscribe(ev.player.resume, sendEvent);
-		ev.unsubscribe(ev.player.finish, sendEvent);
 	}
 
 	function sendEvent() {
-		window.postMessage(
-			{
-				sender: 'web-scrobbler',
-				type: 'DEEZER_STATE',
-				trackInfo: getCurrentMediaInfo(),
-				isPlaying: isPlaying(),
-				isPodcast: isPodcast(),
-			},
-			'*',
-		);
+		window.setTimeout(() => {
+			const trackInfo = getCurrentMediaInfo();
+			const isitPlaying = isPlaying();
+			window.postMessage(
+				{
+					sender: 'web-scrobbler',
+					type: 'DEEZER_STATE',
+					trackInfo,
+					isPlaying: isitPlaying,
+					isPodcast: isPodcast(),
+				},
+				'*',
+			);
+		}, 1000);			   
 	}
 
 	interface State {
@@ -118,7 +116,7 @@ if ('cleanup' in window && typeof window.cleanup === 'function') {
 		const player = window.dzPlayer as {
 			getCurrentSong: () => Media;
 			getPosition: () => number | null;
-			getDuration: () => number | null;
+			getDuration: () => string;
 		};
 		const currentMedia = player.getCurrentSong();
 
@@ -129,7 +127,7 @@ if ('cleanup' in window && typeof window.cleanup === 'function') {
 
 		const mediaType = currentMedia.__TYPE__;
 		const currentTime = player.getPosition();
-		const duration = player.getDuration();
+		const duration = parseInt(player.getDuration());
 
 		let trackInfo: State | null = null;
 

--- a/src/connectors/deezer-dom-inject.ts
+++ b/src/connectors/deezer-dom-inject.ts
@@ -82,7 +82,7 @@ if ('cleanup' in window && typeof window.cleanup === 'function') {
 				},
 				'*',
 			);
-		}, 1000);			   
+		}, 1000);
 	}
 
 	interface State {

--- a/src/connectors/deezer-dom-inject.ts
+++ b/src/connectors/deezer-dom-inject.ts
@@ -114,11 +114,16 @@ if ('cleanup' in window && typeof window.cleanup === 'function') {
 			return;
 		}
 		const player = window.dzPlayer as {
-			getCurrentSong: () => Media;
+			getCurrentSong: () => Media | null;
 			getPosition: () => number | null;
-			getDuration: () => string;
+			getDuration: () => number | string | null;
 		};
 		const currentMedia = player.getCurrentSong();
+
+		// during initialization the player may not have loaded a media yet
+		if (currentMedia === null) {
+			return null;
+		}
 
 		// Radio stations don't provide track info
 		if (currentMedia.EXTERNAL) {
@@ -127,7 +132,10 @@ if ('cleanup' in window && typeof window.cleanup === 'function') {
 
 		const mediaType = currentMedia.__TYPE__;
 		const currentTime = player.getPosition();
-		const duration = parseInt(player.getDuration());
+		let duration = player.getDuration();
+		if (typeof duration === 'string') {
+			duration = parseInt(duration);
+		}
 
 		let trackInfo: State | null = null;
 
@@ -193,8 +201,14 @@ if ('cleanup' in window && typeof window.cleanup === 'function') {
 			return;
 		}
 		const currentMedia = (
-			window.dzPlayer as { getCurrentSong: () => Media }
+			window.dzPlayer as { getCurrentSong: () => Media | null }
 		).getCurrentSong();
+
+		// during initialization the player may not have loaded a media yet
+		if (currentMedia === null) {
+			return null;
+		}
+
 		return currentMedia.__TYPE__ === 'episode';
 	}
 


### PR DESCRIPTION
The listeners for player.paused, ev.player.resume and player.finish events are removed. They are not needed as the player.playing event is firing in any case and they were causing confusing output when debugging.

When calling window.dzPlayer.getCurrentSong() after a track change the response is holding the metadata of the new track (as expected), but window.dzPlayer.getDuration() is still answering with the duration of the previous track. After a 1 second timeout the duration of the new track is given. So I've added a timeout in sendEvent() so that the correct duration gets send.

Now and then the result of window.dzPlayer.getDuration() is a String and not a Float number as expected. When this happens in the debug-log the parsed.duration will be null and processed.duration will be either null or corrected to the real duration. If both are null scrobbling will happen after 30 seconds. I've added parseInt() for the result of getDuration to fix the problem.

I've checked in current Firefox and Chrome that this fixes the problems with missed scrobbles discussed in https://github.com/web-scrobbler/web-scrobbler/issues/3893