### PR TITLE
Fix SiriusXM new url structure for Canada (and other regions) player

### DIFF
--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -1067,7 +1067,7 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'SiriusXM',
-		matches: ['*://www.siriusxm.com/*', '*://www.siriusxm.ca/*'],
+		matches: ['*://www.siriusxm.com/*', '*://*.siriusxm.com/player/*'],
 		js: 'siriusxm-player.js',
 		id: 'siriusxm-player',
 	},

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -1068,8 +1068,8 @@ export default <ConnectorMeta[]>[
 	{
 		label: 'SiriusXM',
 		matches: [
-			'*://www.siriusxm.com/*', 
-			'*://www.siriusxm.ca/*', 
+			'*://www.siriusxm.com/*',
+			'*://www.siriusxm.ca/*',
 			'*://*.siriusxm.com/player/*',
 		],
 		js: 'siriusxm-player.js',

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -1067,7 +1067,7 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'SiriusXM',
-		matches: ['*://www.siriusxm.com/*', '*://*.siriusxm.com/player/*'],
+		matches: ['*://www.siriusxm.com/*', '*://www.siriusxm.ca/*', '*://*.siriusxm.com/player/*'],
 		js: 'siriusxm-player.js',
 		id: 'siriusxm-player',
 	},

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -1067,7 +1067,11 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'SiriusXM',
-		matches: ['*://www.siriusxm.com/*', '*://www.siriusxm.ca/*', '*://*.siriusxm.com/player/*'],
+		matches: [
+			'*://www.siriusxm.com/*', 
+			'*://www.siriusxm.ca/*', 
+			'*://*.siriusxm.com/player/*',
+		],
 		js: 'siriusxm-player.js',
 		id: 'siriusxm-player',
 	},


### PR DESCRIPTION
SiriusXM url structure changed with recent update. Canada player URL is now 'https://can.siriusxm.com/player/'. This should be able to support any sub-region using this new structure (not that there are any other regions, SXM is only US and Canada, ATM).