### PR TITLE
Added additional checks for identifying private SoundCloud tracks

### DIFF
--- a/src/connectors/soundcloud.ts
+++ b/src/connectors/soundcloud.ts
@@ -90,7 +90,35 @@ Connector.getOriginUrl = () => {
 };
 
 Connector.scrobblingDisallowedReason = () => {
-	if (document.querySelector('.sc-label-private')) {
+	// Tracks on profile pages
+	const soundPlaying = document.querySelector(
+		'div:not(.playlist).sound.playing',
+	);
+	if (soundPlaying && soundPlaying.querySelector('.sc-label-private')) {
+		return 'IsPrivate';
+	}
+	// Tracks in playlists and albums on profile pages
+	const activeCompactTrack = document.querySelector(
+		'.compactTrackListItem.active',
+	);
+	if (
+		activeCompactTrack &&
+		!activeCompactTrack.querySelector('.compactTrackListItem__plays')
+	) {
+		return 'IsPrivate';
+	}
+	// Private tracks in playlists
+	if (/\/sets\//.test(new URL(document.URL).pathname)) {
+		// Check for individual private tracks in playlists
+		const activeTrack = document.querySelector('.active');
+		if (activeTrack && activeTrack.querySelector('.sc-label-private')) {
+			return 'IsPrivate';
+		}
+		// Individual track pages
+	} else if (
+		document.querySelector('.fullListenHero') &&
+		document.querySelector('.sc-label-private')
+	) {
 		return 'IsPrivate';
 	}
 };


### PR DESCRIPTION
**Describe the changes you made**
#4519 added a feature to prevent private SoundCloud tracks from being scrobbled, but the function in this commit just checks for the existence of a private track badge anywhere on the page, resulting in public tracks in private playlists or the user's own profile incorrectly not scrobbling. I have improved the logic for identifying private tracks by:

- Checks for the private track badge on individual track pages
- Checks for the private track badge on tracks within a playlist, and ignores whether the playlist itself is public or private
- Checks for the private track badge on tracks on profile pages and the feed
- For tracks in playlists and albums on profile pages / the feed, it checks if the plays are public, and if not, it assumes the track is private. This is an imperfect check, as some tracks with plays explicitly marked as private will not be automatically scrobbled, but it is the only indicator of a private track I am aware of in the HTML of the page.

An issue this commit does not address is the scenario where a private track is added to the "next up" list and begins playing while the user is on a different page - the private track will still be incorrectly scrobbled (this is also the case in #4519). As far as I know, there is no HTML that indicates that the currently playing track is private, but I assume this situation is extremely uncommon.

Fixes #4604 