### PR TITLE
Bandcamp mobile view support

### DIFF
--- a/src/connectors/bandcamp.ts
+++ b/src/connectors/bandcamp.ts
@@ -21,12 +21,36 @@ let bandcampFilter = MetadataFilter.createFilter(
 	),
 );
 
-setupConnector();
+if (document.querySelector('main#p-tralbum-page') === null) {
+	setupDesktopConnector();
+} else {
+	setupMobileConnector();
+}
 
-/**
- * Entry point.
- */
-function setupConnector() {
+function setupMobileConnector() {
+	Connector.playerSelector = '#player';
+
+	Connector.isPlaying = () =>
+		document.querySelector('.playbutton.playing') !== null;
+
+	Connector.artistSelector = '.tralbum-artist';
+
+	Connector.albumArtistSelector = '.tralbum-artist';
+
+	Connector.trackSelector = '.current-track > span:nth-child(2)';
+
+	Connector.albumSelector = '.tralbum-name';
+
+	Connector.durationSelector = '.duration-text';
+
+	Connector.currentTimeSelector = '.progress-text';
+
+	Connector.trackArtSelector = '#tralbum-art-carousel img';
+
+	Connector.getOriginUrl = () => document.location.href.split('?')[0];
+}
+
+function setupDesktopConnector() {
 	initEventListeners();
 	initGenericProperties();
 


### PR DESCRIPTION
**Describe the changes you made**

Bandcamp has a very different mobile view on Album pages.

e.g. https://milieumusic.bandcamp.com/album/aurora-borealis-night-currents if you open this with mobile debugger settings it returns a completely different experience.

Currently doesnt handle all the edgecases and code could be made more reusable for some aspects.
