### PR TITLE
Disables fetching from coverartarchive if scrobbling is disabled

### DIFF
--- a/src/core/object/pipeline/coverartarchive/coverartarchive.ts
+++ b/src/core/object/pipeline/coverartarchive/coverartarchive.ts
@@ -28,6 +28,12 @@ export async function process(song: Song): Promise<void> {
 		let mbId = song.metadata.albumMbId;
 		let coverArtUrl = null;
 
+		// If scrobbling is disabled for this song/site, don't try to fetch cover art as it would never be viewed.
+		if (!song.parsed.isScrobblingAllowed) {
+			debugLog('Scrobbling is not allowed, skipping cover art');
+			return;
+		}
+
 		try {
 			if (!mbId) {
 				mbId = await getMusicBrainzId(endpoint, song);


### PR DESCRIPTION
**Describe the changes you made**
I disabled fetching cover art from the Cover Art Archive if scrobbling is disabled, as you wouldn't see the art anyway.

**Additional context**
Closes https://github.com/web-scrobbler/web-scrobbler/issues/4474
