### PR TITLE
Update RTL+ Musik connector

### DIFF
--- a/src/connectors/rtl-plus-musik.ts
+++ b/src/connectors/rtl-plus-musik.ts
@@ -19,7 +19,7 @@ Connector.isPlaying = () => {
 	const titleElements = Util.queryElements(
 		'plus-player-container .play-icon > svg > title',
 	);
-	if (titleElements && titleElements[0].textContent) {
+	if (titleElements && titleElements[0] && titleElements[0].textContent) {
 		const isPaused = titleElements[0].textContent.indexOf('Abspielen') >= 0;
 		return !isPaused;
 	}

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2252,7 +2252,7 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'RTL+ Musik',
-		matches: ['*://plus.rtl.de/musik/*'],
+		matches: ['*://plus.rtl.de/*'],
 		js: 'rtl-plus-musik.js',
 		id: 'rtl-plus-musik',
 	},


### PR DESCRIPTION

**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->

  * Relax site URL to avoid site detection problems when the site is initially opened without a `/musik/*` suffix
  * Fix invalid attribute access in `isPlaying` for case where player is not yet fully loaded (caused exception which was not recovered from)


**Additional context**
<!-- Add any other context or screenshots here. -->
