### PR TITLE
New FMSpins.com Connector

### DIFF
--- a/src/connectors/fmspins.ts
+++ b/src/connectors/fmspins.ts
@@ -1,0 +1,7 @@
+export {};
+
+Connector.playerSelector = '#main';
+Connector.artistSelector = '#current-spins .list-group-item.spin:first-child .artist a';
+Connector.trackSelector = '#current-spins .list-group-item.spin:first-child .track a';
+Connector.trackArtSelector = '#current-spins .list-group-item.spin:first-child';
+Connector.playButtonSelector = '.actions .fa-play';

--- a/src/connectors/fmspins.ts
+++ b/src/connectors/fmspins.ts
@@ -1,7 +1,9 @@
 export {};
 
 Connector.playerSelector = '#main';
-Connector.artistSelector = '#current-spins .list-group-item.spin:first-child .artist a';
-Connector.trackSelector = '#current-spins .list-group-item.spin:first-child .track a';
+Connector.artistSelector =
+	'#current-spins .list-group-item.spin:first-child .artist a';
+Connector.trackSelector =
+	'#current-spins .list-group-item.spin:first-child .track a';
 Connector.trackArtSelector = '#current-spins .list-group-item.spin:first-child';
 Connector.playButtonSelector = '.actions .fa-play';

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2237,4 +2237,10 @@ export default <ConnectorMeta[]>[
 		js: 'wdr.js',
 		id: 'wdr',
 	},
+	{
+		label: 'FMSpins',
+		matches: ['*://*.fmspins.com/*'],
+		js: 'fmspins.js',
+		id: 'fmspins',
+	},
 ];


### PR DESCRIPTION
New website that allows you to play indie/college radio stations [KEXP](https://kexp.org), [KCRW](https://www.kcrw.com/), [WFUV](https://wfuv.org/) (though the data from this one seems broken), [KUTX](https://kutx.org/), [WXPN](https://xpn.org/) and [KUSF](http://www.kusf.org/). 

The scrobbling data is pulled in via API I believe, so there's a bit of a delay, but seems to be otherwise quite solid. I've found the KEXP connector in the past to sometimes be a bit flaky (the JS to change the song doesn't seem to change unless the tab is in focus), so having a solid second option for listening to that station is great.


![image](https://github.com/web-scrobbler/web-scrobbler/assets/2962327/cac8dd95-56f5-419f-b78f-b3ef16ce49e5)
![image](https://github.com/web-scrobbler/web-scrobbler/assets/2962327/4ca05f1e-52c5-4f2c-be35-c86f185559ef)
