### PR TITLE
Use audible api for determinining isPlaying status

### DIFF
--- a/src/core/background/main.ts
+++ b/src/core/background/main.ts
@@ -487,6 +487,21 @@ setupBackgroundListeners(
 			};
 		},
 	}),
+
+	/**
+	 * Listener called by a content script to figure out whether it is currently audible
+	 */
+	backgroundListener({
+		type: 'isTabAudible',
+		fn: async (_, sender) => {
+			const tabId = sender.tab?.id;
+			if (typeof tabId !== 'number') {
+				return Promise.resolve(true);
+			}
+
+			return (await browser.tabs.get(tabId)).audible ?? true;
+		},
+	}),
 );
 
 /**

--- a/src/core/content/connector.ts
+++ b/src/core/content/connector.ts
@@ -4,6 +4,7 @@ import { ArtistTrackInfo, BaseState, State, TimeInfo } from '@/core/types';
 import * as Util from '@/core/content/util';
 import { ConnectorMeta } from '../connectors';
 import type { DisallowedReason } from '../object/disallowed-reason';
+import { sendContentMessage } from '@/util/communication';
 
 export default class BaseConnector {
 	/**
@@ -546,6 +547,38 @@ export default class BaseConnector {
 	 */
 	public useMediaSessionApi: () => void = () => {
 		this.isMediaSessionAllowed = 'mediaSession' in navigator;
+	};
+
+	/**
+	 * used by {@link BaseConnector.useTabAudibleApi} for async {@link BaseConnector.isPlaying} updates
+	 */
+	private isPlayingAsync = true;
+
+	/**
+	 * Enable using tab audible function for deciding whether song is playing.
+	 *
+	 * Polls for audible once a second, this isn't expensive so it's fine.
+	 *
+	 * overrides {@link BaseConnector.isPlaying}
+	 */
+	public useTabAudibleApi: () => void = () => {
+		this.isPlaying = () => {
+			return this.isPlayingAsync;
+		};
+		setInterval(() => {
+			sendContentMessage({
+				type: 'isTabAudible',
+				payload: undefined,
+			})
+				.then((res) => {
+					this.isPlayingAsync = res;
+					this.onStateChanged();
+				})
+				.catch(() => {
+					this.isPlayingAsync = true;
+					this.onStateChanged();
+				});
+		}, 1000);
 	};
 
 	/**

--- a/src/core/content/connector.ts
+++ b/src/core/content/connector.ts
@@ -555,6 +555,11 @@ export default class BaseConnector {
 	private isPlayingAsync = true;
 
 	/**
+	 * interval being used by {@link BaseConnector.useTabAudibleApi}
+	 */
+	private tabAudibleFetchingInterval: NodeJS.Timeout | null = null;
+
+	/**
 	 * Enable using tab audible function for deciding whether song is playing.
 	 *
 	 * Polls for audible once a second, this isn't expensive so it's fine.
@@ -565,7 +570,12 @@ export default class BaseConnector {
 		this.isPlaying = () => {
 			return this.isPlayingAsync;
 		};
-		setInterval(() => {
+
+		if (this.tabAudibleFetchingInterval !== null) {
+			clearInterval(this.tabAudibleFetchingInterval);
+		}
+
+		this.tabAudibleFetchingInterval = setInterval(() => {
 			sendContentMessage({
 				type: 'isTabAudible',
 				payload: undefined,

--- a/src/core/scrobbler/listenbrainz/listenbrainz-scrobbler.ts
+++ b/src/core/scrobbler/listenbrainz/listenbrainz-scrobbler.ts
@@ -361,7 +361,6 @@ export default class ListenBrainzScrobbler extends BaseScrobbler<'ListenBrainz'>
 				});
 		const timeout = this.REQUEST_TIMEOUT;
 
-		// @ts-expect-error typescript is confused by the combination of ternary and promise wrapped promise. It's a skill issue on typescript's part.
 		const rawHtml = await Util.timeoutPromise(timeout, promise);
 
 		if (rawHtml !== null) {

--- a/src/util/communication.ts
+++ b/src/util/communication.ts
@@ -60,45 +60,45 @@ interface ContentCommunications {
 		payload: {
 			song: CloneableSong;
 		};
-		response: Promise<ServiceCallResult[]>;
+		response: ServiceCallResult[];
 	};
 	setPaused: {
 		payload: {
 			song: CloneableSong;
 		};
-		response: void;
+		response: ServiceCallResult[];
 	};
 	setResumedPlaying: {
 		payload: {
 			song: CloneableSong;
 		};
-		response: void;
+		response: ServiceCallResult[];
 	};
 	scrobble: {
 		payload: {
 			songs: CloneableSong[];
 			currentlyPlaying: boolean;
 		};
-		response: Promise<ServiceCallResult[][]>;
+		response: ServiceCallResult[][];
 	};
 	getSongInfo: {
 		payload: {
 			song: CloneableSong;
 		};
-		response: Promise<(Record<string, never> | ScrobblerSongInfo | null)[]>;
+		response: (Record<string, never> | ScrobblerSongInfo | null)[];
 	};
 	toggleLove: {
 		payload: {
 			song: CloneableSong;
 			isLoved: boolean;
 		};
-		response: Promise<(ServiceCallResult | Record<string, never>)[]>;
+		response: (ServiceCallResult | Record<string, never>)[];
 	};
 	sendListenBrainzRequest: {
 		payload: {
 			url: string;
 		};
-		response: Promise<string | null>;
+		response: string | null;
 	};
 	updateScrobblerProperties: {
 		payload: undefined;
@@ -109,10 +109,14 @@ interface ContentCommunications {
 			url: string;
 			init?: RequestInit | undefined;
 		};
-		response: Promise<{
+		response: {
 			ok: boolean;
 			content: string;
-		}>;
+		};
+	};
+	isTabAudible: {
+		payload: undefined;
+		response: boolean;
 	};
 }
 
@@ -170,11 +174,11 @@ interface BackgroundCommunications {
 	};
 	addToBlocklist: {
 		payload: undefined;
-		response: Promise<void>;
+		response: void;
 	};
 	removeFromBlocklist: {
 		payload: undefined;
-		response: Promise<void>;
+		response: void;
 	};
 	getChannelDetails: {
 		payload: undefined;
@@ -194,7 +198,9 @@ interface SpecificContentListener<K extends keyof BackgroundCommunications> {
 	fn: (
 		payload: BackgroundCommunications[K]['payload'],
 		sender: browser.Runtime.MessageSender,
-	) => BackgroundCommunications[K]['response'];
+	) =>
+		| BackgroundCommunications[K]['response']
+		| Promise<BackgroundCommunications[K]['response']>;
 }
 
 type ContentListener = <R>(
@@ -260,7 +266,9 @@ interface SpecificBackgroundListener<K extends keyof ContentCommunications> {
 	fn: (
 		payload: ContentCommunications[K]['payload'],
 		sender: browser.Runtime.MessageSender,
-	) => ContentCommunications[K]['response'];
+	) =>
+		| ContentCommunications[K]['response']
+		| Promise<ContentCommunications[K]['response']>;
 }
 
 type BackgroundListener = <R>(
@@ -323,7 +331,9 @@ interface SpecificPopupListener<K extends keyof PopupCommunications> {
 	fn: (
 		payload: PopupCommunications[K]['payload'],
 		sender: browser.Runtime.MessageSender,
-	) => PopupCommunications[K]['response'];
+	) =>
+		| PopupCommunications[K]['response']
+		| Promise<PopupCommunications[K]['response']>;
 }
 
 type PopupListener = <R>(


### PR DESCRIPTION
Closes #1516 
Solves this by adding a function Connector.useTabAudibleApi() which when called replaces Connector.isPlaying with a async fetcher.

I'm a bit unsure about the stability of this concept, but it seems to work. If a connector actually starts using it we can worry more about it I guess.

Also reworks communication.ts to stricten typing as it was needed to work properly with .then() syntax.