### PR TITLE
Fixed Mixcloud track detection by updating selectors

### DIFF
--- a/src/connectors/mixcloud.ts
+++ b/src/connectors/mixcloud.ts
@@ -4,9 +4,9 @@ const filter = MetadataFilter.createFilter({
 	artist: [removeByPrefix, removeBuySuffix],
 });
 
-Connector.playerSelector = '[class^=playerQueue__PlayerWrapper-]';
+Connector.playerSelector = '[class^=styles__PlayerWrapper-]';
 
-const trackInfoSelector = '[class^=PlayerSliderComponent__PlayerTrackInfo-]';
+const trackInfoSelector = '[class^=styles__PlayerTrackInfo-]';
 
 Connector.getTrackInfo = () => {
 	const artistTrackElement = document.querySelector(trackInfoSelector);
@@ -19,27 +19,27 @@ Connector.getTrackInfo = () => {
 
 	if (artistTrackElement && artistTrackElement.hasChildNodes()) {
 		artistText = Util.getTextFromSelectors(
-			'[class*=PlayerSliderComponent__Artist-]',
+			'[class*=styles__Artist-]',
 		);
 		trackText = Util.getTextFromSelectors(
-			'[class*=PlayerSliderComponent__Track-]',
+			'[class*=styles__Track-]',
 		);
 		podcastBoolean = false;
 	} else if (artistTrackElement && !artistTrackElement.hasChildNodes()) {
 		artistText = Util.getTextFromSelectors(
-			'[class^=PlayerControls__ShowOwnerName-]',
+			'[class^=styles__ShowOwnerName]',
 		);
 		trackText = Util.getTextFromSelectors(
-			'[class*=PlayerControls__ShowTitle-]',
+			'[class*=PlayerControlsDetails__ShowTitle]',
 		);
 		trackArtUrl = Util.extractImageUrlFromSelectors(
-			'[class^=PlayerControls__ShowPicture-] > img',
+			'[class*=styles__createShowPicture] > img',
 		)?.replace(/(?<=\/)\d+x\d+(?=\/)/g, '300x300'); // larger image path
 		currentTimeValue = Util.getSecondsFromSelectors(
-			'[class^=PlayerSliderComponent__StartTime-]',
+			'[class^=styles__StartTime-]',
 		);
 		remainingTimeValue = Util.getSecondsFromSelectors(
-			'[class^=PlayerSliderComponent__EndTime-]',
+			'[class^=styles__EndTime-]',
 		);
 		podcastBoolean = true;
 	}
@@ -56,7 +56,7 @@ Connector.getTrackInfo = () => {
 
 Connector.isPlaying = () =>
 	Util.getAttrFromSelectors(
-		'[class^=PlayButton__PlayerControl-]',
+		'[class^=styles__PlayerControl-]',
 		'aria-label',
 	) === 'Pause';
 


### PR DESCRIPTION
<!-- 
  Thank you for taking the time to contribute to this project!

  Make sure to check out our guide on contributing with guidelines of how to contribute.

  See: https://github.com/web-scrobbler/web-scrobbler/blob/master/.github/CONTRIBUTING.md

--> 

**Describe the changes you made**
This PR fixes the Mixcloud connector by updating all the selectors to their current values.

I've tested this with shows that contain track info, and shows that have no track info.

**Additional context**
This should fix #4751, #4758 and #4970.
