### PR TITLE
fix byte.fm connector

### DIFF
--- a/src/connectors/byte.fm.ts
+++ b/src/connectors/byte.fm.ts
@@ -5,6 +5,6 @@ Connector.playerSelector = '.player';
 Connector.artistTrackSelector = '.player-current-title';
 
 Connector.isPlaying = () =>
-	Util.getTextFromSelectors('.player-play-button') !== 'play';
+	Util.getTextFromSelectors('.player-play-button>span') !== 'play';
 
 Connector.onReady = Connector.onStateChanged;


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->

The byte.fm connector did not detect the stopped/playing state correctly. Therefore scrobbling was also active while being in "stopped" mode.

The state text is inside an invisible <span>.

Now, with the modified selector, the text is extracted correctly.

**Additional context**
<!-- Add any other context or screenshots here. -->
