### PR TITLE
Make love/unlove checks stricter

### DIFF
--- a/src/connectors/spotify.ts
+++ b/src/connectors/spotify.ts
@@ -48,6 +48,8 @@ Connector.getOriginUrl = () => getTrackUrl();
 
 Connector.loveButtonSelector = `${playerBar} button[data-testid="add-button"][aria-checked="false"]`;
 
+Connector.unloveButtonSelector = `${playerBar} button[data-testid="add-button"][aria-checked="true"]`;
+
 function isMusicPlaying() {
 	return artistUrlIncludes('/artist/', '/show/') || isLocalFilePlaying();
 }

--- a/src/connectors/youtube.ts
+++ b/src/connectors/youtube.ts
@@ -102,6 +102,9 @@ Connector.scrobbleInfoStyle = {
 Connector.loveButtonSelector =
 	'ytd-watch-metadata like-button-view-model button[aria-pressed="false"]';
 
+Connector.unloveButtonSelector =
+	'ytd-watch-metadata like-button-view-model button[aria-pressed="true"]';
+
 Connector.getChannelId = () =>
 	new URL(
 		(

--- a/src/core/content/connector.ts
+++ b/src/core/content/connector.ts
@@ -376,11 +376,19 @@ export default class BaseConnector {
 
 	/**
 	 * Button to love/like a song on listening service.
+	 *
+	 * Note: for safety, you should generally implement BOTH loveButtonSelector AND unloveButtonSelector.
+	 * Ensure there is a direct transition between one to the other with zero time where neither matches.
+	 * Web scrobbler not discovering either for a bit will cause it not to to love/unlove.
 	 */
 	public loveButtonSelector: string | string[] | null = null;
 
 	/**
 	 * Button to unlove/unlike a song on listening service.
+	 *
+	 * Note: for safety, you should generally implement BOTH loveButtonSelector AND unloveButtonSelector.
+	 * Ensure there is a direct transition between one to the other with zero time where neither matches.
+	 * Web scrobbler not discovering either for a bit will cause it not to to love/unlove.
 	 */
 	public unloveButtonSelector: string | string[] | null = null;
 
@@ -393,11 +401,21 @@ export default class BaseConnector {
 	 */
 	public isLoved: () => boolean | null | undefined = () => {
 		if (this.loveButtonSelector) {
-			return !Util.isElementVisible(this.loveButtonSelector);
+			if (Util.isElementVisible(this.loveButtonSelector)) {
+				return false;
+			}
+			if (!this.unloveButtonSelector) {
+				return true;
+			}
 		}
 
 		if (this.unloveButtonSelector) {
-			return Util.isElementVisible(this.unloveButtonSelector);
+			if (Util.isElementVisible(this.unloveButtonSelector)) {
+				return true;
+			}
+			if (!this.loveButtonSelector) {
+				return false;
+			}
 		}
 
 		return null;


### PR DESCRIPTION
By making a strict requirement for the button to actually transition directly from love to unlove, we effectively stop false positives.

We might be able to get away with a slightly less strict version that allows a null value to exist between false/true and still love/unlove.

Closes #4564 #4589