### PR TITLE
Fix piped.ts (connector)

### DIFF
--- a/src/connectors/piped.ts
+++ b/src/connectors/piped.ts
@@ -11,13 +11,13 @@ Connector.getArtistTrack = () => {
 };
 
 Connector.getCurrentTime = () => {
-	const videoEl = document.querySelector('.shaka-video')
-	return videoEl ? videoEl.currentTime : null
+	const videoEl = document.querySelector('.shaka-video');
+	return videoEl ? videoEl.currentTime : null;
 }
 
 Connector.getDuration = () => {
-	const videoEl = document.querySelector('.shaka-video')
-	return videoEl ? videoEl.duration : null
+	const videoEl = document.querySelector('.shaka-video');
+	return videoEl ? videoEl.duration : null;
 }
 
 Connector.getUniqueID = () => {

--- a/src/connectors/piped.ts
+++ b/src/connectors/piped.ts
@@ -13,12 +13,12 @@ Connector.getArtistTrack = () => {
 Connector.getCurrentTime = () => {
 	const videoEl = (document.querySelector('.shaka-video') as HTMLVideoElement);
 	return videoEl ? videoEl.currentTime : null;
-}
+};
 
 Connector.getDuration = () => {
 	const videoEl = (document.querySelector('.shaka-video') as HTMLVideoElement);
 	return videoEl ? videoEl.duration : null;
-}
+};
 
 Connector.getUniqueID = () => {
 	const videoUrl = Util.getAttrFromSelectors('[aria-current=page]', 'href');

--- a/src/connectors/piped.ts
+++ b/src/connectors/piped.ts
@@ -10,9 +10,15 @@ Connector.getArtistTrack = () => {
 	return Util.processYtVideoTitle(text);
 };
 
-Connector.getCurrentTime = () => document.querySelector('.shaka-video')?.currentTime || null;
+Connector.getCurrentTime = () => {
+	const videoEl = document.querySelector('.shaka-video')
+	return videoEl ? videoEl.currentTime : null
+}
 
-Connector.getDuration = () => document.querySelector('.shaka-video')?.duration || null;
+Connector.getDuration = () => {
+	const videoEl = document.querySelector('.shaka-video')
+	return videoEl ? videoEl.duration : null
+}
 
 Connector.getUniqueID = () => {
 	const videoUrl = Util.getAttrFromSelectors('[aria-current=page]', 'href');

--- a/src/connectors/piped.ts
+++ b/src/connectors/piped.ts
@@ -10,9 +10,9 @@ Connector.getArtistTrack = () => {
 	return Util.processYtVideoTitle(text);
 };
 
-Connector.getCurrentTime = () => document.querySelector('.shaka-video')?.currentTime;
+Connector.getCurrentTime = () => document.querySelector('.shaka-video')?.currentTime || null;
 
-Connector.getDuration = () => document.querySelector('.shaka-video')?.duration;
+Connector.getDuration = () => document.querySelector('.shaka-video')?.duration || null;
 
 Connector.getUniqueID = () => {
 	const videoUrl = Util.getAttrFromSelectors('[aria-current=page]', 'href');

--- a/src/connectors/piped.ts
+++ b/src/connectors/piped.ts
@@ -10,11 +10,13 @@ Connector.getArtistTrack = () => {
 	return Util.processYtVideoTitle(text);
 };
 
-Connector.getCurrentTime = () =>
-	Util.getAttrFromSelectors(".shaka-video", "currentTime");
+Connector.getCurrentTime = () => {
+	return Util.getAttrFromSelectors('.shaka-video', 'currentTime');
+}
 
-Connector.getDuration = () =>
-	Util.getAttrFromSelectors(".shaka-video", "duration");
+Connector.getDuration = () => {
+	return Util.getAttrFromSelectors('.shaka-video', 'duration');
+}
 
 Connector.getUniqueID = () => {
 	const videoUrl = Util.getAttrFromSelectors('[aria-current=page]', 'href');

--- a/src/connectors/piped.ts
+++ b/src/connectors/piped.ts
@@ -11,12 +11,12 @@ Connector.getArtistTrack = () => {
 };
 
 Connector.getCurrentTime = () => {
-	const videoEl = document.querySelector('.shaka-video');
+	const videoEl = (document.querySelector('.shaka-video') as HTMLVideoElement);
 	return videoEl ? videoEl.currentTime : null;
 }
 
 Connector.getDuration = () => {
-	const videoEl = document.querySelector('.shaka-video');
+	const videoEl = (document.querySelector('.shaka-video') as HTMLVideoElement);
 	return videoEl ? videoEl.duration : null;
 }
 

--- a/src/connectors/piped.ts
+++ b/src/connectors/piped.ts
@@ -11,11 +11,11 @@ Connector.getArtistTrack = () => {
 };
 
 Connector.getCurrentTime = () => {
-	return (document.querySelector('.shaka-video') as HTMLVideoElement)?.currentTime
+	return (document.querySelector('.shaka-video') as HTMLVideoElement)?.currentTime;
 }
 
 Connector.getDuration = () => {
-	return (document.querySelector('.shaka-video') as HTMLVideoElement)?.duration
+	return (document.querySelector('.shaka-video') as HTMLVideoElement)?.duration;
 }
 
 Connector.getUniqueID = () => {

--- a/src/connectors/piped.ts
+++ b/src/connectors/piped.ts
@@ -16,7 +16,7 @@ Connector.getCurrentTime = () => {
 };
 
 Connector.getDuration = () => {
-	const videoEl = (document.querySelector('.shaka-video') as HTMLVideoElement);
+	const videoEl = document.querySelector('.shaka-video') as HTMLVideoElement;
 	return videoEl ? videoEl.duration : null;
 };
 

--- a/src/connectors/piped.ts
+++ b/src/connectors/piped.ts
@@ -11,11 +11,11 @@ Connector.getArtistTrack = () => {
 };
 
 Connector.getCurrentTime = () => {
-	return Util.getAttrFromSelectors('.shaka-video', 'currentTime');
+	return document.querySelector('.shaka-video')?.currentTime;
 }
 
 Connector.getDuration = () => {
-	return Util.getAttrFromSelectors('.shaka-video', 'duration');
+	return document.querySelector('.shaka-video')?.duration;
 }
 
 Connector.getUniqueID = () => {

--- a/src/connectors/piped.ts
+++ b/src/connectors/piped.ts
@@ -11,11 +11,11 @@ Connector.getArtistTrack = () => {
 };
 
 Connector.getCurrentTime = () => {
-	return document.querySelector('.shaka-video')?.currentTime;
+	return (document.querySelector('.shaka-video') as HTMLVideoElement)?.currentTime
 }
 
 Connector.getDuration = () => {
-	return document.querySelector('.shaka-video')?.duration;
+	return (document.querySelector('.shaka-video') as HTMLVideoElement)?.duration
 }
 
 Connector.getUniqueID = () => {

--- a/src/connectors/piped.ts
+++ b/src/connectors/piped.ts
@@ -11,10 +11,10 @@ Connector.getArtistTrack = () => {
 };
 
 Connector.getCurrentTime = () =>
-	(document.querySelector('.shaka-video') as HTMLVideoElement).currentTime;
+	Util.getAttrFromSelectors(".shaka-video", "currentTime");
 
 Connector.getDuration = () =>
-	(document.querySelector('.shaka-video') as HTMLVideoElement).duration;
+	Util.getAttrFromSelectors(".shaka-video", "duration");
 
 Connector.getUniqueID = () => {
 	const videoUrl = Util.getAttrFromSelectors('[aria-current=page]', 'href');

--- a/src/connectors/piped.ts
+++ b/src/connectors/piped.ts
@@ -10,13 +10,9 @@ Connector.getArtistTrack = () => {
 	return Util.processYtVideoTitle(text);
 };
 
-Connector.getCurrentTime = () => {
-	return (document.querySelector('.shaka-video') as HTMLVideoElement)?.currentTime;
-}
+Connector.getCurrentTime = () => document.querySelector('.shaka-video')?.currentTime;
 
-Connector.getDuration = () => {
-	return (document.querySelector('.shaka-video') as HTMLVideoElement)?.duration;
-}
+Connector.getDuration = () => document.querySelector('.shaka-video')?.duration;
 
 Connector.getUniqueID = () => {
 	const videoUrl = Util.getAttrFromSelectors('[aria-current=page]', 'href');

--- a/src/connectors/piped.ts
+++ b/src/connectors/piped.ts
@@ -11,7 +11,7 @@ Connector.getArtistTrack = () => {
 };
 
 Connector.getCurrentTime = () => {
-	const videoEl = (document.querySelector('.shaka-video') as HTMLVideoElement);
+	const videoEl = document.querySelector('.shaka-video') as HTMLVideoElement;
 	return videoEl ? videoEl.currentTime : null;
 };
 


### PR DESCRIPTION
Fixed piped connector ~~by ditching querySelector, which often returned null. Util.getAttrFromSelectors is now used instead~~

UPDATE: Util.getAttrFromSelectors wasn't the correct solution - querySelector is still used, but now the connector avoids trying to access properties on null objects that are querySelected before the video is added to the DOM (which was the reason for the connector crashing)