### PR TITLE
Created AzuraCast connector

### DIFF
--- a/src/connectors/azuracast.ts
+++ b/src/connectors/azuracast.ts
@@ -6,7 +6,7 @@ Connector.artistSelector = '.now-playing-details .now-playing-main div.now-playi
 
 Connector.trackSelector = '.now-playing-title';
 
-Connector.trackArtSelector = '.now-playing-art .album-art .album-art;
+Connector.trackArtSelector = '.now-playing-art .album-art .album-art';
 
 Connector.isPlaying = () => Util.getAttrFromSelectors('.radio-controls .btn', 'title') == 'Play';
 

--- a/src/connectors/azuracast.ts
+++ b/src/connectors/azuracast.ts
@@ -10,4 +10,7 @@ Connector.trackSelector = '.now-playing-title';
 Connector.trackArtSelector = '.now-playing-art .album-art .album-art';
 
 Connector.isPlaying = () =>
-	Util.getAttrFromSelectors('.radio-controls .btn', 'title') === 'Stop';
+	Util.getAttrFromSelectors(
+		'.radio-controls .radio-control-play-button',
+		'title',
+	) === 'Stop';

--- a/src/connectors/azuracast.ts
+++ b/src/connectors/azuracast.ts
@@ -10,4 +10,4 @@ Connector.trackSelector = '.now-playing-title';
 Connector.trackArtSelector = '.now-playing-art .album-art .album-art';
 
 Connector.isPlaying = () =>
-	Util.getAttrFromSelectors('.radio-controls .btn', 'title') === 'Play';
+	Util.getAttrFromSelectors('.radio-controls .btn', 'title') === 'Stop';

--- a/src/connectors/azuracast.ts
+++ b/src/connectors/azuracast.ts
@@ -1,4 +1,4 @@
-Connector.useMediaSessionsApi();
+Connector.useMediaSessionApi();
 
 Connector.playerSelector = '.radio-player-widget';
 
@@ -8,5 +8,4 @@ Connector.trackSelector = '.now-playing-title';
 
 Connector.trackArtSelector = '.now-playing-art .album-art .album-art';
 
-Connector.isPlaying = () => Util.getAttrFromSelectors('.radio-controls .btn', 'title') == 'Play';
-
+Connector.isPlaying = () => Util.getAttrFromSelectors('.radio-controls .btn', 'title') === 'Play';

--- a/src/connectors/azuracast.ts
+++ b/src/connectors/azuracast.ts
@@ -1,0 +1,12 @@
+Connector.useMediaSessionsApi();
+
+Connector.playerSelector = '.radio-player-widget';
+
+Connector.artistSelector = '.now-playing-details .now-playing-main div.now-playing-artist';
+
+Connector.trackSelector = '.now-playing-title';
+
+Connector.trackArtSelector = '.now-playing-art .album-art .album-art;
+
+Connector.isPlaying = () => Util.getAttrFromSelectors('.radio-controls .btn', 'title') == 'Play';
+

--- a/src/connectors/azuracast.ts
+++ b/src/connectors/azuracast.ts
@@ -2,10 +2,12 @@ Connector.useMediaSessionApi();
 
 Connector.playerSelector = '.radio-player-widget';
 
-Connector.artistSelector = '.now-playing-details .now-playing-main div.now-playing-artist';
+Connector.artistSelector =
+	'.now-playing-details .now-playing-main div.now-playing-artist';
 
 Connector.trackSelector = '.now-playing-title';
 
 Connector.trackArtSelector = '.now-playing-art .album-art .album-art';
 
-Connector.isPlaying = () => Util.getAttrFromSelectors('.radio-controls .btn', 'title') === 'Play';
+Connector.isPlaying = () =>
+	Util.getAttrFromSelectors('.radio-controls .btn', 'title') === 'Play';

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2399,7 +2399,7 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'AzuraCast',
-		matches: ['*://www.azuracast.com'],
+		matches: ['*://www.azuracast.com/*'],
 		js: 'azuracast.js',
 		id: 'azuracast',
 	},

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2399,7 +2399,6 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'AzuraCast',
-		matches: ['*://www.azuracast.com/*'],
 		js: 'azuracast.js',
 		id: 'azuracast',
 	},

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2397,4 +2397,10 @@ export default <ConnectorMeta[]>[
 		js: 'earth.fm.js',
 		id: 'earthfm',
 	},
+	{
+		label: 'AzuraCast',
+		matches: ['*://www.azuracast.com'],
+		js: 'azuracast.js',
+		id: 'azuracast',
+	},
 ];


### PR DESCRIPTION
**Describe the changes you made**
I've created a connector to scrobble radio stations that leverage the [AzuraCast](https://www.azuracast.com) technology.

**Additional context**
I may need some assistance with this as I'm not really a TypeScript dev and I also am not sure how to e.g. categorize this connector; AzuraCast is not like a network of radio stations, it's just software. So every radio station you want to listen to will have to be manually added to the url filters in the AzuraCast connector options. So, you can test my connector at this station https://azura.maraki-infinity.com/public/infinity_radio (not my station) but you will need to add the url pattern yourself.
This also means some AzuraCast radios that use lots of custom frontend stuff like https://lapfoxradio.com won't work with the connector, not that a user would necessarily know to add it to the url match anyway, since it doesn't look like a typical AzuraCast page.
I'm not sure if there is a better way to code the connector to make it match more generally on AzuraCast radios using some TS magic I'm not aware of. 
Also I'm not sure if the basic match to azuracast.com I put in the entry in `connectors.ts` is correct either; that site doesn't really host radio or anything, but it seemed like I was supposed to put _something_ there so I just put the project's domain.

Thanks in advance for any help and for looking this over. I mainly created this as a way to scrobble my own AzuraCast radio station (which has no custom frontend) so I won't be tooooo upset if it's deemed useless for genpop :P
