### PR TITLE
Fix scrobble percent option

### DIFF
--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -3,6 +3,7 @@ import * as Options from '@/core/storage/options';
 import {
 	areAllResults,
 	DebugLogType,
+	parseScrobblePercent,
 	getSecondsToScrobble,
 	isAnyResult,
 } from '@/util/util';
@@ -876,13 +877,11 @@ export default class Controller {
 			return;
 		}
 
-		const percent = await Options.getOption(
+		const rawPercent = await Options.getOption(
 			Options.SCROBBLE_PERCENT,
 			this.connector.meta.id,
 		);
-		if (typeof percent !== 'number') {
-			return;
-		}
+		const percent = parseScrobblePercent(rawPercent);
 
 		const secondsToScrobble = getSecondsToScrobble(duration, percent);
 

--- a/src/core/storage/options.ts
+++ b/src/core/storage/options.ts
@@ -1,6 +1,7 @@
 import connectors, { ConnectorMeta } from '@/core/connectors';
 import * as BrowserStorage from '@/core/storage/browser-storage';
 import { debugLog } from '../content/util';
+import { DEFAULT_SCROBBLE_PERCENT } from '@/util/util';
 
 const options = BrowserStorage.getStorage(BrowserStorage.OPTIONS);
 const connectorsOptions = BrowserStorage.getStorage(
@@ -87,7 +88,7 @@ const DEFAULT_OPTIONS: GlobalOptions = {
 	[SCROBBLE_RECOGNIZED_TRACKS]: true,
 	[SCROBBLE_EDITED_TRACKS_ONLY]: false,
 	[DEBUG_LOGGING_ENABLED]: false,
-	[SCROBBLE_PERCENT]: 50,
+	[SCROBBLE_PERCENT]: DEFAULT_SCROBBLE_PERCENT,
 	[USE_INFOBOX]: true,
 	[DISABLED_CONNECTORS]: {},
 };

--- a/src/ui/options/components/inputs.tsx
+++ b/src/ui/options/components/inputs.tsx
@@ -324,7 +324,7 @@ export function RangeOptionEntry(props: {
 						}
 						const newOptions = {
 							...o,
-							[key]: e.currentTarget.value,
+							[key]: parseInt(e.currentTarget.value),
 						};
 						return newOptions;
 					});
@@ -338,7 +338,7 @@ export function RangeOptionEntry(props: {
 						}
 						const newOptions = {
 							...o,
-							[key]: e.currentTarget.value,
+							[key]: parseInt(e.currentTarget.value),
 						};
 						globalOptions.set(newOptions);
 						return newOptions;

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -27,6 +27,12 @@ export const HIDDEN_PLACEHOLDER = '[hidden]';
 export const DEFAULT_SCROBBLE_TIME = 30;
 
 /**
+ * Percentage of track to playback before the track is scrobbled.
+ * This value is used only if scrobble percent storage is somehow corrupted.
+ */
+export const DEFAULT_SCROBBLE_PERCENT = 50;
+
+/**
  * Minimum number of seconds of scrobbleable track.
  */
 export const MIN_TRACK_DURATION = 30;
@@ -52,6 +58,22 @@ export function debugLog(text: unknown, logType: DebugLogType = 'log'): void {
 
 	/* istanbul ignore next */
 	logFunc(text);
+}
+
+/**
+ * Narrow the typing of scrobble percent.
+ * Fallback to default if scrobble percent is not a number.
+ *
+ * @param percent - Scrobble percent value from settings
+ * @returns percentage of track to play before scrobbling
+ */
+export function parseScrobblePercent(percent: unknown): number {
+	return percent &&
+		typeof percent === 'number' &&
+		!isNaN(percent) &&
+		isFinite(percent)
+		? percent
+		: DEFAULT_SCROBBLE_PERCENT;
 }
 
 /**


### PR DESCRIPTION
An issue caused scrobble percent value to be corrupted if set using the range slider.
Fixes this by parsing integer.
Also ensures graceful fallback for any issues related to corrupted scrobble percent values by falling back to default if it is somehow not a number.