### PR TITLE
Improve tag matching logic for Bilibili connector

### DIFF
--- a/src/connectors/bilibili.ts
+++ b/src/connectors/bilibili.ts
@@ -451,7 +451,8 @@ function getFirstNonNull(arr: (string | null)[]): string | null {
 
 /**
  * case insensitive match
- * @returns tags that be contained in any elem in textFragment array
+ * if there're exact match, return that item only
+ * @returns an array contains tags that be contained in any elem in textFragment array, or an tag that exactly match one elem
  */
 function getMatchedTags(
 	textFragment: (string | null)[],
@@ -460,17 +461,21 @@ function getMatchedTags(
 	const matchedTags: string[] = [];
 	// Traversing as textFragment's order
 	if (textFragment) {
-		textFragment.forEach((fragment) => {
-			tags.forEach((tag) => {
-				if (
+		for (const fragment of textFragment) {
+			for (const tag of tags) {
+				// the tag which exactly the same as the fragment has highest priority
+				if (fragment === tag) {
+					Util.debugLog(`exact tag found: ${tag}`);
+					return [tag];
+				} else if (
 					fragment &&
 					fragment.toLowerCase().includes(tag.toLowerCase()) &&
 					!matchedTags.includes(tag)
 				) {
 					matchedTags.push(tag);
 				}
-			});
-		});
+			}
+		}
 	}
 	return matchedTags;
 }


### PR DESCRIPTION
**Describe the changes you made**
If there is an exact match between a tag and a possible Artist/Track, it should be used as the Artist/Track.

For example:
when detected these possible artist and tags:
```
Video Title:【Official Music Video】輪符雨（Refrain）/ MyGO!!!!!【原创歌曲】
PossibleArtist: Official Music Video,MyGO_AveMujica,MyGO!!!!!
FilteredTags: MyGO!!!!!,mygo
```
Obviously, `MyGO!!!!!` is the artist name, and there is a tag that exactly matches it. But there's also a tag named `mygo`. According to the previous logic, `mygo`  could be recognized as artist, instead of the obvious correct answer(which is confusing)