### PR TITLE
Update Tidal connector.

### DIFF
--- a/src/connectors/tidal.ts
+++ b/src/connectors/tidal.ts
@@ -10,7 +10,7 @@ Connector.scrobblingDisallowedReason = () =>
 	Util.queryElements(Connector.playButtonSelector) ? null : 'ElementMissing';
 
 Connector.trackSelector = [
-	'#nowPlaying span[data-test="now-playing-track-title"]'
+	'#nowPlaying span[data-test="now-playing-track-title"]',
 	`${Connector.playerSelector} div[data-test="footer-track-title"]`,
 ];
 

--- a/src/connectors/tidal.ts
+++ b/src/connectors/tidal.ts
@@ -33,7 +33,7 @@ Connector.getArtist = () => {
 };
 
 Connector.albumSelector = [
-	'#nowPlaying div.react-tabs div[class^="currentMediaInfoContainer--"] a[href^="/album/"]',
+	'#nowPlaying div.react-tabs div[class^="currentMediaInfoContainer--"] div[class^="creditsCell--"] a[href^="/album/"]',
 	`${Connector.playerSelector} a[href^="/album/"]`,
 ];
 

--- a/src/connectors/tidal.ts
+++ b/src/connectors/tidal.ts
@@ -10,7 +10,7 @@ Connector.scrobblingDisallowedReason = () =>
 	Util.queryElements(Connector.playButtonSelector) ? null : 'ElementMissing';
 
 Connector.trackSelector = [
-	'#nowPlaying div.react-tabs__tab-panel--selected > div > div:nth-child(1) > div:nth-child(1) > .wave-text-description-medium',
+	'#nowPlaying span[data-test="now-playing-track-title"]'
 	`${Connector.playerSelector} div[data-test="footer-track-title"]`,
 ];
 
@@ -33,7 +33,7 @@ Connector.getArtist = () => {
 };
 
 Connector.albumSelector = [
-	'#nowPlaying div.react-tabs a[href^="/album/"]',
+	'#nowPlaying div.react-tabs div[class^="currentMediaInfoContainer--"] a[href^="/album/"]',
 	`${Connector.playerSelector} a[href^="/album/"]`,
 ];
 


### PR DESCRIPTION
The now playing panel changed again. `data-test` handles let us simplify track selection and only pull albums from the correct info container. The latter should fix the issue where music videos would scrobble with a random album from the artist's bio.

The track title change also reflects that the now playing track name is the "short" form. We are close to removing the last bits of legacy from having an option to scrobble long or short titles. Two things prevent me from removing the secondary selector.

1. I have not tested on different screen sizes, devices, etc.

2. The unique ID generator looks *inside* the footer selector for the `a` with track link, but said link is on the *outside* of the now playing version of the track.