### PR TITLE
Add 'Like' selector for youtube music

### DIFF
--- a/src/connectors/youtube-music.ts
+++ b/src/connectors/youtube-music.ts
@@ -56,6 +56,9 @@ const playingPaths = [
 	'M6 19h4V5H6v14zm8-14v14h4V5h-4z',
 ];
 
+Connector.loveButtonSelector =
+	'#like-button-renderer #button-shape-like button[aria-pressed="false"]';
+
 Connector.playerSelector = 'ytmusic-player-bar';
 
 Connector.getTrackArt = () => {


### PR DESCRIPTION
Partly addresses the issue, but for youtube music: https://github.com/web-scrobbler/web-scrobbler/issues/4536
**Describe the changes you made**
Added a 'Like' selector for Youtube Music.

**Additional context**
I tried doing the same with Niconico but the selectors aren't helpful and using different selectors to get a normal Love/Unlove response did not work. For example:
![image](https://github.com/web-scrobbler/web-scrobbler/assets/52338697/64c6a937-9f4d-4e7a-89e5-067f21024008)

![image](https://github.com/web-scrobbler/web-scrobbler/assets/52338697/203de923-edb9-4d88-bdcd-4cb418f1a8a7)
For now, I need to think about Niconico but it doesn't seem like there aren't any good, simple UI methods.