### PR TITLE
Fix youtube connector

### DIFF
--- a/src/connectors/youtube.ts
+++ b/src/connectors/youtube.ts
@@ -1,4 +1,4 @@
-import type { TrackInfoWithAlbum } from '@/core/types';
+import type { ArtistTrackInfo, TrackInfoWithAlbum } from '@/core/types';
 
 export {};
 
@@ -30,6 +30,7 @@ const channelNameSelector = [
 	'.slim-owner-channel-name .yt-core-attributed-string',
 ];
 const videoDescriptionSelector = [
+	'#description.ytd-expandable-video-description-body-renderer',
 	'#meta-contents #description',
 	'.crawler-full-description',
 ];
@@ -74,7 +75,12 @@ const getTrackInfoFromYoutubeMusicCache: {
 	};
 } = {};
 
-const trackInfoGetters = [
+const trackInfoGetters: (() =>
+	| ArtistTrackInfo
+	| null
+	| undefined
+	| Record<string, never>
+	| TrackInfoWithAlbum)[] = [
 	getTrackInfoFromChapters,
 	getTrackInfoFromYoutubeMusic,
 	getTrackInfoFromDescription,
@@ -134,6 +140,10 @@ Connector.getTrackInfo = () => {
 
 		if (!trackInfo.track) {
 			trackInfo.track = currentTrackInfo.track;
+		}
+
+		if (!trackInfo.album && 'album' in currentTrackInfo) {
+			trackInfo.album = currentTrackInfo.album;
 		}
 
 		if (!Util.isArtistTrackEmpty(trackInfo)) {
@@ -354,7 +364,7 @@ async function readConnectorOptions() {
 }
 
 function getVideoDescription() {
-	return Util.getTextFromSelectors(videoDescriptionSelector);
+	return Util.getTextFromSelectors(videoDescriptionSelector)?.trim() ?? null;
 }
 
 function getTrackInfoFromDescription() {
@@ -369,7 +379,10 @@ function getTrackInfoFromDescription() {
 	return artistTrackFromDescription;
 }
 
-function getTrackInfoFromYoutubeMusic() {
+function getTrackInfoFromYoutubeMusic():
+	| ArtistTrackInfo
+	| Record<string, never>
+	| undefined {
 	// if neither getTrackInfoFromYtMusicEnabled nor scrobbleMusicRecognisedOnly
 	// are enabled, there is no need to run this getter
 	if (!getTrackInfoFromYtMusicEnabled && !scrobbleMusicRecognisedOnly) {
@@ -482,7 +495,7 @@ function getTrackInfoFromChapters() {
 	return artistTrack;
 }
 
-function getTrackInfoFromTitle() {
+function getTrackInfoFromTitle(): ArtistTrackInfo {
 	let { artist, track } = Util.processYtVideoTitle(
 		Util.getTextFromSelectors(videoTitleSelector),
 	);


### PR DESCRIPTION
Closes #4309 
Closes #4240 
Closes #4044 
Closes #4476 

Also, it does not seem that we were ever actually applying album from description, even though we had logic to fetch it, even in V2, so I did add that since it seems like that was intended.

I have kept old stuff in as well, as it seems that there is a gradual rollout, hence why this has been hard for me to reproduce.