### PR TITLE
Tidy build script naming + typo

### DIFF
--- a/scripts/compile-connectors.ts
+++ b/scripts/compile-connectors.ts
@@ -8,7 +8,7 @@ import chokidar from 'chokidar';
 /**
  * Sends the actual command to typescript to compile connectors, and places them where they should be.
  *
- * @returns A promise that resolves when the conenctors are compiled
+ * @returns A promise that resolves when the connectors are compiled
  */
 function generateConnectors() {
 	return new Promise<void>((resolve, reject) => {

--- a/scripts/minify-images.ts
+++ b/scripts/minify-images.ts
@@ -27,7 +27,7 @@ async function performMinification() {
  */
 export default function minifyImages(): PluginOption {
 	return {
-		name: 'compile-connectors',
+		name: 'minify-images',
 		buildEnd: async () => {
 			await performMinification();
 			colorLog('Finished image minification', 'success');


### PR DESCRIPTION
Fix typo and build script naming