### PR TITLE
Improve popup cover for non-square covers

### DIFF
--- a/src/ui/popup/nowplaying.tsx
+++ b/src/ui/popup/nowplaying.tsx
@@ -121,15 +121,27 @@ export default function NowPlaying(props: { tab: Resource<ManagerTab> }) {
 						}
 						title={t('infoOpenAlbumArt')}
 					>
-						<img
-							class={styles.coverArt}
-							src={
-								song()?.getTrackArt() ??
-								browser.runtime.getURL(
-									'img/cover_art_default.png',
-								)
-							}
-						/>
+						<div
+							class={styles.coverArtBackground}
+							style={{
+								'background-image': `url(${
+									song()?.getTrackArt() ??
+									browser.runtime.getURL(
+										'img/cover_art_default.png',
+									)
+								})`,
+							}}
+						>
+							<img
+								class={styles.coverArt}
+								src={
+									song()?.getTrackArt() ??
+									browser.runtime.getURL(
+										'img/cover_art_default.png',
+									)
+								}
+							/>
+						</div>
 						<Squircle id="coverArtClip" />
 					</PopupLink>
 					<SongDetails

--- a/src/ui/popup/popup.module.scss
+++ b/src/ui/popup/popup.module.scss
@@ -84,6 +84,8 @@ a {
 		height: 10px;
 
 		.coverArt {
+			aspect-ratio: 1 / 1;
+			object-fit: cover;
 			width: 100vh;
 		}
 	}

--- a/src/ui/popup/popup.module.scss
+++ b/src/ui/popup/popup.module.scss
@@ -83,10 +83,15 @@ a {
 		// The entire image still remains clickable link (overflow).
 		height: 10px;
 
-		.coverArt {
-			aspect-ratio: 1 / 1;
-			object-fit: cover;
-			width: 100vh;
+		.coverArtBackground {
+			background-size: cover;
+
+			.coverArt {
+				aspect-ratio: 1 / 1;
+				backdrop-filter: blur(5px);
+				object-fit: contain;
+				width: 100vh;
+			}
 		}
 	}
 


### PR DESCRIPTION
Once again took a clue from eggs enhancement suite in web scrobbler design.
Not sure if this is optimal, but it's at least way better than what we have now.

For wide cover:

Before:
![image](https://github.com/web-scrobbler/web-scrobbler/assets/69117606/3a90c303-0ca1-4931-88df-3787149a8382)

After:
![image](https://github.com/web-scrobbler/web-scrobbler/assets/69117606/262adc5e-a76b-4caa-9325-d6bbf6d02a5f)


For tall cover:

Before: 
![image](https://github.com/web-scrobbler/web-scrobbler/assets/69117606/f7cf1ccc-7c5b-4b37-b98f-ebc8d4772525)

After:
![image](https://github.com/web-scrobbler/web-scrobbler/assets/69117606/ff9c06b9-f1e5-451f-af37-21a435cd07b3)

Square covers look same as before