### PR TITLE
Add Rayo Support

### DIFF
--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -824,6 +824,8 @@ export default <ConnectorMeta[]>[
 		matches: [
 			'*://planetradio.co.uk/*/play/*',
 			'*://planetradio.co.uk/*/player/*',
+			'*://hellorayo.co.uk/*/play/*',
+			'*://hellorayo.co.uk/*/player/*',
 		],
 		js: 'planetradio.js',
 		id: 'planetradio',

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -820,10 +820,8 @@ export default <ConnectorMeta[]>[
 		id: 'listenlive',
 	},
 	{
-		label: 'Planet Radio',
+		label: 'Rayo',
 		matches: [
-			'*://planetradio.co.uk/*/play/*',
-			'*://planetradio.co.uk/*/player/*',
 			'*://hellorayo.co.uk/*/play/*',
 			'*://hellorayo.co.uk/*/player/*',
 		],


### PR DESCRIPTION
**Describe the changes you made**
Adds hellorayo.co.uk, after planet radio was rebranded.

**Additional context**
Original URLs are kept as some things are still operating on the URLs at this point in time.
Links to #4786