### PR TITLE
Add notification when first scrobbling site with built-in scrobbler

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -867,6 +867,14 @@
         "message": "Click the notification to connect your accounts.",
         "description": "Notification text"
     },
+    "notificationNativeScrobbler": {
+      "message": "$1 has a built-in scrobbler!",
+      "description": "Notification title, $1 denotes the name of the website."
+    },
+    "notificationNativeScrobblerText": {
+        "message": "Make sure to turn off either Web Scrobbler or the built-in scrobbler!",
+        "description": "Notification text"
+    },
     "notificationAuthError": {
         "message": "Authentication error",
         "description": "Notification title"

--- a/src/core/background/scrobble.ts
+++ b/src/core/background/scrobble.ts
@@ -1,3 +1,4 @@
+import { showNativeScrobblerWarning } from '@/util/notifications';
 import ClonedSong from '../object/cloned-song';
 import scrobbleService from '../object/scrobble-service';
 import { ServiceCallResult } from '../object/service-call-result';
@@ -8,6 +9,7 @@ export async function sendNowPlaying(
 	song: BaseSong,
 ): Promise<ServiceCallResult[]> {
 	await scrobbleService.bindAllScrobblers();
+	void showNativeScrobblerWarning(song.connector);
 	return scrobbleService.sendNowPlaying(song);
 }
 

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -9,6 +9,11 @@ export interface ConnectorMeta {
 	 * true if connector uses blocklist. Connector must implement {@link Connector.getChannelId}
 	 */
 	usesBlocklist?: true;
+
+	/**
+	 * true if website has its own scrobbling system the user needs to be aware of.
+	 */
+	hasNativeScrobbler?: true;
 }
 
 export default <ConnectorMeta[]>[
@@ -125,6 +130,7 @@ export default <ConnectorMeta[]>[
 		matches: ['*://open.spotify.com/*'],
 		js: 'spotify.js',
 		id: 'spotify',
+		hasNativeScrobbler: true,
 	},
 	{
 		label: 'plug.dj',

--- a/src/core/object/cloned-song.ts
+++ b/src/core/object/cloned-song.ts
@@ -7,6 +7,7 @@ import {
 	ParsedSongData,
 	ProcessedSongData,
 } from './song';
+import { ConnectorMeta } from '../connectors';
 
 /**
  * This class is used to create a song object from a cloned song.
@@ -17,8 +18,7 @@ export default class ClonedSong extends BaseSong {
 	public noRegex: ProcessedSongData;
 	public flags: Flags;
 	public metadata: Metadata;
-	public connectorLabel: string;
-	public connectorId: string;
+	public connector: ConnectorMeta;
 	public controllerTabId: number;
 
 	constructor(song: CloneableSong, controllerTabId: number) {
@@ -28,8 +28,7 @@ export default class ClonedSong extends BaseSong {
 		this.noRegex = song.noRegex;
 		this.flags = song.flags;
 		this.metadata = song.metadata;
-		this.connectorLabel = song.connectorLabel;
-		this.connectorId = song.connectorId;
+		this.connector = song.connector;
 		this.controllerTabId = controllerTabId;
 	}
 

--- a/src/core/object/song.ts
+++ b/src/core/object/song.ts
@@ -59,8 +59,7 @@ export interface CloneableSong {
 	noRegex: ProcessedSongData;
 	flags: Flags;
 	metadata: Metadata;
-	connectorLabel: string;
-	connectorId: string;
+	connector: ConnectorMeta;
 }
 
 export abstract class BaseSong {
@@ -69,8 +68,7 @@ export abstract class BaseSong {
 	public abstract noRegex: ProcessedSongData;
 	public abstract flags: Flags;
 	public abstract metadata: Metadata;
-	public abstract connectorLabel: string;
-	public abstract connectorId: string;
+	public abstract connector: ConnectorMeta;
 
 	/**
 	 * Get song artist.
@@ -227,8 +225,7 @@ export abstract class BaseSong {
 			processed: this.processed,
 			metadata: this.metadata,
 			flags: this.flags,
-			connectorLabel: this.connectorLabel,
-			connectorId: this.connectorId,
+			connector: this.connector,
 		};
 	}
 
@@ -304,8 +301,7 @@ export default class Song extends BaseSong {
 	public noRegex: ProcessedSongData;
 	public flags: Flags;
 	public metadata: Metadata;
-	public connectorLabel: string;
-	public connectorId: string;
+	public connector: ConnectorMeta;
 	/**
 	 * @param parsedData - Current state received from connector
 	 * @param connector - Connector match object
@@ -368,8 +364,7 @@ export default class Song extends BaseSong {
 			/* Filled in `initMetadata` method */
 		};
 
-		this.connectorLabel = connector.label;
-		this.connectorId = connector.id;
+		this.connector = connector;
 
 		this.initSongData();
 	}
@@ -452,7 +447,7 @@ export default class Song extends BaseSong {
 			 */
 			startTimestamp: Math.floor(Date.now() / 1000),
 
-			label: this.connectorLabel,
+			label: this.connector.label,
 		};
 	}
 

--- a/src/core/storage/browser-storage.ts
+++ b/src/core/storage/browser-storage.ts
@@ -63,6 +63,12 @@ export const NOTIFICATIONS = 'Notifications';
 export const LOCAL_CACHE = 'LocalCache';
 
 /**
+ * This storage contains the list of websites with native scrobbling
+ * for which a notification has already been sent to the user before.
+ */
+export const NATIVE_SCROBBLER_NOTIFICATION = 'NativeScrobblerNotification';
+
+/**
  * This storage contains the blocklist of each connector.
  * Each blocklist is an object with channel IDs as keys.
  */
@@ -135,6 +141,7 @@ const storageTypeMap = {
 	Webhook: LOCAL,
 	Pleroma: LOCAL,
 
+	[NATIVE_SCROBBLER_NOTIFICATION]: LOCAL,
 	[BLOCKLISTS]: LOCAL,
 	[LOCAL_CACHE]: LOCAL,
 	[REGEX_EDITS]: LOCAL,

--- a/src/core/storage/native-scrobbler-notification.ts
+++ b/src/core/storage/native-scrobbler-notification.ts
@@ -28,11 +28,8 @@ export default class NativeScrobblerNotification {
 	 * @returns true if notification has not been given for connector; false otherwise
 	 */
 	public async shouldNotifyAboutNativeScrobbler(
-		id: string | undefined | null,
+		id: string,
 	): Promise<boolean> {
-		if (!id) {
-			return false;
-		}
 		const data = await this.storage.get();
 		if (!data) {
 			return true;

--- a/src/core/storage/native-scrobbler-notification.ts
+++ b/src/core/storage/native-scrobbler-notification.ts
@@ -1,0 +1,42 @@
+import * as BrowserStorage from '@/core/storage/browser-storage';
+
+export default class NativeScrobblerNotification {
+	private storage = BrowserStorage.getStorage(
+		BrowserStorage.NATIVE_SCROBBLER_NOTIFICATION,
+	);
+
+	/**
+	 * Add connector ID to list of connectors that has been notified about.
+	 *
+	 * @param id - ID of connector to add
+	 */
+	public async saveHasNotified(id: string): Promise<void> {
+		if (!id) {
+			return;
+		}
+		let data = await this.storage.getLocking();
+		if (!data) {
+			data = {};
+		}
+		data[id] = true;
+		await this.storage.setLocking(data);
+	}
+
+	/**
+	 * @param id - ID of connector to check
+	 *
+	 * @returns true if notification has not been given for connector; false otherwise
+	 */
+	public async shouldNotifyAboutNativeScrobbler(
+		id: string | undefined | null,
+	): Promise<boolean> {
+		if (!id) {
+			return false;
+		}
+		const data = await this.storage.get();
+		if (!data) {
+			return true;
+		}
+		return !data[id];
+	}
+}

--- a/src/core/storage/wrapper.ts
+++ b/src/core/storage/wrapper.ts
@@ -13,6 +13,7 @@ import {
 	STATE_MANAGEMENT,
 	StorageNamespace,
 	BLOCKLISTS,
+	NATIVE_SCROBBLER_NOTIFICATION,
 } from '@/core/storage/browser-storage';
 import {
 	ConnectorOptions,
@@ -109,6 +110,9 @@ export interface DataModels extends ScrobblerModels {
 		[key: number]: {
 			[key in (typeof connectors)[number]['id']]: true;
 		};
+	};
+	[NATIVE_SCROBBLER_NOTIFICATION]: {
+		[key in (typeof connectors)[number]['id']]: true;
 	};
 }
 

--- a/src/ui/popup/nowplaying.tsx
+++ b/src/ui/popup/nowplaying.tsx
@@ -320,7 +320,7 @@ function TrackMetadata(props: { song: Accessor<ClonedSong | null> }) {
 				<LastFMIcon />
 				{props.song()?.metadata.userPlayCount || 0}
 			</PopupLink>
-			<span class={styles.label}>{props.song()?.connectorLabel}</span>
+			<span class={styles.label}>{props.song()?.connector.label}</span>
 		</div>
 	);
 }

--- a/tests/background/connectors.test.ts
+++ b/tests/background/connectors.test.ts
@@ -8,6 +8,7 @@ import * as UrlMatch from '@/util/url-match';
 
 const PROP_TYPES: {
 	usesBlocklist: 'boolean';
+	hasNativeScrobbler: 'boolean';
 	allFrames: 'boolean';
 	matches: 'array';
 	label: 'string';
@@ -15,6 +16,7 @@ const PROP_TYPES: {
 	id: 'string';
 } = {
 	usesBlocklist: 'boolean',
+	hasNativeScrobbler: 'boolean',
 	allFrames: 'boolean',
 	matches: 'array',
 	label: 'string',


### PR DESCRIPTION
When first playing on a site with built-in scrobbler, a notification is shown to the user to make them aware.
Notification shows when a song actually starts playing, not on visit.
Notification will show only once per website and then be disabled through new local storage property.

Currently only enabled for spotify, but I'm sure there are more sites.
A site having a built-in scrobbler is denoted using new hasNativeScrobbler property in connectors.ts

To accomodate this change, the song types have been changed to have a new property connector: ConnectorMeta.
song.connectorLabel and song.connectorId have been removed, since they are made obsolete by song.connector.

<img width="351" alt="image" src="https://github.com/web-scrobbler/web-scrobbler/assets/69117606/104d08e2-a129-46bd-a853-f5c3956f7889">

Closes #1375 