### PR TITLE
Fix RadioJavan connector

### DIFF
--- a/src/connectors/radiojavan.ts
+++ b/src/connectors/radiojavan.ts
@@ -1,22 +1,22 @@
 export {};
 
-Connector.artistSelector = '.mainPanel .artist';
+const PLAY_ICON =
+	'M28.228 18.327L12.205 27.31c-.99.555-2.205-.17-2.205-1.318V8.008c0-1.146 1.215-1.873 2.205-1.317l16.023 8.982c1.029.577 1.029 2.077 0 2.654z';
 
-Connector.albumSelector = '.mainPanel .album';
+Connector.playerSelector = 'main';
 
-Connector.trackSelector = '.mainPanel .song';
+Connector.artistSelector =
+	'.items-start.truncate > div > div:nth-child(2) > p > span > a';
 
-Connector.playButtonSelector = '#mp3_play .musicPlay';
+Connector.trackSelector =
+	'.items-start.truncate > div > div:nth-child(1) > div > p > a';
 
-Connector.currentTimeSelector = '#mp3_position';
+Connector.currentTimeSelector = 'div.pr-2.-mb-1 > p';
 
-Connector.durationSelector = '#mp3_duration';
+Connector.trackArtSelector = 'div.w-16.h-16 > a > div > div > img';
 
-Connector.trackArtSelector = '.mainPanel .artwork > img';
-
-new MutationObserver(Connector.onStateChanged).observe(document, {
-	childList: true,
-	subtree: true,
-	attributes: true,
-	characterData: true,
-});
+Connector.isPlaying = () =>
+	Util.getAttrFromSelectors(
+		'.items-center > button:nth-child(3) > svg > path',
+		'd',
+	) !== PLAY_ICON;

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -1242,7 +1242,7 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'RadioJavan',
-		matches: ['*://www.radiojavan.com/*'],
+		matches: ['*://play.radiojavan.com/*'],
 		js: 'radiojavan.js',
 		id: 'radiojavan',
 	},


### PR DESCRIPTION
**Describe the changes you made**
Closes: #4144 

**Additional context**
They using `disable-devtool`, which adds problem to connector developing.
Script below removes these restrictions.
```js
// ==UserScript==
// @name        RJ: Bypass disable-devtool
// @namespace   rj-bypass-disable-devtool
// @match       https://play.radiojavan.com/*
// @grant       none
// @version     1.0
// @run-at      document-start
// ==/UserScript==

(function () {
  "use strict";

  Object.assign = new Proxy(Object.assign, {
    apply(target, thisArg, argumentsList) {
      const [, obj] = argumentsList;
      if (obj && "isDevToolOpened" in obj) {
        return Reflect.apply(target, thisArg, [
          {},
          { isDevToolOpened: () => false, ignore: () => true },
        ]);
      }
      return Reflect.apply(target, thisArg, argumentsList);
    },
  });
})();


```