### PR TITLE
Add cosine.club connector (#5094)

### DIFF
--- a/src/connectors/cosine.club.ts
+++ b/src/connectors/cosine.club.ts
@@ -1,0 +1,20 @@
+export {};
+
+Connector.playerSelector = '#tracks-container';
+
+Connector.getArtistTrack = () => {
+	const trackElement = document.querySelector(
+		'div[data-playing="true"] span',
+	);
+	return trackElement
+		? Util.splitArtistTrack(trackElement.textContent)
+		: null;
+};
+
+Connector.isPlaying = () => {
+	const currentTrack = document.querySelector('div[data-playing="true"]');
+	const svg = currentTrack?.querySelector('svg');
+	return svg?.getAttribute('aria-label') === 'pause';
+};
+
+setInterval(Connector.onStateChanged, 1000);

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2588,4 +2588,10 @@ export default <ConnectorMeta[]>[
 		js: 'tapes-kglw.js',
 		id: 'tapes-kglw',
 	},
+	{
+		label: 'cosine.club',
+		matches: ['*://cosine.club/*'],
+		js: 'cosine.club.js',
+		id: 'cosine.club',
+	},
 ];


### PR DESCRIPTION
Adds support for [cosine.club](https://cosine.club)

The site uses HTMX and the connector stops working on page navigation. Have added an interval to call `onStateChanged` to re-initialize in this case.