### PR TITLE
Pin stylelint-config-standard-scss to 11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "remark-preset-lint-recommended": "7.0.0",
     "sass": "1.81.0",
     "solid-js": "1.9.3",
+    "stylelint-config-standard-scss": "11.0.0",
     "tsx": "4.19.2",
     "typescript": "5.6.3",
     "vite-plugin-conditional-compiler": "0.3.1",


### PR DESCRIPTION
<!-- 
  Thank you for taking the time to contribute to this project!

  Make sure to check out our guide on contributing with guidelines of how to contribute.

  See: https://github.com/web-scrobbler/web-scrobbler/blob/master/.github/CONTRIBUTING.md

--> 

**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->

This commit/PR pins stylelint-config-standard-scss to 11.0.0 so that I can `npm install` locally.

Otherwise locking/resolving fails because 14.0.0 (latest) specifies `stylelint@"^16.11.0"`, which conflicts with `stylelint@">=15.10.0" from @web-scrobbler/stylelint-config@1.0.1`.

11.0.0 is the version currently in the lock file.


**Additional context**
<!-- Add any other context or screenshots here. -->
```
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: web-scrobbler@3.11.0
npm error Found: stylelint@15.11.0
npm error node_modules/stylelint
npm error   stylelint@"15.11.0" from the root project
npm error   peer stylelint@">=15.10.0" from @web-scrobbler/stylelint-config@1.0.1
npm error   node_modules/@web-scrobbler/stylelint-config
npm error     dev @web-scrobbler/stylelint-config@"1.0.1" from the root project
npm error
npm error Could not resolve dependency:
npm error peer stylelint@"^16.11.0" from stylelint-config-standard-scss@14.0.0
npm error node_modules/stylelint-config-standard-scss
npm error   peer stylelint-config-standard-scss@">=11.0.0" from @web-scrobbler/stylelint-config@1.0.1
npm error   node_modules/@web-scrobbler/stylelint-config
npm error     dev @web-scrobbler/stylelint-config@"1.0.1" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
```