### PR TITLE
Stop the scrobbler from scrobbling privately shared Souncloud tracks

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -671,6 +671,10 @@
         "message": "This song is not being scrobbled",
         "description": "The header of 'disallowed' popup"
     },
+    "disallowedDescIsPrivate": {
+        "message": "The song is not being scrobbled, as it is marked private by the owner. ",
+        "desciption": "The description of 'disallowed' popup when a song that is marked as private is being played."
+    },
     "disallowedDesc1": {
         "message": "Web Scrobbler has detected the song \"$2\" by \"$1\", but will not scrobble it.",
         "description": "The description of 'disallowed' popup. $1 is the artist detected. $2 is the track detected"

--- a/src/connectors/soundcloud.ts
+++ b/src/connectors/soundcloud.ts
@@ -89,6 +89,12 @@ Connector.getOriginUrl = () => {
 	return Connector.getUniqueID();
 };
 
+Connector.scrobblingDisallowedReason = () => {
+	if (document.querySelector('.sc-label-private')) {
+		return 'IsPrivate';
+	}
+};
+
 const filterArtistPremiereRules = [
 	{ source: /^\s*Premiere.*:\s*/i, target: '' },
 	{ source: /^\s*\*\*Premiere\*\*\s*/i, target: '' },

--- a/src/core/object/disallowed-reason.ts
+++ b/src/core/object/disallowed-reason.ts
@@ -51,6 +51,12 @@ export type DisallowedReason =
 	| 'IsLoading'
 
 	/**
+	 * The track has been made private and shared by the owner.
+	 * Currently used for Soundcloud only.
+	 */
+	| 'IsPrivate'
+
+	/**
 	 * Any other reason
 	 */
 	| 'Other';


### PR DESCRIPTION
Addresses issue https://github.com/web-scrobbler/web-scrobbler/issues/4024.
Should stop the scrobbler from scrobbling from private Soundcloud, and private/unlisted youtube videos.

**Additional context**
It was easier to stop the scrobbling from Soundcloud as the private css selector for private tag is much better defined than Youtube's. I didn't tackle embedded Soundcloud as there isn't a connector for them... yet. I'm sure I'll run into the same problem below.
For Youtube, there are two cases: directly watching the private/unlisted video in youtube.com or watching an embedded youtube video. The first case seems a little simpler, where a file is injected into youtube.ts to get the `window.ytInitialPlayerResponse` variables (`isPrivate`, `isUnlisted`). The second cases seems much more difficult since the window variables aren't available in iframe/embedded videos. 
Any suggestions, @yayuyokitano ?