### PR TITLE
Add album guessing options

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -63,6 +63,34 @@
         "message": "Allow the extension to log debug messages to the browser console",
         "description": "Option title"
     },
+    "optionsAlbumGuessing": {
+        "message": "Album guessing",
+        "description": "'Album guessing' section"
+    },
+    "optionAlbumGuessingDisabled": {
+        "message": "Disable album guessing",
+        "description": "Option label"
+    },
+    "optionAlbumGuessingDisabledTitle": {
+        "message": "Web Scrobbler will not guess the album title of any track",
+        "description": "Option title"
+    },
+    "optionAlbumGuessingUneditedOnly": {
+        "message": "Only guess album for unedited tracks (default)",
+        "description": "Option label"
+    },
+    "optionAlbumGuessingUneditedOnlyTitle": {
+        "message": "Web Scrobbler will only guess the album title of unedited tracks. Tracks with only bulk edits applied will still have album guessed",
+        "description": "Option title"
+    },
+    "optionAlbumGuessingAllTracks": {
+        "message": "Guess album title for all tracks",
+        "description": "Option label"
+    },
+    "optionAlbumGuessingAllTracksTitle": {
+        "message": "Web Scrobbler will guess the album title of all albumless tracks including edited ones",
+        "description": "Option title"
+    },
     "optionsScrobbleBehavior": {
         "message": "Scrobble behavior",
         "description": "'Scrobble behavior' section"

--- a/src/core/storage/options.ts
+++ b/src/core/storage/options.ts
@@ -23,6 +23,9 @@ export const SCROBBLE_EDITED_TRACKS_ONLY = 'scrobbleEditedTracksOnly';
 export const SCROBBLE_PERCENT = 'scrobblePercent';
 export const DISABLED_CONNECTORS = 'disabledConnectors';
 export const DEBUG_LOGGING_ENABLED = 'debugLoggingEnabled';
+export const ALBUM_GUESSING_DISABLED = 'albumGuessingDisabled';
+export const ALBUM_GUESSING_UNEDITED_ONLY = 'albumGuessingUneditedOnly';
+export const ALBUM_GUESSING_ALL_TRACKS = 'albumGuessingAllTracks';
 
 export interface GlobalOptions {
 	/**
@@ -81,6 +84,21 @@ export interface GlobalOptions {
 	 * Automatically toggle love on scrobbling service when doing so on website.
 	 */
 	[AUTO_TOGGLE_LOVE]: boolean;
+
+	/**
+	 * Disable guessing of albums
+	 */
+	[ALBUM_GUESSING_DISABLED]: boolean;
+
+	/**
+	 * Only guess albums of unedited tracks
+	 */
+	[ALBUM_GUESSING_UNEDITED_ONLY]: boolean;
+
+	/**
+	 * Guess albums for all albumless tracks including edited ones
+	 */
+	[ALBUM_GUESSING_ALL_TRACKS]: boolean;
 }
 
 /**
@@ -97,6 +115,9 @@ const DEFAULT_OPTIONS: GlobalOptions = {
 	[SCROBBLE_PERCENT]: DEFAULT_SCROBBLE_PERCENT,
 	[USE_INFOBOX]: true,
 	[AUTO_TOGGLE_LOVE]: true,
+	[ALBUM_GUESSING_DISABLED]: false,
+	[ALBUM_GUESSING_UNEDITED_ONLY]: true,
+	[ALBUM_GUESSING_ALL_TRACKS]: false,
 	[DISABLED_CONNECTORS]: {},
 };
 

--- a/src/ui/options/components/advanced-settings.tsx
+++ b/src/ui/options/components/advanced-settings.tsx
@@ -1,7 +1,7 @@
 import * as BrowserStorage from '@/core/storage/browser-storage';
 import { t } from '@/util/i18n';
 import { createResource } from 'solid-js';
-import { GlobalOptionEntry, RangeOptionEntry } from './inputs';
+import { GlobalOptionEntry, RadioButtons, RangeOptionEntry } from './inputs';
 import * as Options from '../../../core/storage/options';
 import styles from './components.module.scss';
 
@@ -40,6 +40,67 @@ export default function AdvancedOptionsComponent() {
 				/>
 				<li class={styles.muted}>{t('optionPercentDesc')}</li>
 			</ul>
+			<AlbumGuessing />
+		</>
+	);
+}
+
+/**
+ * Component that allows the user to select requirements for the scrobbler to actually scrobble a song.
+ */
+function AlbumGuessing() {
+	return (
+		<>
+			<h2 id="header-album-guessing">{t('optionsAlbumGuessing')}</h2>
+			<RadioButtons
+				buttons={[
+					{
+						label: t('optionAlbumGuessingDisabled'),
+						title: t('optionAlbumGuessingDisabledTitle'),
+						value: Options.ALBUM_GUESSING_DISABLED,
+					},
+					{
+						label: t('optionAlbumGuessingUneditedOnly'),
+						title: t('optionAlbumGuessingUneditedOnlyTitle'),
+						value: Options.ALBUM_GUESSING_UNEDITED_ONLY,
+					},
+					{
+						label: t('optionAlbumGuessingAllTracks'),
+						title: t('optionAlbumGuessingAllTracksTitle'),
+						value: Options.ALBUM_GUESSING_ALL_TRACKS,
+					},
+				]}
+				name="albumGuessing"
+				value={() => {
+					if (options()?.[Options.ALBUM_GUESSING_ALL_TRACKS]) {
+						return Options.ALBUM_GUESSING_ALL_TRACKS;
+					}
+					if (options()?.[Options.ALBUM_GUESSING_UNEDITED_ONLY]) {
+						return Options.ALBUM_GUESSING_UNEDITED_ONLY;
+					}
+					return Options.ALBUM_GUESSING_DISABLED;
+				}}
+				onChange={(e) => {
+					const value = e.currentTarget.value;
+					setOptions.mutate((o) => {
+						if (!o) {
+							return o;
+						}
+						const newOptions = {
+							...o,
+							[Options.ALBUM_GUESSING_ALL_TRACKS]:
+								value === Options.ALBUM_GUESSING_ALL_TRACKS,
+							[Options.ALBUM_GUESSING_UNEDITED_ONLY]:
+								value === Options.ALBUM_GUESSING_UNEDITED_ONLY,
+							[Options.ALBUM_GUESSING_DISABLED]:
+								value === Options.ALBUM_GUESSING_DISABLED,
+						};
+						globalOptions.set(newOptions);
+						return newOptions;
+					});
+				}}
+				labelledby="header-album-guessing"
+			/>
 		</>
 	);
 }


### PR DESCRIPTION
Adds three options under **advanced settings**

Disable album guessing: Lastfm will never supply album title from pipeline, only albums explicitly declared by the connector or supplied by user through edits will be used.

Only guess album for unedited tracks (default): Mirrors current behavior. Album is supplied from lastfm if there is none supplied by connector, but album is not supplied when user has edited the track.

Guess album title for all tracks: WIll supply album from lastfm even when user has edited track, as long as there is nothing in album field.

Reasoning for adding to advanced is that this is not really something most people will want to fiddle with, and option fatigue is becoming a real issue.

<img width="750" alt="image" src="https://github.com/web-scrobbler/web-scrobbler/assets/69117606/15bb1d5e-e15a-429a-826b-9979fa0632e5">

Closes #1575 
Closes #2830 