### PR TITLE
Add .com domain support for Yandex.Music connector

### DIFF
--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -228,6 +228,7 @@ export default <ConnectorMeta[]>[
 			'*://music.yandex.by/*',
 			'*://music.yandex.kz/*',
 			'*://music.yandex.ua/*',
+			'*://music.yandex.com/*',
 		],
 		js: 'yandex-music.js',
 		id: 'yandex-music',


### PR DESCRIPTION
**Describe the changes you made**
Added https://music.yandex.com/ to the list of domains, it's the one I'm using this service through but it was missing from the match list