### PR TITLE
Rework youtube music connector

### DIFF
--- a/src/connectors/youtube-music.ts
+++ b/src/connectors/youtube-music.ts
@@ -24,13 +24,16 @@ const trackArtSelector = '.ytmusic-player-bar.image';
 
 const artistSelectors = [
 	// Base selector, combining both new and old
-	'.ytmusic-player-bar.byline [href*="channel/"]:not([href*="channel/MPREb_"]):not([href*="browse/MPREb_"])',
+	'ytmusic-app-layout>ytmusic-player-bar .ytmusic-player-bar.byline [href*="channel/"]:not([href*="channel/MPREb_"]):not([href*="browse/MPREb_"])',
 
 	// Old selector for self-uploaded music
-	'.ytmusic-player-bar.byline [href*="feed/music_library_privately_owned_artist_detaila_"]',
+	'ytmusic-app-layout>ytmusic-player-bar .ytmusic-player-bar.byline [href*="feed/music_library_privately_owned_artist_detaila_"]',
 
 	// New selector for self-uploaded music
-	'.ytmusic-player-bar.byline [href*="browse/FEmusic_library_privately_owned_artist_detaila_"]',
+	'ytmusic-app-layout>ytmusic-player-bar .ytmusic-player-bar.byline [href*="browse/FEmusic_library_privately_owned_artist_detaila_"]',
+
+	// Small screen
+	'ytmusic-app-layout>ytmusic-player-bar .ytmusic-player-bar.byline',
 ];
 const albumSelectors = [
 	// Old base selector, leaving in case removing it would break something

--- a/src/connectors/youtube-music.ts
+++ b/src/connectors/youtube-music.ts
@@ -20,79 +20,34 @@ export {};
  * Uploaded songs have different artist and track selectors
  */
 
-const trackArtSelector = '.ytmusic-player-bar.image';
-
-const artistSelectors = [
-	// Base selector, combining both new and old
-	'ytmusic-app-layout>ytmusic-player-bar .ytmusic-player-bar.byline [href*="channel/"]:not([href*="channel/MPREb_"]):not([href*="browse/MPREb_"])',
-
-	// Old selector for self-uploaded music
-	'ytmusic-app-layout>ytmusic-player-bar .ytmusic-player-bar.byline [href*="feed/music_library_privately_owned_artist_detaila_"]',
-
-	// New selector for self-uploaded music
-	'ytmusic-app-layout>ytmusic-player-bar .ytmusic-player-bar.byline [href*="browse/FEmusic_library_privately_owned_artist_detaila_"]',
-
-	// Small screen
-	'ytmusic-app-layout>ytmusic-player-bar .ytmusic-player-bar.byline',
-];
-const albumSelectors = [
-	// Old base selector, leaving in case removing it would break something
-	'.ytmusic-player-bar [href*="channel/MPREb_"]',
-
-	// New base selector
-	'.ytmusic-player-bar [href*="browse/MPREb_"]',
-
-	// Old selector for self-uploaded music, also leaving for now
-	'.ytmusic-player-bar [href*="feed/music_library_privately_owned_release_detailb_"]',
-
-	// New selector for self-uploaded music
-	'.ytmusic-player-bar [href*="browse/FEmusic_library_privately_owned_release_detailb_"]',
-];
-
-const trackSelector = '.ytmusic-player-bar.title';
 const adSelector = '.ytmusic-player-bar.advertisement';
 
-const playButtonSelector =
-	'.ytmusic-player-bar.play-pause-button #icon > svg > g > path';
-const playingPaths = [
-	'M9,19H7V5H9ZM17,5H15V19h2Z', // New design being rolled out
-	'M6 19h4V5H6v14zm8-14v14h4V5h-4z',
-];
-
 Connector.playerSelector = 'ytmusic-player-bar';
-
-Connector.getTrackArt = () => {
-	const trackArtUrl = Util.extractImageUrlFromSelectors(trackArtSelector);
-	if (trackArtUrl) {
-		return trackArtUrl.substring(0, trackArtUrl.lastIndexOf('='));
-	}
-	return null;
-};
 
 Connector.isTrackArtDefault = (url) => {
 	// Self-uploaded tracks could not have cover arts
 	return Boolean(url?.includes('cover_track_default'));
 };
 
-Connector.albumSelector = albumSelectors;
+Connector.getAlbum = () => navigator.mediaSession.metadata?.album;
 
-function hasVideoAlbum() {
-	return !!Connector.getAlbum();
-}
+Connector.getTrackArt = () => {
+	const artworks = navigator.mediaSession.metadata?.artwork;
+	return artworks?.[artworks.length - 1].src;
+};
 
 Connector.getArtistTrack = () => {
 	let artist;
 	let track;
+	const metadata = navigator.mediaSession.metadata;
 
-	if (hasVideoAlbum()) {
-		artist = getArtists();
-		track = Util.getTextFromSelectors(trackSelector);
+	if (metadata?.album) {
+		artist = metadata.artist;
+		track = metadata.title;
 	} else {
-		({ artist, track } = Util.processYtVideoTitle(
-			Util.getTextFromSelectors(trackSelector),
-		));
+		({ artist, track } = Util.processYtVideoTitle(metadata?.title));
 		if (!artist) {
-			artist = getArtists();
+			artist = metadata?.artist;
 		}
 	}
 	return { artist, track };
@@ -101,9 +56,7 @@ Connector.getArtistTrack = () => {
 Connector.timeInfoSelector = '.ytmusic-player-bar.time-info';
 
 Connector.isPlaying = () => {
-	return playingPaths.includes(
-		Util.getAttrFromSelectors(playButtonSelector, 'd') ?? '',
-	);
+	return navigator.mediaSession.playbackState === 'playing';
 };
 
 Connector.getUniqueID = () => {
@@ -120,14 +73,8 @@ Connector.getUniqueID = () => {
 Connector.scrobblingDisallowedReason = () =>
 	Util.isElementVisible(adSelector) ? 'IsAd' : null;
 
-function getArtists() {
-	// FIXME Use Array.from after jQuery support will be removed
-	const artistElements = Util.queryElements(artistSelectors);
-	return artistElements && Util.joinArtists([...artistElements]);
-}
-
 function filterYoutubeIfNonAlbum(text: string) {
-	return hasVideoAlbum() ? text : MetadataFilter.youtube(text);
+	return Connector.getAlbum() ? text : MetadataFilter.youtube(text);
 }
 
 const youtubeMusicFilter = MetadataFilter.createFilter({


### PR DESCRIPTION
A lot of unnecessary complexity here as pointed out by https://github.com/web-scrobbler/web-scrobbler/issues/4571#issuecomment-1997836031

Scraps entire selector driven approach to use mediaSession API instead.

Still applies similar logic. When song being played is a youtube video, no album is provided. In this case, we process the mediaSession.metadata.title as a youtube title, trying to get both artist and track from it, and using the artist field (channel) as the artist if it fails. If there is an album (means actual well structured upload), we just use mediaSession metadata with only slight modifications.

This is a little bit scary given the size of the changes to such a big platform, but it really does seem way more reliable than it was.

Closes #4571 
Closes #4561 