### PR TITLE
KEXP connector - Added filter to replace "smart" quotes with plain

### DIFF
--- a/src/connectors/kexp.ts
+++ b/src/connectors/kexp.ts
@@ -1,5 +1,11 @@
 export {};
 
+const filter = MetadataFilter.createFilter({
+	artist: replaceSmartQuotes,
+	track: replaceSmartQuotes,
+	album: replaceSmartQuotes,
+});
+
 Connector.playerSelector = '.Player';
 
 Connector.artistTrackSelector = '.Player-title';
@@ -12,3 +18,9 @@ Connector.isTrackArtDefault = (url) => url?.includes('default');
 
 Connector.isPlaying = () =>
 	Util.hasElementClass(Connector.playerSelector, 'Player--playing');
+
+Connector.applyFilter(filter);
+
+function replaceSmartQuotes(text: string) {
+	return text.replace(/[\u2018\u2019]/g, "'").replace(/[\u201c\u201d]/g, '"');
+}


### PR DESCRIPTION
Added filter function to replace "smart" quotes with plain quotes.  Filter function copied from #3548.

The KEXP website often uses right single apostrophes ("smart" quotes) instead of plain apostrophes.  On Last.fm, tags with right single apostrophes are treated as separate pages which is often the less common tag.

playlist with right single apostrophe
![image](https://github.com/web-scrobbler/web-scrobbler/assets/8346050/e98812af-569c-4758-b557-1d29ef2f1157)

plain apostrophe
![image](https://github.com/web-scrobbler/web-scrobbler/assets/8346050/86982ac7-df71-460c-9f66-9a52c9f20ddf)

right single apostrophe
![image](https://github.com/web-scrobbler/web-scrobbler/assets/8346050/0589c676-b615-4b86-9d6d-5cde773a9183)


