### PR TITLE
Don't typecheck connectors at build time

### DIFF
--- a/scripts/compile-connectors.ts
+++ b/scripts/compile-connectors.ts
@@ -13,7 +13,7 @@ import chokidar from 'chokidar';
 function generateConnectors() {
 	return new Promise<void>((resolve, reject) => {
 		exec(
-			'esbuild src/connectors/*.ts --bundle --outdir=build/connectorraw',
+			'esbuild src/connectors/*.ts --bundle --outdir=build/connectorraw --tsconfig=tsconfig.connectors.json',
 			(err, stdout, stderr) => {
 				if (err) {
 					colorLog(err, 'error');

--- a/scripts/compile-connectors.ts
+++ b/scripts/compile-connectors.ts
@@ -13,7 +13,7 @@ import chokidar from 'chokidar';
 function generateConnectors() {
 	return new Promise<void>((resolve, reject) => {
 		exec(
-			'tsc --project tsconfig.connectors.json',
+			'esbuild src/connectors/*.ts --bundle --outdir=build/connectorraw',
 			(err, stdout, stderr) => {
 				if (err) {
 					colorLog(err, 'error');
@@ -27,7 +27,7 @@ function generateConnectors() {
 				try {
 					fs.removeSync(`build/${getBrowser()}/connectors`);
 					fs.moveSync(
-						'build/connectorraw/connectors',
+						'build/connectorraw',
 						`build/${getBrowser()}/connectors`,
 					);
 					fs.removeSync('build/connectorraw');


### PR DESCRIPTION
Builds connectors using esbuild instead of tsc, ignoring typechecking.
I am seeing build speed increases of ~40% on my end from ~5s to ~3s (~2s when hot reloading)
Typechecking is still handled by checkts, and presumably by the developers IDE.
At this point the bottleneck of builds seems to be compressing images, which I don't know if we can do anything about (maybe we can entirely drop it in dev build reload for further speed increase when hot reloading?)