### PR TITLE
Fix albums when the large TIDAL player's tab is open.

### DIFF
--- a/src/connectors/tidal.ts
+++ b/src/connectors/tidal.ts
@@ -33,7 +33,7 @@ Connector.getArtist = () => {
 };
 
 Connector.albumSelector = [
-	'#nowPlaying div.react-tabs div[class^="currentMediaInfoContainer--"] div[class^="creditsCell--"] a[href^="/album/"]',
+	'#nowPlaying div.react-tabs div[class^="_currentMediaInfoContainer"] div[class^="_creditsCell"] a[href^="/album/"]',
 	`${Connector.playerSelector} a[href^="/album/"]`,
 ];
 


### PR DESCRIPTION
The naming scheme of their internals changed; Any logic remains constant.