### PR TITLE
Fix disallow being too aggressive

### DIFF
--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -677,6 +677,14 @@ export default class Controller {
 
 		if (isPlayingStateChanged && isPlaying !== void 0) {
 			this.onPlayingStateChanged(isPlaying);
+		} else if (
+			this.mode === ControllerMode.Disallowed &&
+			this.shouldScrobble() &&
+			isPlaying
+		) {
+			// we need to unset disallowed whenever needed.
+			// this is not necessarily tied to pausing/unpausing
+			this.setSongNowPlaying();
 		}
 	}
 


### PR DESCRIPTION
Notably, on youtube, if a song took too long to load, it would cause the extension to display disallowed until scrobbling, which no longer happens
Don't think there should be any negative effects from this