### PR TITLE
Add ability to love songs through listening services

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -47,6 +47,14 @@
         "message": "Scrobble podcast episodes",
         "description": "Option title"
     },
+    "optionAutoToggleLove": {
+        "message": "Love/unlove tracks through players",
+        "description": "Option label"
+    },
+    "optionAutoToggleLoveTitle": {
+        "message": "When you like or dislike a track on a website, the track will also be loved/unloved in your scrobbler",
+        "description": "Option label"
+    },
     "optionDebugLoggingEnabled": {
         "message": "Enable debug logging",
         "description": "Option label"

--- a/src/connectors/spotify.ts
+++ b/src/connectors/spotify.ts
@@ -45,6 +45,8 @@ Connector.getUniqueID = () => getTrackUri();
 
 Connector.getOriginUrl = () => getTrackUrl();
 
+Connector.loveButtonSelector = `${playerBar} button[data-testid="add-button"][aria-checked="false"]`;
+
 function isMusicPlaying() {
 	return artistUrlIncludes('/artist/', '/show/') || isLocalFilePlaying();
 }

--- a/src/connectors/youtube.ts
+++ b/src/connectors/youtube.ts
@@ -93,6 +93,9 @@ Connector.scrobbleInfoStyle = {
 	fontWeight: '700',
 };
 
+Connector.loveButtonSelector =
+	'ytd-watch-metadata like-button-view-model button[aria-pressed="false"]';
+
 Connector.getChannelId = () =>
 	new URL(
 		(

--- a/src/core/content/connector.ts
+++ b/src/core/content/connector.ts
@@ -646,16 +646,22 @@ export default class BaseConnector {
 	/**
 	 * Callback set by the controller to listen on state changes of this connector.
 	 */
-	private _isLovedCallback: ((isLoved: boolean | null) => void) | null = null;
+	private _isLovedCallback:
+		| ((isLoved: boolean | null) => Promise<void>)
+		| null = null;
 
 	/**
 	 * Callback set by the controller to listen on state changes of this connector.
 	 */
-	public get isLovedCallback(): ((isLoved: boolean | null) => void) | null {
+	public get isLovedCallback():
+		| ((isLoved: boolean | null) => Promise<void>)
+		| null {
 		return this._isLovedCallback;
 	}
 
-	public set isLovedCallback(callback: (isLoved: boolean | null) => void) {
+	public set isLovedCallback(
+		callback: (isLoved: boolean | null) => Promise<void>,
+	) {
 		callback(this.isLoved() ?? null);
 		this._isLovedCallback = callback;
 	}

--- a/src/core/content/connector.ts
+++ b/src/core/content/connector.ts
@@ -373,6 +373,35 @@ export default class BaseConnector {
 	) => boolean | null | undefined = () => false;
 
 	/**
+	 * Button to love/like a song on listening service.
+	 */
+	public loveButtonSelector: string | string[] | null = null;
+
+	/**
+	 * Button to unlove/unlike a song on listening service.
+	 */
+	public unloveButtonSelector: string | string[] | null = null;
+
+	/**
+	 * A check to see if song is loved or not.
+	 * If this changes from false to true or vice-versa the song
+	 * will be loved/unloved on scrobbling services.
+	 *
+	 * @returns True if song is liked; false otherwise
+	 */
+	public isLoved: () => boolean | null | undefined = () => {
+		if (this.loveButtonSelector) {
+			return !Util.isElementVisible(this.loveButtonSelector);
+		}
+
+		if (this.unloveButtonSelector) {
+			return Util.isElementVisible(this.unloveButtonSelector);
+		}
+
+		return null;
+	};
+
+	/**
 	 * Default implementation of a check to see if a state change is allowed.
 	 * MutationObserver will ignore mutations while this function returns false.
 	 *
@@ -615,6 +644,23 @@ export default class BaseConnector {
 	}
 
 	/**
+	 * Callback set by the controller to listen on state changes of this connector.
+	 */
+	private _isLovedCallback: ((isLoved: boolean | null) => void) | null = null;
+
+	/**
+	 * Callback set by the controller to listen on state changes of this connector.
+	 */
+	public get isLovedCallback(): ((isLoved: boolean | null) => void) | null {
+		return this._isLovedCallback;
+	}
+
+	public set isLovedCallback(callback: (isLoved: boolean | null) => void) {
+		callback(this.isLoved() ?? null);
+		this._isLovedCallback = callback;
+	}
+
+	/**
 	 * Function for all the hard work around detecting and updating state.
 	 */
 	private stateChangedWorker: () => void;
@@ -779,6 +825,12 @@ export default class BaseConnector {
 				}
 				// #v-endif
 			}
+
+			/**
+			 * Finally, handle state change to isLoved,
+			 * which is completely independent of other state.
+			 */
+			this.isLovedCallback?.(this.isLoved() ?? null);
 		};
 
 		this.getCurrentState = () => {

--- a/src/core/content/starter.ts
+++ b/src/core/content/starter.ts
@@ -93,6 +93,7 @@ async function setupStateListening(): Promise<void> {
 function createController(isEnabled: boolean) {
 	const controller = new Controller(Connector, isEnabled);
 	Connector.controllerCallback = controller.onStateChanged.bind(controller);
+	Connector.isLovedCallback = controller.onLoveChanged.bind(controller);
 }
 
 /**

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -605,7 +605,7 @@ export default class Controller {
 		}
 
 		/**
-		 * song already had fetched a definitive loved state,
+		 * Song already had fetched a definitive loved state,
 		 * and this one is different.
 		 * This means user has actively changed it.
 		 * Change if option suggests so.

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -568,6 +568,60 @@ export default class Controller {
 	}
 
 	/**
+	 * React on love/unlove.
+	 * @param isLoved - Whether song is now liked or unliked
+	 */
+	async onLoveChanged(isLoved: boolean | null): Promise<void> {
+		if (!this.currentSong) {
+			return;
+		}
+
+		/**
+		 * If there has not been definitive state before,
+		 * just change state without sending anything to service.
+		 * We dont want the extension to randomly unlove songs
+		 * on scrobbling service because user didnt do it on
+		 * streaming service.
+		 */
+		if (this.currentSong.flags.isLovedInService === null) {
+			this.currentSong.flags.isLovedInService = isLoved;
+			return;
+		}
+
+		/**
+		 * If suddenly we are not receiving definitive state anymore
+		 * be safe and reset the isloved state
+		 */
+		if (isLoved === null) {
+			this.currentSong.flags.isLovedInService = null;
+			return;
+		}
+
+		/**
+		 * State did not change, don't do anything.
+		 */
+		if (this.currentSong.flags.isLovedInService === isLoved) {
+			return;
+		}
+
+		/**
+		 * song already had fetched a definitive loved state,
+		 * and this one is different.
+		 * This means user has actively changed it.
+		 * Change if option suggests so.
+		 */
+		this.currentSong.flags.isLovedInService = isLoved;
+		if (
+			await Options.getOption(
+				Options.AUTO_TOGGLE_LOVE,
+				this.connector.meta.id,
+			)
+		) {
+			this.toggleLove(isLoved);
+		}
+	}
+
+	/**
 	 * React on state change.
 	 * @param newState - State of connector
 	 */

--- a/src/core/object/song.ts
+++ b/src/core/object/song.ts
@@ -34,6 +34,7 @@ export type Flags =
 			isMarkedAsPlaying: boolean;
 			isSkipped: boolean;
 			isReplaying: boolean;
+			isLovedInService: boolean | null;
 	  }
 	| Record<string, never>;
 
@@ -432,6 +433,14 @@ export default class Song extends BaseSong {
 			 * Flag means song is replaying again.
 			 */
 			isReplaying: false,
+
+			/**
+			 * Flag means song has been liked/loved in the scrobbling service.
+			 * Is null until value has been read from the service page.
+			 * This is because we do not want to do anything when first setting from page,
+			 * but we do want to do something if the value changes afterwards.
+			 */
+			isLovedInService: null,
 		};
 	}
 

--- a/src/core/storage/options.ts
+++ b/src/core/storage/options.ts
@@ -16,6 +16,7 @@ export const USE_UNRECOGNIZED_SONG_NOTIFICATIONS =
 	'useUnrecognizedSongNotifications';
 export const USE_INFOBOX = 'showInfobox';
 export const SCROBBLE_PODCASTS = 'scrobblePodcasts';
+export const AUTO_TOGGLE_LOVE = 'autoToggleLove';
 export const FORCE_RECOGNIZE = 'forceRecognize';
 export const SCROBBLE_RECOGNIZED_TRACKS = 'scrobbleRecognizedTracks';
 export const SCROBBLE_EDITED_TRACKS_ONLY = 'scrobbleEditedTracksOnly';
@@ -75,6 +76,11 @@ export interface GlobalOptions {
 	 * Allow debug messages to be logged to the browser console.
 	 */
 	[DEBUG_LOGGING_ENABLED]: boolean;
+
+	/**
+	 * Automatically toggle love on scrobbling service when doing so on website.
+	 */
+	[AUTO_TOGGLE_LOVE]: boolean;
 }
 
 /**
@@ -90,6 +96,7 @@ const DEFAULT_OPTIONS: GlobalOptions = {
 	[DEBUG_LOGGING_ENABLED]: false,
 	[SCROBBLE_PERCENT]: DEFAULT_SCROBBLE_PERCENT,
 	[USE_INFOBOX]: true,
+	[AUTO_TOGGLE_LOVE]: true,
 	[DISABLED_CONNECTORS]: {},
 };
 
@@ -101,6 +108,7 @@ const OVERRIDE_CONTENT = {
 	[USE_NOTIFICATIONS]: true,
 	[USE_UNRECOGNIZED_SONG_NOTIFICATIONS]: false,
 	[USE_INFOBOX]: true,
+	[AUTO_TOGGLE_LOVE]: true,
 };
 
 export interface ConnectorOptions {
@@ -129,6 +137,7 @@ export interface ConnectorsOverrideOptionValues {
 	[USE_NOTIFICATIONS]?: boolean;
 	[USE_INFOBOX]?: boolean;
 	[SCROBBLE_PODCASTS]?: boolean;
+	[AUTO_TOGGLE_LOVE]?: boolean;
 	[USE_UNRECOGNIZED_SONG_NOTIFICATIONS]?: boolean;
 	[SCROBBLE_RECOGNIZED_TRACKS]?: boolean;
 	[SCROBBLE_EDITED_TRACKS_ONLY]?: boolean;

--- a/src/ui/options/components/connector-override.tsx
+++ b/src/ui/options/components/connector-override.tsx
@@ -252,6 +252,16 @@ function ConnectorOverrideOptionDetails(props: {
 					setOverrideOptions={setOverrideOptions}
 					connectorOverrideOptions={connectorOverrideOptions}
 				/>
+				<ConnectorTripleCheckbox
+					title={t('optionAutoToggleLoveTitle')}
+					label={t('optionAutoToggleLove')}
+					connector={props.connector}
+					option={Options.AUTO_TOGGLE_LOVE}
+					overrideOptions={overrideOptions}
+					setOverrideOptions={setOverrideOptions}
+					connectorOverrideOptions={connectorOverrideOptions}
+				/>
+
 				<h3 id={`${props.connector.id}-scrobble-behavior`}>
 					{t('optionsScrobbleBehavior')}
 				</h3>

--- a/src/ui/options/components/options/global-options.tsx
+++ b/src/ui/options/components/options/global-options.tsx
@@ -65,6 +65,14 @@ export default function GlobalOptionsList(props: {
 					i18nlabel="optionScrobblePodcasts"
 					key={Options.SCROBBLE_PODCASTS}
 				/>
+				<GlobalOptionEntry
+					options={props.options}
+					setOptions={props.setOptions}
+					globalOptions={globalOptions}
+					i18ntitle="optionAutoToggleLoveTitle"
+					i18nlabel="optionAutoToggleLove"
+					key={Options.AUTO_TOGGLE_LOVE}
+				/>
 			</ul>
 		</>
 	);


### PR DESCRIPTION
Closes #1424 
Really dont know about these labels in options, I think they can be improved a lot.
Adds properties to connector:
`Connector.isLoved`: function that returns true/false/nullish for whether a song is loved on website or not.
`Connector.loveButtonSelector`: selector or selectors for love/like button. When this is visible the song is interpreted as not loved.
`Connector.unloveButtonSelector`: selector or selectors for unlove/unlike button. When this is visible the song is interpreted as loved.

Only one of these three should be specified in any given connector similar to play/pause button selectors and isplaying function.

Property has been implemented to youtube and spotify connectors so far, but I think we could do with a few more. You can see how it works in practice though in those connector implementations.