### PR TITLE
New Basspistol Radio connector

### DIFF
--- a/src/connectors/basspistol.ts
+++ b/src/connectors/basspistol.ts
@@ -1,0 +1,20 @@
+export {};
+
+const filter = MetadataFilter.createFilter({
+	artist: cleanupArtist,
+});
+
+Connector.playerSelector = '.radio-player-widget';
+Connector.trackSelector = '.now-playing-title';
+Connector.artistSelector = '.now-playing-artist';
+Connector.trackArtSelector = 'img.album_art';
+Connector.isPlaying = () =>
+	Util.getAttrFromSelectors('.radio-control-play-button', 'aria-label') !==
+	'Play';
+
+Connector.applyFilter(filter);
+
+function cleanupArtist(artist: string) {
+	// remove brackets
+	return artist.replace(/^([^\(]+)(\(.*)$/, '$1');
+}

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2449,4 +2449,10 @@ export default <ConnectorMeta[]>[
 		js: 'chirpradio.js',
 		id: 'chirpradio',
 	},
+	{
+		label: 'Basspistol Radio',
+		matches: ['*://*.basspistol.com/*'],
+		js: 'basspistol.js',
+		id: 'basspistol',
+	},
 ];


### PR DESCRIPTION
https://radio.basspistol.com connector. A lot of the time the artist will have the URL to their website or Bandcamp, so that is filtered out. 

<img width="741" alt="image" src="https://github.com/user-attachments/assets/c43c87fd-e8c4-41bd-8318-dec695376d1e">