### PR TITLE
Revert id change of lITT live change

### DIFF
--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -1722,7 +1722,7 @@ export default <ConnectorMeta[]>[
 		label: 'LITT Live',
 		matches: ['*://littlive.com/*'],
 		js: 'littlive.js',
-		id: 'littlive',
+		id: 'dashradio',
 	},
 	{
 		label: 'Niconico',


### PR DESCRIPTION
ID was changed in #4867 but we should maintain it to keep edits etc as they are saved on a per-connector level.