### PR TITLE
Ignore yarn.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ coverage/
 
 # Cache
 .eslintcache
+
+# Yarn
+yarn.lock
+


### PR DESCRIPTION
**Describe the changes you made**
One of the edits @yayuyokitano made in PR 3908 was to remove `yarn.lock`, so I figured it might be ideal to just add it to `.gitignore`.