### PR TITLE
Update release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,6 +11,7 @@ categories:
     label: 'maintenance'
 exclude-labels:
   - 'skip-changelog'
+  - 'chore'
 version-resolver:
   major:
     labels:


### PR DESCRIPTION
Will make `chore` ones be skipped.

e.g. https://github.com/web-scrobbler/web-scrobbler/pull/4485

otherwise they show up here

![image](https://github.com/web-scrobbler/web-scrobbler/assets/713525/7ceae350-1fa7-4348-a77f-e375150fdf8e)


Unless you think chore things should be tagged differently?