### PR TITLE
fix youtube-music connector on Firefox

### DIFF
--- a/src/connectors/youtube-music-dom-inject.ts
+++ b/src/connectors/youtube-music-dom-inject.ts
@@ -1,0 +1,44 @@
+export {};
+
+/**
+ * This script runs in non-isolated environment(youtube music itself)
+ * for accessing navigator variables on Firefox
+ *
+ * * Script is run as an IIFE to ensure variables are scoped, as in the event
+ * of extension reload/update a new script will have to override the current one.
+ *
+ * Script starts by calling window.cleanup to cleanup any potential previous script.
+ *
+ * @returns a cleanup function that cleans up event listeners and similar for a future overriding script.
+ */
+
+if ('cleanup' in window && typeof window.cleanup === 'function') {
+	window.cleanup();
+}
+
+(window as unknown as { cleanup: () => void }).cleanup = (() => {
+	const sendData = () => {
+		window.postMessage(
+			{
+				sender: 'web-scrobbler',
+				playbackState: navigator.mediaSession.playbackState,
+				metadata: {
+					title: navigator.mediaSession.metadata?.title,
+					artist: navigator.mediaSession.metadata?.artist,
+					artwork: navigator.mediaSession.metadata?.artwork,
+					album: navigator.mediaSession.metadata?.album,
+				},
+			},
+			'*',
+		);
+	};
+	const interval = setInterval(() => {
+		sendData();
+	}, 1000);
+
+	return () => {
+		// remove the subscribers added by this extension from the array.
+		// we dont have a confirmed reference to it so we have to check all of them.
+		clearInterval(interval);
+	};
+})();

--- a/src/connectors/youtube-music.ts
+++ b/src/connectors/youtube-music.ts
@@ -22,6 +22,26 @@ export {};
 
 const adSelector = '.ytmusic-player-bar.advertisement';
 
+const mediaInfo = {
+	playbackState: 'none',
+	metadata: {
+		title: '',
+		artist: '',
+		artwork: [{ src: '' }],
+		album: '',
+	},
+};
+
+Connector.onScriptEvent = (event) => {
+	mediaInfo.playbackState = event.data.playbackState as string;
+	mediaInfo.metadata = event.data.metadata as {
+		title: string;
+		artist: string;
+		artwork: { src: string; size: string; type: string }[];
+		album: string;
+	};
+};
+
 Connector.playerSelector = 'ytmusic-player-bar';
 
 Connector.isTrackArtDefault = (url) => {
@@ -29,17 +49,17 @@ Connector.isTrackArtDefault = (url) => {
 	return Boolean(url?.includes('cover_track_default'));
 };
 
-Connector.getAlbum = () => navigator.mediaSession.metadata?.album;
+Connector.getAlbum = () => mediaInfo.metadata?.album;
 
 Connector.getTrackArt = () => {
-	const artworks = navigator.mediaSession.metadata?.artwork;
+	const artworks = mediaInfo.metadata?.artwork;
 	return artworks?.[artworks.length - 1].src;
 };
 
 Connector.getArtistTrack = () => {
 	let artist;
 	let track;
-	const metadata = navigator.mediaSession.metadata;
+	const metadata = mediaInfo.metadata;
 
 	if (metadata?.album) {
 		artist = metadata.artist;
@@ -55,9 +75,7 @@ Connector.getArtistTrack = () => {
 
 Connector.timeInfoSelector = '.ytmusic-player-bar.time-info';
 
-Connector.isPlaying = () => {
-	return navigator.mediaSession.playbackState === 'playing';
-};
+Connector.isPlaying = () => mediaInfo.playbackState === 'playing';
 
 Connector.loveButtonSelector =
 	'ytmusic-like-button-renderer #button-shape-like button[aria-pressed="false"]';
@@ -93,3 +111,5 @@ const youtubeMusicFilter = MetadataFilter.createFilter({
 });
 
 Connector.applyFilter(youtubeMusicFilter);
+
+Connector.injectScript('connectors/youtube-music-dom-inject.js');


### PR DESCRIPTION
**Describe the changes you made**
Previous implementation was not able to access the `navigator` object on Firefox, making the extention unable to detect music on Firefox
see [#4613 (comment)](https://github.com/web-scrobbler/web-scrobbler/issues/4613#issuecomment-2106074775)

Added inject script for youtube music to access the `navigator` object on Firefox and send data to the connector.

**Additional context**
Fixes #4613 
