### PR TITLE
Update edge deploy pipeline step 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,12 +85,11 @@ jobs:
         run: echo "PACKAGE_VERSION=$(jq .version package.json -r)" >> $GITHUB_ENV
 
       - name: Publish the extension for Edge
-        uses: inverse/edge-addon@v1.0.9
+        uses: inverse/edge-addon@v2.0.0
         with:
           product_id: ${{ secrets.EDGE_PRODUCT_ID }}
           client_id: ${{ secrets.EDGE_CLIENT_ID }}
-          client_secret: ${{ secrets.EDGE_CLIENT_SECRET }}
-          access_token_url: ${{ secrets.EDGE_ACCESS_TOKEN_URL }}
+          api_key: ${{ secrets.EDGE_CLIENT_SECRET }}
           zip: web-scrobbler-chrome.zip # Compatible with Chrome
           notes: 'Version ${{ env.PACKAGE_VERSION }} upload'
           debug: true


### PR DESCRIPTION
**Describe the changes you made**

Edge deployment failed and it looks like they changed the API. I applied the changes from the package copied to the addon which should resolve this.

I also rotated the credentials saved in the secrets. Lets see with the next release

**Additional context**
<!-- Add any other context or screenshots here. -->

- Failing pipeline: https://github.com/web-scrobbler/web-scrobbler/actions/runs/13421085267/job/37505704977
- Addon bump:  https://github.com/inverse/edge-addon/pull/12
- Lib bump: https://github.com/inverse/python-edge-addons-api/pull/46
