### PR TITLE
Fix isScrobblingAllowed logic for BiliBili

### DIFF
--- a/src/connectors/bilibili.ts
+++ b/src/connectors/bilibili.ts
@@ -204,7 +204,8 @@ Connector.isScrobblingAllowed = () => {
 		if (!tags.includes('音乐')) {
 			return false;
 		}
-	} else if (useScrobbleTagFilter) {
+	}
+	if (useScrobbleTagFilter) {
 		if (tags.some((tag) => isIncludeElems(tag, tagFilterKeyWords))) {
 			return false;
 		}


### PR DESCRIPTION
## changes I made
I've corrected the logic for determining whether to scrobble a video on BiliBili. 
The `tagFilterKeyWords` should always being used when `useScrobbleTagFilter` is true. However, in the previous code, it wasn't when there was a '音乐' (which means music) tag.

## example
When a video is tagged ['音乐','音乐教学'] (which means ['music', 'music tutorial']), it would be scrobbled, but actually it shouldn't be. This pull request fixes that issue."