### PR TITLE
Add fetching from background in content util

### DIFF
--- a/src/core/background/main.ts
+++ b/src/core/background/main.ts
@@ -467,6 +467,26 @@ setupBackgroundListeners(
 			});
 		},
 	}),
+
+	/**
+	 * Listener called by a content script to fetch through background script.
+	 */
+	backgroundListener({
+		type: 'fetch',
+		fn: async ({ url, init }) => {
+			const res = await fetch(url, init);
+			if (!res.ok) {
+				return {
+					ok: false,
+					content: '',
+				};
+			}
+			return {
+				ok: true,
+				content: await res.text(),
+			};
+		},
+	}),
 );
 
 /**

--- a/src/util/communication.ts
+++ b/src/util/communication.ts
@@ -104,6 +104,16 @@ interface ContentCommunications {
 		payload: undefined;
 		response: void;
 	};
+	fetch: {
+		payload: {
+			url: string;
+			init?: RequestInit | undefined;
+		};
+		response: Promise<{
+			ok: boolean;
+			content: string;
+		}>;
+	};
 }
 
 interface BackgroundCommunications {


### PR DESCRIPTION
Allows connectors to easily run fetch requests through the service worker.
The main use of this is allowing connectors to ignore CORS restrictions when fetching from outside sources.
Implemented as a contributor has expressed interested in an implementation of NTS that uses fetch requests to a domain with CORS restrictions.