### PR TITLE
Run CI on the latest Mac image.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
 
   build-safari:
     name: Build the extension for Safari
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Reverts 26cf7792309f515ea89ca9b0ad3eadbfe69f8841.

12 has been deprecated, breaking our builds. Pinning would be a preferable
strategy but this brings Mac builds back into line.