### PR TITLE
Fix scrobbling tracks without covers not working in Yandex Music

### DIFF
--- a/src/connectors/yandex-music-dom-inject.ts
+++ b/src/connectors/yandex-music-dom-inject.ts
@@ -65,7 +65,7 @@ if ('cleanup' in window && typeof window.cleanup === 'function') {
 			album = trackInfo.album.title;
 		}
 
-		const trackArt = `https://${trackInfo.cover.replace('%%', '400x400')}`;
+		const trackArt = trackInfo.cover ? `https://${trackInfo.cover.replace('%%', '400x400')}` : undefined;
 
 		return {
 			track,

--- a/src/connectors/yandex-music-dom-inject.ts
+++ b/src/connectors/yandex-music-dom-inject.ts
@@ -65,7 +65,9 @@ if ('cleanup' in window && typeof window.cleanup === 'function') {
 			album = trackInfo.album.title;
 		}
 
-		const trackArt = trackInfo.cover ? `https://${trackInfo.cover.replace('%%', '400x400')}` : undefined;
+		const trackArt = trackInfo.cover
+			? `https://${trackInfo.cover.replace('%%', '400x400')}`
+			: undefined;
 
 		return {
 			track,


### PR DESCRIPTION
Fixes #4529

Yandex Music connector fails when a track has no cover art:
![image](https://github.com/user-attachments/assets/5c800c53-7a49-4c61-b1e8-28697d935d0f)

I have added a check to ensure that a cover exists