### PR TITLE
Get custom ID from URL if possible on YouTube Music

### DIFF
--- a/src/connectors/youtube-music.ts
+++ b/src/connectors/youtube-music.ts
@@ -104,12 +104,14 @@ Connector.isPlaying = () => {
 };
 
 Connector.getUniqueID = () => {
-	const videoUrl = Util.getAttrFromSelectors('.yt-uix-sessionlink', 'href');
+	const uniqueId = new URLSearchParams(window.location.search).get('v');
 
-	if (videoUrl) {
-		return Util.getYtVideoIdFromUrl(videoUrl);
+	if (uniqueId) {
+		return uniqueId;
 	}
-	return null;
+
+	const videoUrl = Util.getAttrFromSelectors('.yt-uix-sessionlink', 'href');
+	return Util.getYtVideoIdFromUrl(videoUrl);
 };
 
 Connector.isScrobblingAllowed = () => !Util.isElementVisible(adSelector);


### PR DESCRIPTION
**Describe the changes you made**

Changes the YouTube Music connector to get the custom ID from the current page URL if possible, and only then falls back to searching the page for it. This helps with #4342, but is not an entire fix as it doesn't work when the user is not on the video view.

**Additional context**

I've also experimented with a way of fixing this while the user is in another view, however since sometimes the current video ID is no longer found in the DOM at all I resorted to opening the current track's context menu and extracting it from the "Start radio" button that is then rendered. Reason I have not included it in this PR is that I don't think any other connector automatically interacts with the page beyond reading it, and I'd like to get some feedback on whether the maintainers oppose it doing so first.