### PR TITLE
Allow clicking edit while paused and recently loved/unloved

### DIFF
--- a/src/core/background/main.ts
+++ b/src/core/background/main.ts
@@ -252,6 +252,7 @@ async function updateTab(
 			fn({
 				tabId,
 				mode: ControllerMode.Unsupported,
+				permanentMode: ControllerMode.Unsupported,
 				song: null,
 			}),
 			...activeTabs,
@@ -277,10 +278,15 @@ async function updateTab(
  * @param tabId - ID of the tab to update mode of
  * @param mode - New controller mode
  */
-async function updateMode(tabId: number | undefined, mode: ControllerModeStr) {
+async function updateMode(
+	tabId: number | undefined,
+	mode: ControllerModeStr,
+	permanentMode: ControllerModeStr,
+) {
 	await updateTab(tabId, (oldTab) => ({
 		tabId: oldTab.tabId,
 		mode,
+		permanentMode,
 		song: oldTab.song,
 	}));
 }
@@ -298,6 +304,7 @@ async function updateState(
 	await updateTab(tabId, (oldTab) => ({
 		tabId: oldTab.tabId,
 		mode: oldTab.mode,
+		permanentMode: oldTab.permanentMode,
 		song,
 	}));
 }
@@ -309,8 +316,8 @@ setupBackgroundListeners(
 	 */
 	backgroundListener({
 		type: 'controllerModeChange',
-		fn: (mode, sender) => {
-			updateMode(sender.tab?.id, mode);
+		fn: ({ mode, permanentMode }, sender) => {
+			updateMode(sender.tab?.id, mode, permanentMode);
 			console.log(`changed mode to ${mode} in tab ${sender.tab?.id}`);
 		},
 	}),

--- a/src/core/background/util.ts
+++ b/src/core/background/util.ts
@@ -167,6 +167,7 @@ async function getTabDetails(tabId: number): Promise<ManagerTab> {
 		const curTab: ManagerTab = {
 			tabId,
 			mode: tabState.mode,
+			permanentMode: tabState.permanentMode,
 			song: tabState.song,
 		};
 		return curTab;
@@ -174,6 +175,7 @@ async function getTabDetails(tabId: number): Promise<ManagerTab> {
 		return {
 			tabId,
 			mode: ControllerMode.Unsupported,
+			permanentMode: ControllerMode.Unsupported,
 			song: null,
 		};
 	}

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -314,6 +314,7 @@ export default class Controller {
 				type: 'getConnectorDetails',
 				fn: () => ({
 					mode: this.getMode(),
+					permanentMode: this.mode,
 					song: this.currentSong?.getCloneableData() ?? null,
 				}),
 			}),
@@ -380,7 +381,10 @@ export default class Controller {
 		this.updateInfoBox();
 		sendContentMessage({
 			type: 'controllerModeChange',
-			payload: this.getMode(),
+			payload: {
+				mode: this.getMode(),
+				permanentMode: this.mode,
+			},
 		});
 	}
 

--- a/src/core/storage/wrapper.ts
+++ b/src/core/storage/wrapper.ts
@@ -81,6 +81,7 @@ export interface ScrobblerModels {
 export interface ManagerTab {
 	tabId: number;
 	mode: ControllerModeStr;
+	permanentMode: ControllerModeStr;
 	song: CloneableSong | null;
 }
 

--- a/src/ui/popup/nowplaying.tsx
+++ b/src/ui/popup/nowplaying.tsx
@@ -167,7 +167,7 @@ function NowPlayingContextMenu(props: {
 		const items: Navigator = [
 			{
 				namei18n:
-					props.tab()?.mode === ControllerMode.Playing
+					props.tab()?.permanentMode === ControllerMode.Playing
 						? 'infoEditTitleShort'
 						: 'infoEditUnableTitleShort',
 				icon: EditOutlined,
@@ -177,7 +177,7 @@ function NowPlayingContextMenu(props: {
 		if (props.song()?.flags.isCorrectedByUser) {
 			items.push({
 				namei18n:
-					props.tab()?.mode === ControllerMode.Playing
+					props.tab()?.permanentMode === ControllerMode.Playing
 						? 'infoRevertTitleShort'
 						: 'infoRevertUnableTitleShort',
 				icon: RestartAltOutlined,
@@ -339,9 +339,9 @@ function TrackControls(props: {
 		<div class={styles.controlButtons}>
 			<button
 				class={styles.controlButton}
-				disabled={props.tab()?.mode !== ControllerMode.Playing}
+				disabled={props.tab()?.permanentMode !== ControllerMode.Playing}
 				title={
-					props.tab()?.mode === ControllerMode.Playing
+					props.tab()?.permanentMode === ControllerMode.Playing
 						? t('infoEditTitle')
 						: t('infoEditUnableTitle')
 				}
@@ -352,9 +352,11 @@ function TrackControls(props: {
 			<Show when={props.song()?.flags.isCorrectedByUser}>
 				<button
 					class={styles.controlButton}
-					disabled={props.tab()?.mode !== ControllerMode.Playing}
+					disabled={
+						props.tab()?.permanentMode !== ControllerMode.Playing
+					}
 					title={
-						props.tab()?.mode === ControllerMode.Playing
+						props.tab()?.permanentMode === ControllerMode.Playing
 							? t('infoRevertTitle')
 							: t('infoRevertUnableTitle')
 					}
@@ -365,15 +367,15 @@ function TrackControls(props: {
 			</Show>
 			<button
 				class={`${styles.controlButton}${
-					props.tab()?.mode !== ControllerMode.Scrobbled
+					props.tab()?.permanentMode !== ControllerMode.Scrobbled
 						? ` ${styles.hiddenDisabled}`
 						: ''
 				}${
-					props.tab()?.mode === ControllerMode.Skipped
+					props.tab()?.permanentMode === ControllerMode.Skipped
 						? ` ${styles.active}`
 						: ''
 				}`}
-				disabled={props.tab()?.mode !== ControllerMode.Playing}
+				disabled={props.tab()?.permanentMode !== ControllerMode.Playing}
 				onClick={() => actionSkipCurrentSong(props.tab)}
 				title={t(getSkipLabel(props.tab, false))}
 			>
@@ -435,7 +437,7 @@ function PopupLink(props: {
  */
 function getSkipLabel(tab: Resource<ManagerTab>, isShort: boolean): string {
 	let res = 'infoSkipUnableTitle';
-	switch (tab()?.mode) {
+	switch (tab()?.permanentMode) {
 		case ControllerMode.Playing:
 			res = 'infoSkipTitle';
 			break;

--- a/src/util/communication.ts
+++ b/src/util/communication.ts
@@ -21,7 +21,10 @@ interface PopupCommunications {
 
 interface ContentCommunications {
 	controllerModeChange: {
-		payload: ControllerModeStr;
+		payload: {
+			mode: ControllerModeStr;
+			permanentMode: ControllerModeStr;
+		};
 		response: void;
 	};
 	songUpdate: {
@@ -163,6 +166,7 @@ interface BackgroundCommunications {
 		payload: undefined;
 		response: {
 			mode: ControllerModeStr;
+			permanentMode: ControllerModeStr;
 			song: CloneableSong | null;
 		};
 	};


### PR DESCRIPTION
Adds new field "permanentMode" to some communications, which ignores temporary modes paused, loved, unloved.
This allows some functionality in UI to be unaffected by temporary modes.

Closes #4539 

It is worth noting this change is a little past trivial, but it's not huge.