### PR TITLE
Skip image compression on dev builds

### DIFF
--- a/scripts/compile-connectors.ts
+++ b/scripts/compile-connectors.ts
@@ -13,7 +13,7 @@ import chokidar from 'chokidar';
 function generateConnectors() {
 	return new Promise<void>((resolve, reject) => {
 		exec(
-			'tsc --project tsconfig.connectors.json',
+			'esbuild src/connectors/*.ts --bundle --outdir=build/connectorraw',
 			(err, stdout, stderr) => {
 				if (err) {
 					colorLog(err, 'error');
@@ -27,7 +27,7 @@ function generateConnectors() {
 				try {
 					fs.removeSync(`build/${getBrowser()}/connectors`);
 					fs.moveSync(
-						'build/connectorraw/connectors',
+						'build/connectorraw',
 						`build/${getBrowser()}/connectors`,
 					);
 					fs.removeSync('build/connectorraw');

--- a/scripts/minify-images.ts
+++ b/scripts/minify-images.ts
@@ -25,10 +25,17 @@ async function performMinification() {
 /**
  * Vite plugin that minifies images then move them to the right place
  */
-export default function minifyImages(): PluginOption {
+export default function minifyImages(options: {
+	isDev: boolean;
+}): PluginOption {
 	return {
 		name: 'compile-connectors',
 		buildEnd: async () => {
+			if (options.isDev) {
+				colorLog('Skipping image minification for dev build', 'info');
+				return;
+			}
+
 			await performMinification();
 			colorLog('Finished image minification', 'success');
 		},

--- a/vite.configs.ts
+++ b/vite.configs.ts
@@ -112,6 +112,6 @@ export const buildStart: UserConfig = {
 			isDev: isDev(),
 			watchDirectory: 'src/connectors/*',
 		}),
-		minifyImages(),
+		minifyImages({ isDev: isDev() }),
 	],
 };


### PR DESCRIPTION
Improves build times for dev builds considerably.
We don't need to care about bundle size on dev builds, so this is a complete waste of time.
Depends on #4479 