### PR TITLE
Fix for SomaFM player update

### DIFF
--- a/src/connectors/somafm.ts
+++ b/src/connectors/somafm.ts
@@ -2,20 +2,22 @@ export {};
 
 Connector.playerSelector = '.frameContents';
 
-Connector.artistSelector =
-	'tr.songHistoryLine:nth-child(1) > td:nth-child(2) > div:nth-child(2)';
+Connector.artistSelector = '.playbackInfo__secondaryLine';
 
-Connector.trackSelector =
-	'tr.songHistoryLine:nth-child(1) > td:nth-child(2) > div:nth-child(1)';
+Connector.trackSelector = '.playbackInfo__primaryLine';
 
 Connector.isPlaying = () => {
 	// making sure selector is not null
 	const playerSelector =
-		document.querySelector('.playbackController__info') ??
-		document.createElement('div');
+		document.querySelector(
+			'.playbackController__actionButton > svg:nth-child(1) > path:nth-child(1)',
+		) ?? document.createElement('div');
 
-	// player is playing if it has channel name AND extra div for track info as children
-	return playerSelector.childElementCount === 2;
+	// player is playing if 'd' attribute on SVG is the stop button path
+	return (
+		playerSelector.getAttribute('d') ===
+		'M6 7V17C6 17.5523 6.44772 18 7 18H17C17.5523 18 18 17.5523 18 17V7C18 6.44772 17.5523 6 17 6H7C6.44772 6 6 6.44772 6 7Z'
+	);
 };
 
 Connector.onReady = Connector.onStateChanged;


### PR DESCRIPTION
SomaFM's new player has been updated, and broke [my previous PR to support it](https://github.com/web-scrobbler/web-scrobbler/pull/5023).

**Additional context**

Updated the CSS selectors, and am now matching on the SVG path for playing or not, since they changed the player to always show artist and track even when stopped (previous PR detected presence or not of this info to know if it was playing).
