### PR TITLE
Fix SiriusXM CSS selectors and add support for Spanish UI

### DIFF
--- a/src/connectors/siriusxm-player.ts
+++ b/src/connectors/siriusxm-player.ts
@@ -19,23 +19,17 @@ const playerBar = "[class*='playbackControls']";
 
 Connector.playerSelector = playerBar;
 
-Connector.artistTrackSelector =
-	`${playerBar} [class*='title']`;
+Connector.artistTrackSelector = `${playerBar} [class*='title']`;
 
-Connector.trackArtSelector =
-	`${playerBar} [class*='trackImage'] img[class*='image-image']`;
+Connector.trackArtSelector = `${playerBar} [class*='trackImage'] img[class*='image-image']`;
 
-Connector.playButtonSelector =
-	`${playerBar} button[aria-label='Play'], ${playerBar} button[aria-label='Reproducir']`;
+Connector.playButtonSelector = `${playerBar} button[aria-label='Play'], ${playerBar} button[aria-label='Reproducir']`;
 
-Connector.pauseButtonSelector =
-	`${playerBar} button[aria-label='Pause'], ${playerBar} button[aria-label='Pausar']`;
+Connector.pauseButtonSelector = `${playerBar} button[aria-label='Pause'], ${playerBar} button[aria-label='Pausar']`;
 
-Connector.loveButtonSelector =
-	`${playerBar} button[aria-label='Thumb up'], ${playerBar} button[aria-label='Pulgar hacia arriba']`;
+Connector.loveButtonSelector = `${playerBar} button[aria-label='Thumb up'], ${playerBar} button[aria-label='Pulgar hacia arriba']`;
 
-Connector.unloveButtonSelector =
-	`${playerBar} button[aria-label='Thumb down'], ${playerBar} button[aria-label='Pulgar hacia abajo']`;
+Connector.unloveButtonSelector = `${playerBar} button[aria-label='Thumb down'], ${playerBar} button[aria-label='Pulgar hacia abajo']`;
 
 Connector.scrobblingDisallowedReason = () => {
 	const artist = Connector.getArtist()?.toLowerCase();

--- a/src/connectors/siriusxm-player.ts
+++ b/src/connectors/siriusxm-player.ts
@@ -15,19 +15,27 @@ const filter = MetadataFilter.createFilter({
 	track: [removeYear, removeCover, removeExclusive],
 });
 
-Connector.playerSelector = "[class*='playbackControls']";
+const playerBar = "[class*='playbackControls']";
+
+Connector.playerSelector = playerBar;
 
 Connector.artistTrackSelector =
-	"*[class*='playbackControls'] [class*='title']";
+	`${playerBar} [class*='title']`;
 
 Connector.trackArtSelector =
-	"[class*='playbackControls'] [class*='trackImage'] img[class*='image-image']";
+	`${playerBar} [class*='trackImage'] img[class*='image-image']`;
 
 Connector.playButtonSelector =
-	"[class*='playbackControls'] button[aria-label='Play'], [class*='playbackControls'] button[aria-label='Reproducir']";
+	`${playerBar} button[aria-label='Play'], ${playerBar} button[aria-label='Reproducir']`;
 
 Connector.pauseButtonSelector =
-	"[class*='playbackControls'] button[aria-label='Pause'], [class*='playbackControls'] button[aria-label='Pausar']";
+	`${playerBar} button[aria-label='Pause'], ${playerBar} button[aria-label='Pausar']`;
+
+Connector.loveButtonSelector =
+	`${playerBar} button[aria-label='Thumb up'], ${playerBar} button[aria-label='Pulgar hacia arriba']`;
+
+Connector.unloveButtonSelector =
+	`${playerBar} button[aria-label='Thumb down'], ${playerBar} button[aria-label='Pulgar hacia abajo']`;
 
 Connector.scrobblingDisallowedReason = () => {
 	const artist = Connector.getArtist()?.toLowerCase();

--- a/src/connectors/siriusxm-player.ts
+++ b/src/connectors/siriusxm-player.ts
@@ -15,19 +15,19 @@ const filter = MetadataFilter.createFilter({
 	track: [removeYear, removeCover, removeExclusive],
 });
 
-Connector.playerSelector = "*[class^='_playbackControls_']";
+Connector.playerSelector = "[class*='playbackControls']";
 
 Connector.artistTrackSelector =
-	"*[class^='_playbackControls_'] *[class*='_title_']";
+	"*[class*='playbackControls'] [class*='title']";
 
 Connector.trackArtSelector =
-	"*[class^='_playbackControls_'] *[class^='_trackImage_'] img[class^='_image-image']";
+	"[class*='playbackControls'] [class*='trackImage'] img[class*='image-image']";
 
 Connector.playButtonSelector =
-	"*[class^='_playbackControls_'] button[aria-label='Play']";
+	"[class*='playbackControls'] button[aria-label='Play'], [class*='playbackControls'] button[aria-label='Reproducir']";
 
 Connector.pauseButtonSelector =
-	"*[class^='_playbackControls_'] button[aria-label='Pause']";
+	"[class*='playbackControls'] button[aria-label='Pause'], [class*='playbackControls'] button[aria-label='Pausar']";
 
 Connector.scrobblingDisallowedReason = () => {
 	const artist = Connector.getArtist()?.toLowerCase();


### PR DESCRIPTION
**Describe the changes you made**

Hey folks 👋, the SiriusXM connector stopped working in the latest version of the extension (`3.12.0`). I tested it on macOS (`14.5 (23F79)`) with Chrome (`133.0.6943.54 (Build oficial) (arm64)`) and Safari (`17.5 (19618.2.12.11.6)`). I did take a quick look at the CSS selectors, and it looks like the SXM UI (`7.52.0`) has changed and therfore broke the old ones.

So, this change:
- Fixes the broken CSS selectors
- Adds like/unlike CSS selectors
- And adds support for the Spanish SiriusXM player UI
