### PR TITLE
Fix ListenBrainz Log In Issue Related to DOMParser and Recent React Port 

### DIFF
--- a/src/core/scrobbler/listenbrainz/listenbrainz.types.ts
+++ b/src/core/scrobbler/listenbrainz/listenbrainz.types.ts
@@ -42,4 +42,11 @@ export type ListenBrainzParams =
 export type MetadataLookup = {
 	recording_mbid?: string;
 };
+
+export interface ListenBrainzHTMLReactProps {
+	current_user: {
+		name: string;
+		auth_token: string;
+	};
+}
 /* eslint-enable camelcase */


### PR DESCRIPTION
> I'm not sure if this is the best approach to fix both problems, the main reason I'm creating this PR right now is to get feedback.

There were two issues with ListenBrainz account log-in:

1. Profile page ([now called Settings page](https://github.com/metabrainz/listenbrainz-server/commit/27c3ffbc581075776c452ebdc47c13e220760aba)) [was ported to React](https://github.com/metabrainz/listenbrainz-server/commit/ab625dc14cffabbb10b0494e1fc513571a05d27d), so we can't `fetch` the page and get the username and user token like before.
2. Chrome Manifest V3 uses Service Workers for extensions, and DOMParser do not exist on them.

This PR fixes both, since they depend on each other.

**Describe the changes you made**

1. I used the JSON data from the `script` element with the ID `global-react-properties`. It contains the username and user token value for us, which are the only things we need.
2. I used regex to capture the only section we require (which is the `script` element I mentioned above) from raw HTML data.

**Additional context**

There are probably better ways for parsing the HTML and getting the data we require, but `chrome.offscreen` requires some workarounds (you need an HTML page and a JS script to send runtime messages) and it's not certain if other browsers support it, and a DOM parser dependency would be too huge just to get several client information at max.

There are also two or three connectors which use DOMParser for getting some information. But I'm not sure if they're being run under a Service Worker (I don't know about extensions API much) and I can't check them since they're not available in my country, so I left them as is.