### PR TITLE
restrict love/unlove to playing and scrobbled modes

### DIFF
--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -630,6 +630,17 @@ export default class Controller {
 		}
 
 		/**
+		 * Only update love status for some specific modes
+		 */
+		const loveChangeableModes = [
+			ControllerMode.Playing,
+			ControllerMode.Scrobbled,
+		];
+		if (!loveChangeableModes.includes(this.mode)) {
+			return;
+		}
+
+		/**
 		 * If there has not been definitive state before,
 		 * just change state without sending anything to service.
 		 * We dont want the extension to randomly unlove songs


### PR DESCRIPTION
In some cases, love/unlove event may be triggered when it shouldn't. This should eliminate that
Check goes straight on the private mode variable, so it ignores temp modes pause/love/unlove