### PR TITLE
 Notify if user loved/unloved song via hotkey

### DIFF
--- a/scripts/generate-icons.ts
+++ b/scripts/generate-icons.ts
@@ -103,6 +103,14 @@ const monochromeColors = {
 		light: '#d51107',
 		dark: '#fc3434',
 	},
+	'action_loved.svg': {
+		light: '#d51107',
+		dark: '#fc3434',
+	},
+	'action_unloved.svg': {
+		light: '#d51107',
+		dark: '#fc3434',
+	},
 };
 
 /**

--- a/src/core/background/main.ts
+++ b/src/core/background/main.ts
@@ -77,6 +77,7 @@ browser.commands?.onCommand.addListener(
  */
 async function commandHandler(command: string) {
 	const tab = await getCurrentTab();
+	const alreadyLoved = tab.song?.metadata.userloved;
 
 	switch (command) {
 		case 'toggle-connector':
@@ -87,10 +88,18 @@ async function commandHandler(command: string) {
 			}
 			break;
 		case 'love-song':
-			setLoveStatus(tab.tabId, true, true);
+			// only set love status if song is not yet loved, ignore if song is already loved
+			// only send notification when song is unloved but will be loved
+			if (!alreadyLoved) {
+				setLoveStatus(tab.tabId, true, true);
+			}
 			break;
 		case 'unlove-song':
-			setLoveStatus(tab.tabId, false, true);
+			// only set unlove status if song is loved, ignore if song is unloved
+			// only send notification when song is loved but will be unloved
+			if (alreadyLoved) {
+				setLoveStatus(tab.tabId, false, true);
+			}
 			break;
 	}
 }
@@ -100,7 +109,7 @@ async function commandHandler(command: string) {
  *
  * @param tabId	- Tab ID of the tab to update
  * @param isLoved - Whether the song is loved
- * @param shouldShowNotification - Whether the song is (un)loved by hotkey command
+ * @param shouldShowNotification - Whether the song should show notification when (un)loved
  *
  */
 function setLoveStatus(

--- a/src/core/background/main.ts
+++ b/src/core/background/main.ts
@@ -87,10 +87,10 @@ async function commandHandler(command: string) {
 			}
 			break;
 		case 'love-song':
-			setLoveStatus(tab.tabId, true);
+			setLoveStatus(tab.tabId, true, true);
 			break;
 		case 'unlove-song':
-			setLoveStatus(tab.tabId, false);
+			setLoveStatus(tab.tabId, false, true);
 			break;
 	}
 }
@@ -100,13 +100,15 @@ async function commandHandler(command: string) {
  *
  * @param tabId	- Tab ID of the tab to update
  * @param isLoved - Whether the song is loved
+ * @param isCommand - Whether the song is (un)loved by hotkey command
  *
  */
-function setLoveStatus(tabId: number, isLoved: boolean) {
+function setLoveStatus(tabId: number, isLoved: boolean, isCommand: boolean) {
 	sendBackgroundMessage(tabId ?? -1, {
 		type: 'toggleLove',
 		payload: {
 			isLoved,
+			isCommand: true,
 		},
 	});
 }
@@ -413,7 +415,9 @@ setupBackgroundListeners(
 		type: 'toggleLove',
 		fn: (payload, sender) => {
 			const song = new ClonedSong(payload.song, sender.tab?.id ?? -1);
-			showLovedNotification(song, payload.isLoved);
+			if (payload.isCommand) {
+				showLovedNotification(song, payload.isLoved);
+			}
 			return toggleLove(song, payload.isLoved);
 		},
 	}),

--- a/src/core/background/main.ts
+++ b/src/core/background/main.ts
@@ -32,6 +32,7 @@ import { CloneableSong } from '@/core/object/song';
 import {
 	clearNowPlaying,
 	showAuthNotification,
+	showLovedNotification,
 	showNowPlaying,
 	showSongNotRecognized,
 } from '@/util/notifications';
@@ -411,10 +412,9 @@ setupBackgroundListeners(
 	backgroundListener({
 		type: 'toggleLove',
 		fn: (payload, sender) => {
-			return toggleLove(
-				new ClonedSong(payload.song, sender.tab?.id ?? -1),
-				payload.isLoved,
-			);
+			const song = new ClonedSong(payload.song, sender.tab?.id ?? -1);
+			showLovedNotification(song, payload.isLoved);
+			return toggleLove(song, payload.isLoved);
 		},
 	}),
 

--- a/src/core/background/main.ts
+++ b/src/core/background/main.ts
@@ -100,15 +100,19 @@ async function commandHandler(command: string) {
  *
  * @param tabId	- Tab ID of the tab to update
  * @param isLoved - Whether the song is loved
- * @param isCommand - Whether the song is (un)loved by hotkey command
+ * @param shouldShowNotification - Whether the song is (un)loved by hotkey command
  *
  */
-function setLoveStatus(tabId: number, isLoved: boolean, isCommand: boolean) {
+function setLoveStatus(
+	tabId: number,
+	isLoved: boolean,
+	shouldShowNotification: boolean,
+) {
 	sendBackgroundMessage(tabId ?? -1, {
 		type: 'toggleLove',
 		payload: {
 			isLoved,
-			isCommand: true,
+			shouldShowNotification,
 		},
 	});
 }
@@ -415,7 +419,7 @@ setupBackgroundListeners(
 		type: 'toggleLove',
 		fn: (payload, sender) => {
 			const song = new ClonedSong(payload.song, sender.tab?.id ?? -1);
-			if (payload.isCommand) {
+			if (payload.shouldShowNotification) {
 				showLovedNotification(song, payload.isLoved);
 			}
 			return toggleLove(song, payload.isLoved);

--- a/src/core/object/controller/controller-mode.ts
+++ b/src/core/object/controller/controller-mode.ts
@@ -57,3 +57,13 @@ export const Unknown = 'Unknown';
  * Site is unsupported.
  */
 export const Unsupported = 'Unsupported';
+
+/**
+ * A user loved a song.
+ */
+export const Loved = 'Loved';
+
+/**
+ * A user unloved a song.
+ */
+export const Unloved = 'Unloved';

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -658,6 +658,16 @@ export default class Controller {
 				this.connector.meta.id,
 			)
 		) {
+			if (
+				// do not show notification if:
+				// 1. song is already loved and is being toggled to love status
+				// 2. song is already unloved and is being toggled to unlove status
+				(this.currentSong.metadata.userloved === true && isLoved) ||
+				(this.currentSong.metadata.userloved === false && !isLoved)
+			) {
+				return;
+			}
+			// do send notification if song has not yet been (un)loved toggled yet
 			this.toggleLove(isLoved, true);
 		}
 	}

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -257,8 +257,8 @@ export default class Controller {
 			}),
 			contentListener({
 				type: 'toggleLove',
-				fn: ({ isLoved, isCommand }) => {
-					this.toggleLove(isLoved, isCommand);
+				fn: ({ isLoved, shouldShowNotification }) => {
+					this.toggleLove(isLoved, shouldShowNotification);
 				},
 			}),
 			contentListener({
@@ -575,9 +575,12 @@ export default class Controller {
 	/**
 	 * Send request to love or unlove current song.
 	 * @param isLoved - Flag indicated song is loved
-	 * @param isCommand - Flag indicating hotkey command was used
+	 * @param shouldShowNotification - Flag indicating that a notification should show up
 	 */
-	async toggleLove(isLoved: boolean, isCommand: boolean): Promise<void> {
+	async toggleLove(
+		isLoved: boolean,
+		shouldShowNotification: boolean,
+	): Promise<void> {
 		this.assertSongIsPlaying();
 		if (!assertSongNotNull(this.currentSong)) {
 			return;
@@ -595,7 +598,7 @@ export default class Controller {
 				payload: {
 					song: this.currentSong.getCloneableData(),
 					isLoved,
-					isCommand,
+					shouldShowNotification,
 				},
 			});
 		} catch (err) {

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -658,7 +658,7 @@ export default class Controller {
 				this.connector.meta.id,
 			)
 		) {
-			this.toggleLove(isLoved);
+			this.toggleLove(isLoved, true);
 		}
 	}
 

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -257,8 +257,8 @@ export default class Controller {
 			}),
 			contentListener({
 				type: 'toggleLove',
-				fn: ({ isLoved }) => {
-					this.toggleLove(isLoved);
+				fn: ({ isLoved, isCommand }) => {
+					this.toggleLove(isLoved, isCommand);
 				},
 			}),
 			contentListener({
@@ -575,13 +575,13 @@ export default class Controller {
 	/**
 	 * Send request to love or unlove current song.
 	 * @param isLoved - Flag indicated song is loved
+	 * @param isCommand - Flag indicating hotkey command was used
 	 */
-	async toggleLove(isLoved: boolean): Promise<void> {
+	async toggleLove(isLoved: boolean, isCommand: boolean): Promise<void> {
 		this.assertSongIsPlaying();
 		if (!assertSongNotNull(this.currentSong)) {
 			return;
 		}
-
 		if (!this.currentSong.isValid()) {
 			throw new Error('No valid song is now playing');
 		}
@@ -595,6 +595,7 @@ export default class Controller {
 				payload: {
 					song: this.currentSong.getCloneableData(),
 					isLoved,
+					isCommand,
 				},
 			});
 		} catch (err) {

--- a/src/icons/monochrome/action_loved.svg
+++ b/src/icons/monochrome/action_loved.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge  css-c1sh5i"
+   focusable="false"
+   aria-hidden="true"
+   viewBox="0 0 24 24"
+   data-testid="FavoriteIcon"
+   aria-label="fontSize large"
+   version="1.1"
+   id="svg480"
+   sodipodi:docname="action_loved.svg"
+   inkscape:version="1.2.2 (b0a84865, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs484" />
+  <sodipodi:namedview
+     id="namedview482"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-width="1309"
+     inkscape:window-height="456"
+     inkscape:window-x="71"
+     inkscape:window-y="131"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg480" />
+  <path
+     d="M 12,23.01 10.26,21.426 C 4.08,15.822 0,12.126 0,7.59 0,3.894 2.904,0.99 6.6,0.99 c 2.088,0 4.092,0.972 5.4,2.508 1.308,-1.536 3.312,-2.508 5.4,-2.508 3.696,0 6.6,2.904 6.6,6.6 0,4.536 -4.08,8.232 -10.26,13.848 z"
+     id="path478"
+     style="stroke-width:1.2" />
+</svg>

--- a/src/icons/monochrome/action_unloved.svg
+++ b/src/icons/monochrome/action_unloved.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge  css-c1sh5i"
+   focusable="false"
+   aria-hidden="true"
+   viewBox="0 0 24 24"
+   data-testid="HeartBrokenIcon"
+   aria-label="fontSize large"
+   version="1.1"
+   id="svg663"
+   sodipodi:docname="action_unloved.svg"
+   inkscape:version="1.2.2 (b0a84865, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs667" />
+  <sodipodi:namedview
+     id="namedview665"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-width="1309"
+     inkscape:window-height="456"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg663" />
+  <path
+     d="m 17.4,1.2 c -1.152,0 -2.28,0.3 -3.276,0.828 L 12,8.4 h 3.6 L 12,20.4 13.2,9.6 H 9.6 L 11.448,3.132 C 10.164,1.932 8.412,1.2 6.6,1.2 2.904,1.2 0,4.104 0,7.8 c 0,4.956 4.992,8.616 12,15 6.564,-5.928 12,-9.912 12,-15 0,-3.696 -2.904,-6.6 -6.6,-6.6"
+     id="path661"
+     style="stroke-width:1.2" />
+</svg>

--- a/src/ui/popup/main.tsx
+++ b/src/ui/popup/main.tsx
@@ -51,6 +51,8 @@ const contextMenuModes = [
 	ControllerMode.Scrobbled,
 	ControllerMode.Loading,
 	ControllerMode.Unknown,
+	ControllerMode.Loved,
+	ControllerMode.Unloved,
 ];
 
 /**
@@ -94,6 +96,8 @@ function Popup() {
 		[ControllerMode.Paused]: () => <NowPlaying tab={tab} />,
 		[ControllerMode.Skipped]: () => <NowPlaying tab={tab} />,
 		[ControllerMode.Scrobbled]: () => <NowPlaying tab={tab} />,
+		[ControllerMode.Loved]: () => <NowPlaying tab={tab} />,
+		[ControllerMode.Unloved]: () => <NowPlaying tab={tab} />,
 		[ControllerMode.Disallowed]: () => <Disallowed tab={tab} />,
 		[ControllerMode.Unknown]: () => <Edit tab={tab} />,
 		[ControllerMode.Unsupported]: () => <Unsupported />,

--- a/src/ui/popup/nowplaying.tsx
+++ b/src/ui/popup/nowplaying.tsx
@@ -486,6 +486,7 @@ function toggleLove(
 		type: 'toggleLove',
 		payload: {
 			isLoved: !song()?.metadata.userloved,
+			isCommand: false,
 		},
 	});
 }

--- a/src/ui/popup/nowplaying.tsx
+++ b/src/ui/popup/nowplaying.tsx
@@ -486,7 +486,7 @@ function toggleLove(
 		type: 'toggleLove',
 		payload: {
 			isLoved: !song()?.metadata.userloved,
-			isCommand: false,
+			shouldShowNotification: false,
 		},
 	});
 }

--- a/src/util/communication.ts
+++ b/src/util/communication.ts
@@ -91,7 +91,7 @@ interface ContentCommunications {
 		payload: {
 			song: CloneableSong;
 			isLoved: boolean;
-			isCommand: boolean;
+			shouldShowNotification: boolean;
 		};
 		response: Promise<(ServiceCallResult | Record<string, never>)[]>;
 	};
@@ -129,7 +129,7 @@ interface BackgroundCommunications {
 	toggleLove: {
 		payload: {
 			isLoved: boolean;
-			isCommand: boolean;
+			shouldShowNotification: boolean;
 		};
 		response: void;
 	};

--- a/src/util/communication.ts
+++ b/src/util/communication.ts
@@ -91,6 +91,7 @@ interface ContentCommunications {
 		payload: {
 			song: CloneableSong;
 			isLoved: boolean;
+			isCommand: boolean;
 		};
 		response: Promise<(ServiceCallResult | Record<string, never>)[]>;
 	};
@@ -128,6 +129,7 @@ interface BackgroundCommunications {
 	toggleLove: {
 		payload: {
 			isLoved: boolean;
+			isCommand: boolean;
 		};
 		response: void;
 	};

--- a/src/util/notifications.ts
+++ b/src/util/notifications.ts
@@ -8,6 +8,7 @@ import { Scrobbler } from '@/core/object/scrobble-service';
 import { debugLog } from '@/core/content/util';
 import * as BrowserStorage from '@/core/storage/browser-storage';
 import NativeScrobblerNotification from '@/core/storage/native-scrobbler-notification';
+import { Console } from 'console';
 
 /**
  * Notification service.
@@ -415,6 +416,10 @@ export async function showLovedNotification(
 	song: BaseSong,
 	isLoved: boolean,
 ): Promise<void> {
+	if (!(await isAllowed(song.connector))) {
+		return;
+	}
+
 	const iconUrl = song.getTrackArt() || defaultTrackArtUrl;
 	const message = `${song.getTrack()}\n${song.getArtist()}`;
 

--- a/src/util/notifications.ts
+++ b/src/util/notifications.ts
@@ -407,7 +407,7 @@ export async function showAuthNotification(): Promise<void> {
 }
 
 /**
- * Show 'Loved'/'Unloved' notification when song is love/unlove toggled by a custom hotkey.
+ * Show 'Loved'/'Unloved' notification when song is love/unlove toggled.
  * @param song - Copy of song isntance
  * @param isLoved - whether a song is loved or not
  */

--- a/src/util/notifications.ts
+++ b/src/util/notifications.ts
@@ -407,6 +407,42 @@ export async function showAuthNotification(): Promise<void> {
 }
 
 /**
+ * Show 'Loved' notification when song is love toggled by a custom hotkey.
+ * @param song - Copy of song isntance
+ * @param isLoved - whether a song is loved or not
+ */
+export async function showLovedNotification(
+	song: BaseSong,
+	isLoved: boolean,
+): Promise<void> {
+	// Don't show notification if extension popup is open
+	const windows = browser.extension.getViews();
+
+	for (const extensionWindow of windows) {
+		if (extensionWindow.location.href.includes('popup')) {
+			return;
+		}
+	}
+
+	// TODO: i18n
+	// TODO: firefox/chrome/edge/safari specific formatting?
+	const title = isLoved ? 'Loved' : 'Unloved';
+	const iconUrl = song.getTrackArt() || defaultTrackArtUrl;
+
+	const options = {
+		iconUrl,
+		title,
+		message: `${song.getTrack()}\n${song.getArtist()}`,
+	};
+	try {
+		await showNotification(options, null);
+	} catch (err) {
+		debugLog('Unable to show loved notification: ', 'warn');
+		debugLog(err, 'warn');
+	}
+}
+
+/**
  * Completely remove notification.
  * Do nothing if ID does not match any existing notification.
  *

--- a/src/util/notifications.ts
+++ b/src/util/notifications.ts
@@ -415,12 +415,10 @@ export async function showLovedNotification(
 	song: BaseSong,
 	isLoved: boolean,
 ): Promise<void> {
-	// TODO: i18n
-	// TODO: firefox/chrome/edge/safari specific formatting?
 	const iconUrl = song.getTrackArt() || defaultTrackArtUrl;
-	let message = `${song.getTrack()}\n${song.getArtist()}`;
+	const message = `${song.getTrack()}\n${song.getArtist()}`;
 
-	let title = isLoved
+	const title = isLoved
 		? browser.i18n.getMessage('pageActionLoved', message)
 		: browser.i18n.getMessage('pageActionUnloved', message);
 	const options = {

--- a/src/util/notifications.ts
+++ b/src/util/notifications.ts
@@ -8,7 +8,6 @@ import { Scrobbler } from '@/core/object/scrobble-service';
 import { debugLog } from '@/core/content/util';
 import * as BrowserStorage from '@/core/storage/browser-storage';
 import NativeScrobblerNotification from '@/core/storage/native-scrobbler-notification';
-import { Console } from 'console';
 
 /**
  * Notification service.
@@ -416,6 +415,7 @@ export async function showLovedNotification(
 	song: BaseSong,
 	isLoved: boolean,
 ): Promise<void> {
+	// do not show the notification when user has them disabled
 	if (!(await isAllowed(song.connector))) {
 		return;
 	}

--- a/src/util/notifications.ts
+++ b/src/util/notifications.ts
@@ -407,7 +407,7 @@ export async function showAuthNotification(): Promise<void> {
 }
 
 /**
- * Show 'Loved' notification when song is love toggled by a custom hotkey.
+ * Show 'Loved'/'Unloved' notification when song is love/unlove toggled by a custom hotkey.
  * @param song - Copy of song isntance
  * @param isLoved - whether a song is loved or not
  */
@@ -415,24 +415,18 @@ export async function showLovedNotification(
 	song: BaseSong,
 	isLoved: boolean,
 ): Promise<void> {
-	// Don't show notification if extension popup is open
-	const windows = browser.extension.getViews();
-
-	for (const extensionWindow of windows) {
-		if (extensionWindow.location.href.includes('popup')) {
-			return;
-		}
-	}
-
 	// TODO: i18n
 	// TODO: firefox/chrome/edge/safari specific formatting?
-	const title = isLoved ? 'Loved' : 'Unloved';
 	const iconUrl = song.getTrackArt() || defaultTrackArtUrl;
+	let message = `${song.getTrack()}\n${song.getArtist()}`;
 
+	let title = isLoved
+		? browser.i18n.getMessage('pageActionLoved', message)
+		: browser.i18n.getMessage('pageActionUnloved', message);
 	const options = {
 		iconUrl,
 		title,
-		message: `${song.getTrack()}\n${song.getArtist()}`,
+		message,
 	};
 	try {
 		await showNotification(options, null);


### PR DESCRIPTION
This PR addresses this issue: https://github.com/web-scrobbler/web-scrobbler/issues/4374

**Describe the changes you made**
-Added functionality to show a popup notification when a song is loved or unloved through user defined hotkeys. 
-Noticing that hotkeys went through the `commandHandler` function in main.ts, I added an `isCommand` parameter to `setLoveStatus`, backgroundListeners, contentListeners, contentCommunications, backgroundCommunications.
-In `nowplaying.ts`, `isCommand` is set as false as that's the extension popup UI.
- Change icon to loved/unloved when song is loved/unloved toggled through the scrobble service (https://github.com/web-scrobbler/web-scrobbler/pull/4437) or through hotkeys, then is reset to default state.

**Additional context**
While I can run the extension on Windows Chrome and Firefox, I can't seem to do so on Safari. The extension does build, but the instructions to add the extension to Safari doesn't work: after I right click and open or double click, it appears for a microsecond then disappears with no extension added. My mac is an older model so it's limited to Catalina 10.15 and to XCode12.4, so that could be a reason why it's not working. 
Edit: (February 6) still unable to test on Mac/Safari.