### PR TITLE
Add "Use local instance" button

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -179,6 +179,10 @@
         "message": "Sign in",
         "description": "Button label"
     },
+    "accountsUseLocalInstance": {
+        "message": "Use local instance",
+        "description": "Button label"
+    },
     "accountsScrobblerProps": {
         "message": "Properties",
         "description": "Button label"

--- a/src/ui/options/components/accounts.tsx
+++ b/src/ui/options/components/accounts.tsx
@@ -106,6 +106,7 @@ function ScrobblerDisplay(props: { label: ScrobblerLabel }) {
 			return scrobbler.getProfileUrl();
 		}
 	});
+	const [showLocalProps, setShowLocalProps] = createSignal(false);
 
 	const onFocus = async () => {
 		try {
@@ -131,7 +132,13 @@ function ScrobblerDisplay(props: { label: ScrobblerLabel }) {
 	return (
 		<>
 			<h2>{rawScrobbler()?.getLabel()}</h2>
-			<Switch fallback={<SignedOut scrobbler={rawScrobbler()} />}>
+			<Switch
+				fallback={
+					<Show when={!showLocalProps()}>
+						<SignedOut scrobbler={rawScrobbler()} />
+					</Show>
+				}
+			>
 				<Match when={rawScrobbler()?.isLocalOnly}>
 					<Show when={!session.error && session()}>
 						<p>
@@ -173,8 +180,27 @@ function ScrobblerDisplay(props: { label: ScrobblerLabel }) {
 					</div>
 				</Match>
 			</Switch>
-			<Properties scrobbler={rawScrobbler()} />
-			<ArrayProperties scrobbler={rawScrobbler()} />
+			<Switch>
+				<Match
+					when={
+						!showLocalProps() &&
+						!rawScrobbler()?.isLocalOnly &&
+						(labelHasProperties(rawScrobbler()?.getLabel()) ||
+							labelHasArrayProperties(rawScrobbler()?.getLabel()))
+					}
+				>
+					<button
+						class={`${styles.resetButton} ${styles.topSpacing}`}
+						onClick={() => setShowLocalProps(true)}
+					>
+						{t('accountsUseLocalInstance')}
+					</button>
+				</Match>
+				<Match when={showLocalProps() || rawScrobbler()?.isLocalOnly}>
+					<Properties scrobbler={rawScrobbler()} />
+					<ArrayProperties scrobbler={rawScrobbler()} />
+				</Match>
+			</Switch>
 		</>
 	);
 }

--- a/src/ui/options/components/components.module.scss
+++ b/src/ui/options/components/components.module.scss
@@ -513,3 +513,7 @@ summary {
 		transition: transform 600ms ease-in-out;
 	}
 }
+
+.topSpacing {
+	margin-top: 0.5em;
+}


### PR DESCRIPTION
I have seen people struggle with the listenbrainz signin process before because of the lack of separation between listenbrainz.org and custom instance signin.
This makes that separation clearer.
This only affects listenbrainz currently, but it's not tied to just listenbrainz, just any scrobbler that has both a main instance and a custom instance option.

![localsignin](https://github.com/web-scrobbler/web-scrobbler/assets/69117606/a2efc137-776c-4e62-84c0-c5bc7e483314)
