### PR TITLE
Apply album artist when processing metadata

### DIFF
--- a/src/core/object/pipeline/metadata.ts
+++ b/src/core/object/pipeline/metadata.ts
@@ -60,7 +60,9 @@ export async function process(
 			}
 
 			if (!song.getAlbum() || song.flags.isAlbumFetched) {
+				song.processed.albumArtist = songInfo.albumArtist;
 				song.processed.album = songInfo.album;
+				song.noRegex.albumArtist = songInfo.albumArtist;
 				song.noRegex.album = songInfo.album;
 				song.flags.isAlbumFetched = true;
 			}

--- a/src/core/scrobbler/base-scrobbler.ts
+++ b/src/core/scrobbler/base-scrobbler.ts
@@ -36,6 +36,7 @@ export interface ScrobblerSongInfo {
 	trackArtUrl?: string;
 
 	album?: string;
+	albumArtist?: string;
 	albumUrl?: string;
 	albumMbId?: string;
 

--- a/src/core/scrobbler/lastfm/lastfm-scrobbler.ts
+++ b/src/core/scrobbler/lastfm/lastfm-scrobbler.ts
@@ -137,6 +137,7 @@ export default class LastFmScrobbler extends AudioScrobbler {
 
 		if (albumInfo) {
 			songInfo.album = albumInfo.title;
+			songInfo.albumArtist = albumInfo.artist;
 			songInfo.albumUrl = albumInfo.url;
 			songInfo.albumMbId = albumInfo.mbid;
 


### PR DESCRIPTION
This makes sure you're scrobbling the right album artist instead of the album artist always being set to the same artist as the current song, which is problematic when you're scrobbling a track that's in an album released as a 'Various Artists' album.

**Describe the changes you made**
I made sure the album artist is getting put as the album artist when an album is getting autofilled.

**Additional context**
Here's a before and after:
https://imgur.com/a/NA9NPVB
