### PR TITLE
Add infobox menu

### DIFF
--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -32,6 +32,10 @@ export const common: Manifest.WebExtensionManifest = {
 			resources: ['icons/*'],
 			matches: ['<all_urls>'],
 		},
+		{
+			resources: ['src/ui/popup/index.html'],
+			matches: ['<all_urls>'],
+		},
 	],
 
 	options_ui: {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1048,7 +1048,7 @@
         "description": "Hotkey label"
     },
     "infoBoxStateDisallowed": {
-        "message":  "Scrobbling is not allowed. Click web scrobbler extension icon for more information.",
+        "message": "Scrobbling is not allowed. Click web scrobbler extension icon for more information.",
         "description": "Infobox text when an option is disallowing scrobbling"
     },
     "infoBoxStateError": {
@@ -1058,5 +1058,9 @@
     "infoBoxStateUnknown": {
         "message": "The track is not recognized. Click web scrobbler extension icon to correct info.",
         "description": "Infobox track is not recognized"
+    },
+    "infoBoxDisable": {
+        "message": "Disable infobox on $1",
+        "description": "Infobox menu button label, $1 denotes website name"
     }
 }

--- a/src/connectors/bilibili.ts
+++ b/src/connectors/bilibili.ts
@@ -159,10 +159,11 @@ Connector.durationSelector = durationSelector;
 // scrobble info is shown beside the video info
 Connector.scrobbleInfoLocationSelector = '.video-info-detail';
 Connector.scrobbleInfoStyle = {
-	...Connector.scrobbleInfoStyle,
-	fontSize: '13px',
-	fontWeight: '400',
-	marginLeft: '10px',
+	'#scrobbler-infobox-expand-button': {
+		fontSize: '13px',
+		fontWeight: '400',
+		marginLeft: '10px',
+	},
 };
 
 Connector.isPlaying = () => {

--- a/src/connectors/nts.ts
+++ b/src/connectors/nts.ts
@@ -10,7 +10,8 @@ Connector.trackSelector =
 
 Connector.scrobbleInfoLocationSelector = '.page-live-tracks__title';
 Connector.scrobbleInfoStyle = {
-	...Connector.scrobbleInfoStyle,
-	fontSize: '0.7em',
-	marginTop: '0.7em',
+	'#scrobbler-infobox-expand-button': {
+		fontSize: '0.7em',
+		marginTop: '0.7em',
+	},
 };

--- a/src/connectors/youtube.ts
+++ b/src/connectors/youtube.ts
@@ -92,11 +92,15 @@ setupEventListener();
 
 Connector.playerSelector = ['#content', '#player'];
 
-Connector.scrobbleInfoLocationSelector = '#primary #title.ytd-watch-metadata';
+Connector.scrobbleInfoLocationSelector = [
+	'#primary #title.ytd-watch-metadata',
+	'.slim-video-information-title-and-badges',
+];
 Connector.scrobbleInfoStyle = {
-	...Connector.scrobbleInfoStyle,
-	fontSize: '1.17em',
-	fontWeight: '700',
+	'#scrobbler-infobox-expand-button': {
+		fontSize: '1.17em',
+		fontWeight: '700',
+	},
 };
 
 Connector.loveButtonSelector =

--- a/src/core/background/main.ts
+++ b/src/core/background/main.ts
@@ -487,6 +487,16 @@ setupBackgroundListeners(
 			};
 		},
 	}),
+
+	/**
+	 * Listener to trigger popup to open up to edit
+	 */
+	backgroundListener({
+		type: 'openEditMenu',
+		fn: () => {
+			browser.action.openPopup();
+		},
+	}),
 );
 
 /**

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -28,7 +28,7 @@ import { ScrobbleStatus } from '@/core/storage/wrapper';
 import browser from 'webextension-polyfill';
 import BaseConnector from '@/core/content/connector';
 import Blocklist from '@/core/storage/blocklist';
-import { DisallowedReason } from '../disallowed-reason';
+import { updateInfoBox } from '@/ui/inject/infobox';
 
 /**
  * List of song fields used to check if song is changed. If any of
@@ -128,97 +128,12 @@ export default class Controller {
 		return true;
 	}
 
-	/**
-	 * Function that handles updating the scrobble info box
-	 */
-	private async getInfoBoxElement(): Promise<HTMLDivElement | null> {
-		if (
-			!this.connector.scrobbleInfoLocationSelector ||
-			// infobox is disabled in options
-			!(await Options.getOption(
-				Options.USE_INFOBOX,
-				this.connector.meta.id,
-			))
-		) {
-			return null;
-		}
-
-		const parentEl = document.querySelector(
-			this.connector.scrobbleInfoLocationSelector,
-		);
-		if (!parentEl) {
-			return null;
-		}
-
-		// check if infoBoxEl was already created
-		let infoBoxElement = document.querySelector<HTMLDivElement>(
-			'#scrobbler-infobox-el',
-		);
-
-		// check if element is still in the correct place
-		if (infoBoxElement) {
-			if (infoBoxElement.parentElement !== parentEl) {
-				infoBoxElement.remove();
-			} else {
-				return infoBoxElement;
-			}
-		}
-
-		// if it was not in the correct place or didn't exist, create it
-		infoBoxElement = document.createElement('div');
-		infoBoxElement.setAttribute('id', 'scrobbler-infobox-el');
-
-		// style the infobox
-		for (const prop in this.connector.scrobbleInfoStyle) {
-			infoBoxElement.style[prop] =
-				this.connector.scrobbleInfoStyle[prop] ?? '';
-		}
-
-		parentEl.appendChild(infoBoxElement);
-		return infoBoxElement;
-	}
-
 	private async updateInfoBox() {
-		let oldInfoBoxText: string | false = false;
-		const infoBoxElement = await this.getInfoBoxElement();
-		if (!infoBoxElement) {
-			// clean up
-			const infoBoxElement = document.querySelector<HTMLDivElement>(
-				'#scrobbler-infobox-el',
-			);
-			if (infoBoxElement) {
-				infoBoxElement.remove();
-			}
-			return;
-		}
-		const textEl = infoBoxElement.querySelector('span');
-		if (textEl) {
-			oldInfoBoxText = textEl.innerText;
-		}
-
-		const mode = this.getMode();
-		const infoBoxText = Util.getInfoBoxText(mode, this.currentSong);
-
-		// Check if infobox needs to be updated
-		if (!oldInfoBoxText || infoBoxText !== oldInfoBoxText) {
-			const img = document.createElement('img');
-			img.setAttribute(
-				'src',
-				browser.runtime.getURL('./icons/icon_main_48.png'),
-			);
-			img.setAttribute('alt', 'Web Scrobbler state:');
-			img.setAttribute('style', 'height: 1.2em');
-
-			const info = document.createElement('span');
-			info.innerText = infoBoxText;
-
-			// Clear old contents of infoBoxElement
-			while (infoBoxElement.firstChild) {
-				infoBoxElement.removeChild(infoBoxElement.firstChild);
-			}
-			infoBoxElement.appendChild(img);
-			infoBoxElement.appendChild(info);
-		}
+		return updateInfoBox({
+			mode: this.getMode(),
+			song: this.currentSong,
+			connector: this.connector,
+		});
 	}
 
 	/**
@@ -227,6 +142,7 @@ export default class Controller {
 	 * @param isEnabled - Flag indicates initial stage
 	 */
 	constructor(connector: BaseConnector, isEnabled: boolean) {
+		connector.controller = this;
 		this.connector = connector;
 		this.blocklist = new Blocklist(this.connector.meta.id);
 		this.isEnabled = isEnabled;
@@ -314,12 +230,7 @@ export default class Controller {
 			contentListener({
 				type: 'forceScrobbleSong',
 				fn: () => {
-					this.forceScrobble = true;
-					if (this.shouldHaveScrobbled) {
-						void this.scrobbleSong();
-					} else {
-						void this.setSongNowPlaying();
-					}
+					this.forceScrobbleSong();
 				},
 			}),
 			contentListener({
@@ -486,7 +397,29 @@ export default class Controller {
 	}
 
 	/**
-	 * Make the controller to ignore current song.
+	 * Enable or disable a connector
+	 *
+	 * @param isEnabled - Whether to enable or disable connector.
+	 */
+	public setConnectorState(isEnabled: boolean) {
+		this.setEnabled(isEnabled);
+		Options.setConnectorEnabled(this.getConnector(), isEnabled);
+	}
+
+	/**
+	 * Make the controller scrobble current song.
+	 */
+	public forceScrobbleSong() {
+		this.forceScrobble = true;
+		if (this.shouldHaveScrobbled) {
+			void this.scrobbleSong();
+		} else {
+			void this.setSongNowPlaying();
+		}
+	}
+
+	/**
+	 * Make the controller ignore current song.
 	 */
 	skipCurrentSong(): void {
 		this.assertSongIsPlaying();
@@ -1125,16 +1058,6 @@ export default class Controller {
 	private setSongNotRecognized(): void {
 		this.setMode(ControllerMode.Unknown);
 		this.dispatchEvent(ControllerEvents.SongUnrecognized);
-	}
-
-	/**
-	 * Enable or disable a connector
-	 *
-	 * @param isEnabled - Whether to enable or disable connector.
-	 */
-	private setConnectorState(isEnabled: boolean) {
-		this.setEnabled(isEnabled);
-		Options.setConnectorEnabled(this.getConnector(), isEnabled);
 	}
 
 	/**

--- a/src/core/storage/options.ts
+++ b/src/core/storage/options.ts
@@ -287,10 +287,7 @@ export async function setConnectorOverrideOption(
 	key: keyof ConnectorsOverrideOptionValues,
 	value: boolean | undefined,
 ): Promise<void> {
-	const data = await connectorsOverrideOptions.get();
-	if (!data) {
-		throw new Error('No connectors override data found');
-	}
+	const data = (await connectorsOverrideOptions.get()) ?? {};
 	if (!data[connector]) {
 		data[connector] = {};
 	}

--- a/src/ui/inject/infobox-selectors.ts
+++ b/src/ui/inject/infobox-selectors.ts
@@ -1,0 +1,55 @@
+export const infoBoxIds = {
+	wrapper: 'scrobbler-infobox-wrapper',
+	expandButton: 'scrobbler-infobox-expand-button',
+	dialog: 'scrobbler-infobox-dialog',
+	list: 'scrobbler-infobox-list',
+	title: 'scrobbler-infobox-title',
+	icon: 'scrobbler-infobox-icon',
+} as const;
+
+type InfoBoxIdSelector = `#${(typeof infoBoxIds)[keyof typeof infoBoxIds]}`;
+
+export const infoBoxClasses = {
+	listItem: 'scrobbler-infobox-list-item',
+	button: 'scrobbler-infobox-button',
+	buttonPersistDialog: 'scrobbler-infobox-persist-dialog',
+} as const;
+
+type InfoBoxClassSelector =
+	`.${(typeof infoBoxClasses)[keyof typeof infoBoxClasses]}`;
+
+export const infoBoxOther = {
+	buttonHover: 'button-hover',
+	buttonSeparator: 'button-separator',
+};
+
+export type InfoBoxOther =
+	`$${(typeof infoBoxOther)[keyof typeof infoBoxOther]}`;
+
+export type InfoBoxSelector =
+	| InfoBoxIdSelector
+	| InfoBoxClassSelector
+	| InfoBoxOther;
+
+export type InfoBoxCSS = Partial<
+	Record<InfoBoxSelector, Partial<CSSStyleDeclaration>>
+>;
+
+// this is so small that it is probably faster to just use an array anyway
+const infoBoxSelectors = [
+	...Object.values(infoBoxIds).map((id) => `#${id}`),
+	...Object.values(infoBoxClasses).map((className) => `.${className}`),
+	...Object.values(infoBoxOther).map((otherName) => `$${otherName}`),
+];
+
+/**
+ * Checks if a given string is a valid {@link InfoBoxSelector}
+ *
+ * @param selector - string to check if is valid {@link InfoBoxSelector}
+ * @returns true if string is valid {@link InfoBoxSelector}; false otherwise
+ */
+export function isValidInfoBoxSelector(
+	selector: string,
+): selector is InfoBoxSelector {
+	return infoBoxSelectors.includes(selector);
+}

--- a/src/ui/inject/infobox.ts
+++ b/src/ui/inject/infobox.ts
@@ -1,0 +1,484 @@
+import type BaseConnector from '@/core/content/connector';
+import type { ControllerModeStr } from '@/core/object/controller/controller';
+import * as ControllerMode from '@/core/object/controller/controller-mode';
+import type Song from '@/core/object/song';
+import browser from 'webextension-polyfill';
+import * as Options from '@/core/storage/options';
+import {
+	InfoBoxCSS,
+	InfoBoxSelector,
+	infoBoxClasses,
+	infoBoxIds,
+	infoBoxOther,
+} from './infobox-selectors';
+import { t } from '@/util/i18n';
+
+/**
+ * Solid is not used here as this is run from content script and the content is
+ * injected into page. We do not want to load all of solid for that.
+ */
+
+interface infoBoxButtonProps {
+	onClick: (ev: MouseEvent) => void;
+	label: string;
+	connector: BaseConnector;
+	isLastItem?: true;
+	shouldKeepDialogOpen?: true;
+}
+
+interface infoBoxAppendProps extends infoBoxButtonProps {
+	wrapper: HTMLUListElement;
+}
+
+let currentDialog: {
+	wrapper: HTMLDivElement;
+	buttons: infoBoxButtonProps[];
+	connector: BaseConnector;
+} | null = null;
+
+function openDialog(e: MouseEvent) {
+	e.stopPropagation();
+	const dialog = document.querySelector<HTMLDialogElement>(
+		`#${infoBoxIds.dialog}`,
+	);
+	if (!dialog) {
+		return;
+	}
+
+	if (dialog.open) {
+		dialog.close();
+	} else {
+		dialog.show();
+	}
+}
+
+function closeDialog(e: MouseEvent) {
+	if (
+		e.target &&
+		'closest' in e.target &&
+		typeof e.target.closest === 'function' &&
+		e.target.closest(`.${infoBoxClasses.buttonPersistDialog}`)
+	) {
+		return;
+	}
+	document.querySelector<HTMLDialogElement>(`#${infoBoxIds.dialog}`)?.close();
+}
+
+function resizeIframe(e: MessageEvent<unknown>) {
+	if (
+		!e.data ||
+		typeof e.data !== 'object' ||
+		!('sender' in e.data) ||
+		e.data.sender !== 'web-scrobbler-popup' ||
+		!('width' in e.data) ||
+		!('height' in e.data) ||
+		typeof e.data.width !== 'number' ||
+		typeof e.data.height !== 'number' ||
+		!isFinite(e.data.width) ||
+		!isFinite(e.data.height)
+	) {
+		return;
+	}
+
+	const iframe = document.querySelector<HTMLIFrameElement>(
+		`#${infoBoxIds.dialog} iframe`,
+	);
+	if (!iframe) {
+		return;
+	}
+
+	iframe.width = e.data.width.toString();
+	iframe.height = e.data.height.toString();
+}
+
+function applyStyles(
+	element: HTMLElement,
+	connector: BaseConnector,
+	selector: InfoBoxSelector,
+) {
+	const styles = connector.scrobbleInfoStyle[selector];
+	if (styles) {
+		for (const prop in styles) {
+			element.style[prop] = styles[prop] ?? '';
+		}
+	}
+}
+
+function createInfoBoxDialog(props: {
+	wrapper: HTMLDivElement;
+	buttons: infoBoxButtonProps[];
+	connector: BaseConnector;
+}) {
+	currentDialog = props;
+
+	// remove if already exists
+	document.querySelector(`#${infoBoxIds.dialog}`)?.remove();
+
+	// create dialog
+	const dialog = document.createElement('dialog');
+	dialog.id = infoBoxIds.dialog;
+	applyStyles(dialog, props.connector, `#${infoBoxIds.dialog}`);
+	// reset dialog on close in case user created iframe
+	dialog.addEventListener('close', () => {
+		if (currentDialog) {
+			createInfoBoxDialog(currentDialog);
+		}
+	});
+
+	// create list
+	const list = document.createElement('ul');
+	list.id = infoBoxIds.list;
+	applyStyles(list, props.connector, `#${infoBoxIds.list}`);
+	dialog.appendChild(list);
+
+	// create buttons
+	for (const button of props.buttons) {
+		appendInfoBoxButton({
+			...button,
+			wrapper: list,
+		});
+	}
+
+	// append
+	props.wrapper.appendChild(dialog);
+
+	// setup event listeners
+	window.removeEventListener('click', closeDialog);
+	window.addEventListener('click', closeDialog);
+	window.removeEventListener('message', resizeIframe);
+	window.addEventListener('message', resizeIframe);
+}
+
+function appendInfoBoxButton(props: infoBoxAppendProps) {
+	const item = document.createElement('li');
+	item.classList.add(infoBoxClasses.listItem);
+	applyStyles(item, props.connector, `.${infoBoxClasses.listItem}`);
+
+	const button = document.createElement('button');
+	button.addEventListener('click', (e) => {
+		e.stopImmediatePropagation();
+		props.onClick(e);
+		closeDialog(e);
+	});
+	button.addEventListener('mouseenter', () => {
+		applyStyles(button, props.connector, `$${infoBoxOther.buttonHover}`);
+	});
+	button.addEventListener('mouseleave', () => {
+		button.attributeStyleMap.clear();
+		applyStyles(button, props.connector, `.${infoBoxClasses.button}`);
+		if (props.shouldKeepDialogOpen) {
+			applyStyles(
+				button,
+				props.connector,
+				`.${infoBoxClasses.buttonPersistDialog}`,
+			);
+		}
+		if (!props.isLastItem) {
+			applyStyles(
+				button,
+				props.connector,
+				`$${infoBoxOther.buttonSeparator}`,
+			);
+		}
+	});
+
+	button.innerText = props.label;
+	button.classList.add(infoBoxClasses.button);
+	applyStyles(button, props.connector, `.${infoBoxClasses.button}`);
+
+	if (props.shouldKeepDialogOpen) {
+		button.classList.add(infoBoxClasses.buttonPersistDialog);
+		applyStyles(
+			button,
+			props.connector,
+			`.${infoBoxClasses.buttonPersistDialog}`,
+		);
+	}
+
+	if (!props.isLastItem) {
+		applyStyles(
+			button,
+			props.connector,
+			`$${infoBoxOther.buttonSeparator}`,
+		);
+	}
+
+	item.appendChild(button);
+	props.wrapper.appendChild(item);
+}
+
+/**
+ * Function that handles updating the scrobble info box
+ */
+export async function getInfoBoxElementUnsafe(
+	connector: BaseConnector,
+): Promise<HTMLDivElement | null> {
+	if (
+		!connector.scrobbleInfoLocationSelector ||
+		// infobox is disabled in options
+		!(await Options.getOption(Options.USE_INFOBOX, connector.meta.id))
+	) {
+		return null;
+	}
+
+	const parentEl = Util.queryElements(
+		connector.scrobbleInfoLocationSelector,
+	)?.[0];
+	if (!parentEl) {
+		return null;
+	}
+
+	// check if infobox element was already created
+	let infoBoxElement = document.querySelector<HTMLDivElement>(
+		`#${infoBoxIds.wrapper}`,
+	);
+
+	// check if element is still in the correct place
+	if (infoBoxElement) {
+		if (infoBoxElement.parentElement !== parentEl) {
+			infoBoxElement.remove();
+		} else {
+			return infoBoxElement;
+		}
+	}
+
+	// if it was not in the correct place or didn't exist, create it
+	infoBoxElement = document.createElement('div');
+	infoBoxElement.id = infoBoxIds.wrapper;
+
+	// style the infobox
+	applyStyles(infoBoxElement, connector, `#${infoBoxIds.wrapper}`);
+
+	parentEl.appendChild(infoBoxElement);
+	return infoBoxElement;
+}
+
+async function getInfoBoxElementSafe(
+	connector: BaseConnector,
+): Promise<HTMLDivElement | null> {
+	const infoBoxElement = await getInfoBoxElementUnsafe(connector);
+	if (!infoBoxElement) {
+		// clean up
+		const infoBoxElement = document.querySelector<HTMLButtonElement>(
+			`#${infoBoxIds.wrapper}`,
+		);
+		if (infoBoxElement) {
+			infoBoxElement.remove();
+		}
+		return null;
+	}
+	return infoBoxElement;
+}
+
+export async function updateInfoBox(props: {
+	mode: ControllerModeStr;
+	song: Song | null;
+	connector: BaseConnector;
+}) {
+	let oldInfoBoxText: string | false = false;
+	const infoBoxElement = await getInfoBoxElementSafe(props.connector);
+	if (!infoBoxElement) {
+		return;
+	}
+
+	const textEl = infoBoxElement.querySelector<HTMLButtonElement>(
+		`#${infoBoxIds.title}`,
+	);
+	if (textEl) {
+		oldInfoBoxText = textEl.innerText;
+	}
+
+	const infoBoxText = Util.getInfoBoxText(props.mode, props.song);
+
+	// Check if infobox needs to be updated
+	if (!oldInfoBoxText || infoBoxText !== oldInfoBoxText) {
+		// create expand button
+		const infoBoxExpandButton = document.createElement('button');
+		infoBoxExpandButton.id = infoBoxIds.expandButton;
+		applyStyles(
+			infoBoxExpandButton,
+			props.connector,
+			`#${infoBoxIds.expandButton}`,
+		);
+		infoBoxExpandButton.addEventListener('click', openDialog);
+
+		// create label and image
+		const img = document.createElement('img');
+		img.src = browser.runtime.getURL('./icons/icon_main_48.png');
+		img.alt = 'Web Scrobbler state:';
+		applyStyles(img, props.connector, `#${infoBoxIds.icon}`);
+
+		const info = document.createElement('span');
+		info.id = infoBoxIds.title;
+		info.innerText = infoBoxText;
+		applyStyles(info, props.connector, `#${infoBoxIds.title}`);
+
+		infoBoxExpandButton.appendChild(img);
+		infoBoxExpandButton.appendChild(info);
+
+		// Clear old contents of infoBoxElement
+		while (infoBoxElement.lastChild) {
+			infoBoxElement.removeChild(infoBoxElement.lastChild);
+		}
+
+		infoBoxElement.appendChild(infoBoxExpandButton);
+
+		const buttons: infoBoxButtonProps[] = [];
+		if (props.mode === ControllerMode.Playing) {
+			buttons.push(
+				editSongButton(props.connector),
+				skipSongButton(props.connector),
+			);
+		}
+		if (props.mode === ControllerMode.Disallowed) {
+			buttons.push(forceScrobbleButton(props.connector));
+		}
+
+		if (props.mode === ControllerMode.Disabled) {
+			buttons.push(enableConnectorButton(props.connector));
+		} else {
+			buttons.push(disableConnectorButton(props.connector));
+		}
+
+		buttons.push(disableInfoBoxButton(props.connector));
+
+		createInfoBoxDialog({
+			wrapper: infoBoxElement,
+			buttons,
+			connector: props.connector,
+		});
+	}
+}
+
+const disableInfoBoxButton = (
+	connector: BaseConnector,
+): infoBoxButtonProps => ({
+	onClick: () => {
+		const infoBoxElement = document.querySelector<HTMLDivElement>(
+			`#${infoBoxIds.wrapper}`,
+		);
+		infoBoxElement?.remove();
+		Options.setConnectorOverrideOption(
+			connector.meta.id,
+			Options.USE_INFOBOX,
+			false,
+		);
+	},
+	label: t('infoBoxDisable', connector.meta.label),
+	connector,
+	isLastItem: true,
+});
+
+const enableConnectorButton = (
+	connector: BaseConnector,
+): infoBoxButtonProps => ({
+	onClick: () => {
+		connector.controller?.setConnectorState(true);
+	},
+	label: t('menuEnableConnector', connector.meta.label),
+	connector,
+});
+
+const disableConnectorButton = (
+	connector: BaseConnector,
+): infoBoxButtonProps => ({
+	onClick: () => {
+		connector.controller?.setConnectorState(false);
+	},
+	label: t('menuDisableConnector', connector.meta.label),
+	connector,
+});
+
+const forceScrobbleButton = (connector: BaseConnector): infoBoxButtonProps => ({
+	onClick: () => {
+		connector.controller?.forceScrobbleSong();
+	},
+	label: t('disallowedButton'),
+	connector,
+});
+
+const skipSongButton = (connector: BaseConnector): infoBoxButtonProps => ({
+	onClick: () => {
+		connector.controller?.skipCurrentSong();
+	},
+	label: t('infoSkipTitle'),
+	connector,
+});
+
+const editSongButton = (connector: BaseConnector): infoBoxButtonProps => ({
+	onClick: (e) => {
+		e.stopImmediatePropagation();
+		const infoBoxDialog = document.querySelector<HTMLDialogElement>(
+			`#${infoBoxIds.dialog}`,
+		);
+		if (!infoBoxDialog) {
+			return;
+		}
+
+		// Clear old contents of infoBoxDialog
+		while (infoBoxDialog.lastChild) {
+			infoBoxDialog.removeChild(infoBoxDialog.lastChild);
+		}
+
+		const frame = document.createElement('iframe');
+		frame.src = browser.runtime.getURL(
+			'src/ui/popup/index.html?action=edit',
+		);
+		infoBoxDialog.appendChild(frame);
+	},
+	label: t('infoEditTitle'),
+	connector,
+	shouldKeepDialogOpen: true,
+});
+
+export const DEFAULT_SCROBBLE_INFO_STYLE: InfoBoxCSS = {
+	'#scrobbler-infobox-wrapper': {
+		position: 'relative',
+	},
+	'#scrobbler-infobox-expand-button': {
+		display: 'flex',
+		gap: '0.5em',
+		alignItems: 'center',
+		appearance: 'none',
+		background: 'transparent',
+		border: 'none',
+		cursor: 'pointer',
+		padding: '0',
+	},
+	'#scrobbler-infobox-icon': {
+		height: '1.2em',
+	},
+	'#scrobbler-infobox-list': {
+		listStyleType: 'none',
+		margin: '0',
+		padding: '0',
+	},
+	'#scrobbler-infobox-dialog': {
+		padding: '0',
+		borderRadius: '0.5em',
+		backgroundColor: '#d82323',
+		position: 'absolute',
+		zIndex: '10000000',
+		left: '0',
+		bottom: '0',
+		margin: '0',
+		transform: 'translateY(100%)',
+	},
+	'.scrobbler-infobox-button': {
+		appearance: 'none',
+		background: 'transparent',
+		border: 'none',
+		cursor: 'pointer',
+		padding: '0.75em',
+		color: 'white',
+		fontSize: '1.4em',
+		width: '100%',
+		textAlign: 'left',
+	},
+	'$button-separator': {
+		borderBottom: '1px solid white',
+	},
+	'$button-hover': {
+		backgroundColor: '#fc3434',
+	},
+};

--- a/src/ui/popup/main.tsx
+++ b/src/ui/popup/main.tsx
@@ -138,8 +138,21 @@ function Popup() {
 	);
 }
 
-// render the popup
+// prepare observer to communicate when popup running as iframe.
 const body = document.body;
+const resizeObserver = new ResizeObserver(() => {
+	window.parent.postMessage(
+		{
+			sender: 'web-scrobbler-popup',
+			width: body.scrollWidth,
+			height: body.scrollHeight,
+		},
+		'*',
+	);
+});
+resizeObserver.observe(body);
+
+// render the popup
 const root = document.createElement('div');
 root.id = 'root';
 root.classList.add(styles.root);

--- a/src/ui/popup/nowplaying.tsx
+++ b/src/ui/popup/nowplaying.tsx
@@ -101,6 +101,12 @@ export default function NowPlaying(props: { tab: Resource<ManagerTab> }) {
 		}
 	});
 
+	// immediately edit with param, this is used by infobox to instantly go to edit.
+	const params = new URLSearchParams(window.location.search);
+	if (params.get('action') === 'edit') {
+		setIsEditing(true);
+	}
+
 	return (
 		<Switch fallback={<Base />}>
 			<Match when={isEditing()}>

--- a/src/util/communication.ts
+++ b/src/util/communication.ts
@@ -114,6 +114,10 @@ interface ContentCommunications {
 			content: string;
 		}>;
 	};
+	openEditMenu: {
+		payload: undefined;
+		response: void;
+	};
 }
 
 interface BackgroundCommunications {


### PR DESCRIPTION
Draft PR: currently functional, but needs some refactoring and UI needs some cleanup visually.

Adds a menu to infobox, and makes some changes to connector API to reflect this.
This allows user to edit track, skip track, enable/disable connector, and disable the infobox itself on the website as they're scrobbling.
Especially convenient on mobile.

Since we are injecting straight into website, we do not use any framework, html, or css here, just pure typescript.
Editing is done through just creating an iframe to extension popup (regular popup cannot be programmatically opened in chromium, so this is a workaround).

Moves all the infobox logic out to src/ui/inject/infobox.ts