### PR TITLE
Fix the location of TIDAL's first-choice track selector.

### DIFF
--- a/src/connectors/tidal.ts
+++ b/src/connectors/tidal.ts
@@ -10,7 +10,7 @@ Connector.scrobblingDisallowedReason = () =>
 	Util.queryElements(Connector.playButtonSelector) ? null : 'ElementMissing';
 
 Connector.trackSelector = [
-	'#nowPlaying div.react-tabs__tab-panel--selected > div > div:nth-child(1) > div:nth-child(1) > wave-text:nth-child(2)',
+	'#nowPlaying div.react-tabs__tab-panel--selected > div > div:nth-child(1) > div:nth-child(1) > .wave-text-description-medium',
 	`${Connector.playerSelector} div[data-test="footer-track-title"]`,
 ];
 


### PR DESCRIPTION
This changed slightly again. The `-medium` sounds suspiciously viewport-dependent, but I cannot get the DOM to change by manipulating my window.
