### PR TITLE
Update connectors.ts with Synology default secure port

### DIFF
--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -1701,6 +1701,7 @@ export default <ConnectorMeta[]>[
 		label: 'Synology',
 		matches: [
 			'*://*5000/*',
+			'*://*5001/*',
 			'*://*/?launchApp=SYNO.SDS.AudioStation.Application*',
 		],
 		js: 'synology.js',


### PR DESCRIPTION
**Describe the changes you made**
Added port 5001 for Synology (AudioStation) player.
5000 is Synology default unsecure HTTP port.
5001 is default secure HTTPS port.

**Additional context**
Still not an ideal way of recognizing Synology AudioStation player but at least it now covers the base defaults.
