### PR TITLE
Update connectors - nugs.net and livephish

### DIFF
--- a/src/connectors/livephish.ts
+++ b/src/connectors/livephish.ts
@@ -1,17 +1,19 @@
 export {};
 
-Connector.playerSelector = 'div[app-player] .player-wrapper';
+Connector.playerSelector = '#audio-player.audio-player';
 
-Connector.pauseButtonSelector = '.player-controls .pause-toggle';
+Connector.pauseButtonSelector = '#player-play-pause';
 
-Connector.artistSelector = '.player-info .artist-name';
+Connector.trackSelector = '#player-title';
 
-Connector.trackSelector = '.player-info .track-title';
+Connector.artistSelector = '#player-artist-name';
 
-Connector.albumSelector = '.player-info .recording-title';
+Connector.albumSelector = '#player-meta-info .player-venue';
 
-Connector.currentTimeSelector = '.scrubber-time .player-time';
+Connector.currentTimeSelector =
+	'#player-time-current';
 
-Connector.durationSelector = '.scrubber-time .track-time';
+Connector.remainingTimeSelector =
+	'#player-time-remaining';
 
-Connector.trackArtSelector = '.player-cover img';
+Connector.trackArtSelector = '#player-cover-image';

--- a/src/connectors/livephish.ts
+++ b/src/connectors/livephish.ts
@@ -10,10 +10,8 @@ Connector.artistSelector = '#player-artist-name';
 
 Connector.albumSelector = '#player-meta-info .player-venue';
 
-Connector.currentTimeSelector =
-	'#player-time-current';
+Connector.currentTimeSelector = '#player-time-current';
 
-Connector.remainingTimeSelector =
-	'#player-time-remaining';
+Connector.remainingTimeSelector = '#player-time-remaining';
 
 Connector.trackArtSelector = '#player-cover-image';

--- a/src/connectors/nugs.ts
+++ b/src/connectors/nugs.ts
@@ -2,18 +2,18 @@ export {};
 
 Connector.playerSelector = '#audio-player.audio-player';
 
-Connector.pauseButtonSelector = 'i.icon-pause';
+Connector.pauseButtonSelector = '#player-play-pause';
 
-Connector.trackSelector = 'main[class^="_about_"] div.fs-16';
+Connector.trackSelector = '#player-title';
 
-Connector.artistSelector = 'main[class^="_about_"] > div.fs-14.ellipsis';
+Connector.artistSelector = '#player-artist-name';
 
-Connector.albumSelector = 'main[class^="_about_"] > div[markuee]';
+Connector.albumSelector = '#player-meta-info .player-venue';
 
 Connector.currentTimeSelector =
-	'div[class^="_controls_"] + div > span.align-right';
+	'#player-time-current';
 
 Connector.remainingTimeSelector =
-	'div[class^="_controls_"] + div span:last-child';
+	'#player-time-remaining';
 
-Connector.trackArtSelector = 'div[class^="_header_"] > img[class=^"_cover_"]';
+Connector.trackArtSelector = '#player-cover-image';

--- a/src/connectors/nugs.ts
+++ b/src/connectors/nugs.ts
@@ -10,10 +10,8 @@ Connector.artistSelector = '#player-artist-name';
 
 Connector.albumSelector = '#player-meta-info .player-venue';
 
-Connector.currentTimeSelector =
-	'#player-time-current';
+Connector.currentTimeSelector = '#player-time-current';
 
-Connector.remainingTimeSelector =
-	'#player-time-remaining';
+Connector.remainingTimeSelector = '#player-time-remaining';
 
 Connector.trackArtSelector = '#player-cover-image';


### PR DESCRIPTION
# Changelog

- Updated nugs.net player selectors to improve integration with Web Scrobbler.
- Updated livephish player selectors to improve integration with Web Scrobbler.

**Additional context**

This PR addresses the latest markup changes on [nugs.net web player](https://play.nugs.net/) and [livephish web player](https://plus.livephish.com/) we made for `Web Scrobbler` extension.