### PR TITLE
Improve listenbrainz and maloja local login

### DIFF
--- a/src/core/scrobbler/listenbrainz/listenbrainz-scrobbler.ts
+++ b/src/core/scrobbler/listenbrainz/listenbrainz-scrobbler.ts
@@ -278,6 +278,9 @@ export default class ListenBrainzScrobbler extends BaseScrobbler<'ListenBrainz'>
 			url = new URL(`https://${this.userApiUrl}`);
 		}
 		url.pathname = url.pathname.split('/1/')[0];
+		if (url.pathname.endsWith('/1')) {
+			url.pathname = url.pathname.slice(0, -2);
+		}
 		if (url.pathname.endsWith('/')) {
 			url.pathname = url.pathname.slice(0, -1);
 		}

--- a/src/core/scrobbler/listenbrainz/listenbrainz-scrobbler.ts
+++ b/src/core/scrobbler/listenbrainz/listenbrainz-scrobbler.ts
@@ -281,13 +281,10 @@ export default class ListenBrainzScrobbler extends BaseScrobbler<'ListenBrainz'>
 		if (url.pathname.endsWith('/1')) {
 			url.pathname = url.pathname.slice(0, -2);
 		}
-		if (url.pathname.endsWith('/')) {
-			url.pathname = url.pathname.slice(0, -1);
-		}
 
 		const pathQuerySplitIndex = path.indexOf('?');
 		if (pathQuerySplitIndex === -1) {
-			url.pathname += path;
+			url.pathname += url.pathname.endsWith('/') ? path.slice(1) : path;
 		} else {
 			url.pathname = path.slice(0, pathQuerySplitIndex);
 			url.search = path.slice(pathQuerySplitIndex);

--- a/src/core/scrobbler/maloja/maloja-scrobbler.ts
+++ b/src/core/scrobbler/maloja/maloja-scrobbler.ts
@@ -127,7 +127,7 @@ export default class MalojaScrobbler extends BaseScrobbler<'Maloja'> {
 			// try to automatically prepend https://
 			url = new URL(`https://${this.userApiUrl}`);
 		}
-		url.pathname = url.pathname.split('/apis/mlj_1/')[0];
+		url.pathname = url.pathname.split('/apis/mlj_1')[0];
 		if (url.pathname.endsWith('/')) {
 			url.pathname = url.pathname.slice(0, -1);
 		}

--- a/src/core/scrobbler/maloja/maloja-scrobbler.ts
+++ b/src/core/scrobbler/maloja/maloja-scrobbler.ts
@@ -128,10 +128,7 @@ export default class MalojaScrobbler extends BaseScrobbler<'Maloja'> {
 			url = new URL(`https://${this.userApiUrl}`);
 		}
 		url.pathname = url.pathname.split('/apis/mlj_1')[0];
-		if (url.pathname.endsWith('/')) {
-			url.pathname = url.pathname.slice(0, -1);
-		}
-		url.pathname += path;
+		url.pathname += url.pathname.endsWith('/') ? path.slice(1) : path;
 
 		const promise = fetch(url, requestInfo);
 


### PR DESCRIPTION
Previously login to these services with local instances was clunky, as you had to know you were supposed to input exact scrobble endpoint. Now almost anything works as long as you point it to the right general location.

Also, loving tracks should now work on local instances of listenbrainz, it did not previously.

Should be fully backwards compatible, so existing users will not need to change their login info.