### PR TITLE
Fix popup loading

### DIFF
--- a/src/ui/popup/main.tsx
+++ b/src/ui/popup/main.tsx
@@ -112,7 +112,11 @@ function Popup() {
 			</Show>
 			<Dynamic
 				component={
-					popupContent[tab()?.mode ?? ControllerMode.Unsupported]
+					popupContent[
+						tab.loading
+							? ControllerMode.Loading
+							: tab()?.mode ?? ControllerMode.Unsupported
+					]
 				}
 			/>
 			<Show


### PR DESCRIPTION
Loading the state of the extension to display popup takes a usually but not always imperceptible amount of time.
#4145 introduced a new fallback to unsupported, which improves extension a bit especially on safari.
However, this was quite jarring when we were loading another popup, because the unsupported popup is quite big, with a lot of content in it.
This makes it so while loading, no content is displayed. This makes the loading less jarring, while still providing the benefit of the unsupported fallback.