### PR TITLE
Fix firefox saving of bulk edits

### DIFF
--- a/src/core/storage/regex-edits.model.ts
+++ b/src/core/storage/regex-edits.model.ts
@@ -44,6 +44,17 @@ export default abstract class RegexEditsModel extends CustomStorage<K> {
 	 * @param replace - Replace to save
 	 */
 	async saveRegexEdit(newEdit: RegexEdit): Promise<void> {
+		/**
+		 * The edit here might be from a solidjs store, which is a proxy.
+		 * Firefox does not like this, so we ensure an explicit shallow copy to regular objects.
+		 * It looks odd, but removing this will break firefox support.
+		 */
+		newEdit.search = {
+			...newEdit.search,
+		};
+		newEdit.replace = {
+			...newEdit.replace,
+		};
 		const storageData = await this.getRegexEditStorage();
 		if (storageData === null) {
 			await this.saveRegexEditToStorage([newEdit]);


### PR DESCRIPTION
For convenience, new regex edit overhaul moved from a basic signal to a store.
The store object is however a proxy, not a normal object.
Firefox seems to take issue with this.
This PR does a shallow copy of the relevant parts of bulk edits.
This ensures that if the input is a proxy it is copied to a regular object first, satisfying firefox.

Closes #4552 