### PR TITLE
Fix Epidemic Sound connector selectors

### DIFF
--- a/src/connectors/epidemicsound.ts
+++ b/src/connectors/epidemicsound.ts
@@ -6,7 +6,7 @@ Connector.artistSelector = '[class*=_CreativesLabel__container_]';
 
 Connector.trackSelector = [
 	'[class*=_ScrollingLabel__label_]',
-	'[class*=_TrackInfo__mobileContainer_] > [aria-label^=track]',
+	'[class*=_TrackInfo__container_] > [aria-label^=track]',
 ];
 
 Connector.currentTimeSelector = '[class*=_PlayerBar__elapsedTime_]';
@@ -14,7 +14,5 @@ Connector.currentTimeSelector = '[class*=_PlayerBar__elapsedTime_]';
 Connector.durationSelector = '[class*=_PlayerBar__waveform_] + span';
 
 Connector.isPlaying = () =>
-	Util.getAttrFromSelectors(
-		'[class*=_PlaybackControls__playPauseButton_]',
-		'title',
-	) === 'Pause';
+	Util.getAttrFromSelectors('button[aria-label="Pause"]', 'aria-label') ===
+	'Pause';


### PR DESCRIPTION
**Describe the changes you made**

* Update the selector name used for `trackSelector`
* Update the selector name used for `isPlaying`

**Additional context**

Screenshot showing the extension working with these changes:

![image](https://github.com/web-scrobbler/web-scrobbler/assets/77452832/1ebd9771-c18b-4ec6-b2ab-e08d69e1c164)

This PR addresses issue #4655.