### PR TITLE
Fix warp-aphextwin connector

### DIFF
--- a/src/connectors/warp-aphextwin.ts
+++ b/src/connectors/warp-aphextwin.ts
@@ -2,6 +2,8 @@ export {};
 
 Connector.playerSelector = '.player';
 
+Connector.artistSelector = '.current-track .js-current-track-artist';
+
 Connector.trackSelector = '.current-track .js-current-track-title';
 
 Connector.durationSelector = '.current-track .js-current-track-duration';
@@ -11,9 +13,10 @@ Connector.currentTimeSelector = '.current-time.js-current-time';
 Connector.playButtonSelector = '.track-controls .js-play-track';
 
 Connector.getArtist = () => {
-	return Util.getTextFromSelectors(
-		'.current-track .js-current-track-artist',
-	)?.replace(' - ', '');
+	return Util.getTextFromSelectors(Connector.artistSelector)?.replace(
+		'- ',
+		'',
+	);
 };
 
 Connector.getAlbum = () => {


### PR DESCRIPTION
Fix scrobbling artist with ` - Aphex Twin` instead of `Aphex Twin`

Example pages:
- https://aphextwin.warp.net/tracks
- https://aphextwin.warp.net/release/86954-aphex-twin-windowlicker