### PR TITLE
Fix album artist special case in TIDAL.

### DIFF
--- a/src/connectors/tidal.ts
+++ b/src/connectors/tidal.ts
@@ -38,7 +38,10 @@ Connector.albumSelector = [
 ];
 
 Connector.getAlbumArtist = () => {
-	const albumUrlSegments = Util.getAttrFromSelectors(Connector.albumSelector, 'href')?.split('/');
+	const albumUrlSegments = Util.getAttrFromSelectors(
+		Connector.albumSelector,
+		'href',
+	)?.split('/');
 	const pageUrlSegments = Util.getAttrFromSelectors(
 		'head meta[name="apple-itunes-app"]',
 		'content',

--- a/src/connectors/tidal.ts
+++ b/src/connectors/tidal.ts
@@ -40,12 +40,12 @@ Connector.albumSelector = [
 Connector.getAlbumArtist = () => {
 	const albumUrl = Util.getAttrFromSelectors(Connector.albumSelector, 'href');
 	const canonicalUrl = Util.getAttrFromSelectors(
-		'head link[rel="canonical"]',
-		'href',
+		'head meta[name="apple-itunes-app"]',
+		'content',
 	);
-	if (albumUrl && canonicalUrl && canonicalUrl.endsWith(albumUrl)) {
+	if (albumUrl && canonicalUrl && 'album' === albumUrl.split('/').at(-2) && 'album' === canonicalUrl.split('/').at(-2) && albumUrl.split('/').at(-1) === canonicalUrl.split('/').at(-1)) {
 		const albumArtistNode = document.querySelectorAll(
-			'#main .header-details .artist-link a',
+			'main div[class^="_detailContainer"] .artist-link a',
 		);
 		return Util.joinArtists(Array.from(albumArtistNode));
 	}

--- a/src/connectors/tidal.ts
+++ b/src/connectors/tidal.ts
@@ -43,7 +43,13 @@ Connector.getAlbumArtist = () => {
 		'head meta[name="apple-itunes-app"]',
 		'content',
 	);
-	if (albumUrl && canonicalUrl && 'album' === albumUrl.split('/').at(-2) && 'album' === canonicalUrl.split('/').at(-2) && albumUrl.split('/').at(-1) === canonicalUrl.split('/').at(-1)) {
+	if (
+		albumUrl &&
+		canonicalUrl &&
+		'album' === albumUrl.split('/').at(-2) &&
+		'album' === canonicalUrl.split('/').at(-2) &&
+		albumUrl.split('/').at(-1) === canonicalUrl.split('/').at(-1)
+	) {
 		const albumArtistNode = document.querySelectorAll(
 			'main div[class^="_detailContainer"] .artist-link a',
 		);

--- a/src/connectors/tidal.ts
+++ b/src/connectors/tidal.ts
@@ -38,17 +38,15 @@ Connector.albumSelector = [
 ];
 
 Connector.getAlbumArtist = () => {
-	const albumUrl = Util.getAttrFromSelectors(Connector.albumSelector, 'href');
-	const canonicalUrl = Util.getAttrFromSelectors(
+	const albumUrlSegments = Util.getAttrFromSelectors(Connector.albumSelector, 'href')?.split('/');
+	const pageUrlSegments = Util.getAttrFromSelectors(
 		'head meta[name="apple-itunes-app"]',
 		'content',
-	);
+	)?.split('/');
 	if (
-		albumUrl &&
-		canonicalUrl &&
-		'album' === albumUrl.split('/').at(-2) &&
-		'album' === canonicalUrl.split('/').at(-2) &&
-		albumUrl.split('/').at(-1) === canonicalUrl.split('/').at(-1)
+		'album' === albumUrlSegments?.at(-2) &&
+		'album' === pageUrlSegments?.at(-2) &&
+		albumUrlSegments?.at(-1) === pageUrlSegments?.at(-1)
 	) {
 		const albumArtistNode = document.querySelectorAll(
 			'main div[class^="_detailContainer"] .artist-link a',


### PR DESCRIPTION
The "canonical" link is gone; The same data is stored in a `apple-itunes-app` meta tag.

The container for artist details is slightly different. See #5213.

The information about an album page is no longer a full URL, so we match on the
last two segments, which should be a literal "album" and then its ID.