### PR TITLE
Pin the Safari build to the macos-12 runner.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
 
   build-safari:
     name: Build the extension for Safari
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
There appears to be a problem with building node-canvas on macos-latest. There is no tarball for M1 Macs available and the runner does not have the dependencies to build using node-gyp.

The last successful
build (https://github.com/web-scrobbler/web-scrobbler/actions/runs/8759607054/job/24042984451#step:1:8) used macos-12; Not sure why macos-13 was skipped a week later (https://github.com/web-scrobbler/web-scrobbler/actions/runs/8902808795/job/24450278411#step:1:8), but this should keep Safari builds working until the dependencies get sorted out.
