### PR TITLE
Revert deep cut id change

### DIFF
--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -1671,7 +1671,7 @@ export default <ConnectorMeta[]>[
 			'*://deep-cut.fm/*',
 		],
 		js: 'deep-cut.fm.js',
-		id: 'deep-cut.fm',
+		id: 'deepcut.fm',
 	},
 	{
 		label: 'Burntable',


### PR DESCRIPTION
Changed in #4277 which should not be mutated to avoid any data for that connector.