### PR TITLE
fix: radio.de connector

### DIFF
--- a/src/connectors/radio.de.ts
+++ b/src/connectors/radio.de.ts
@@ -1,15 +1,17 @@
 export {};
 
-Connector.playerSelector = 'div.player-nav-holder';
+Connector.playerSelector = '[data-testid=sticky-player]';
 
 Connector.getArtistTrack = () => {
-	const text = Util.getTextFromSelectors('span');
-	const m = text?.match(/(.*?) - (.*?) auf (.*?)/);
-	if (m && m.length === 4) {
-		return { artist: m[1], track: m[2] };
+	const text = Util.getTextFromSelectors('[data-testid=status-display]');
+
+	if (text) {
+		const artist = text.split(' - ')[0];
+		const track = text.split(' - ')[1];
+		return { artist, track };
 	}
 	return null;
 };
 
 Connector.isPlaying = () =>
-	Util.getAttrFromSelectors('.player_playbutton', 'title') !== 'Wiedergabe';
+	Util.getAttrFromSelectors('[data-testid=global-player-pause]', 'title') !== 'Wiedergabe';

--- a/src/connectors/radio.de.ts
+++ b/src/connectors/radio.de.ts
@@ -6,9 +6,7 @@ Connector.getArtistTrack = () => {
 	const text = Util.getTextFromSelectors('[data-testid=status-display]');
 
 	if (text) {
-		const artist = text.split(' - ')[0];
-		const track = text.split(' - ')[1];
-		return { artist, track };
+		return Util.splitArtistTrack(text);
 	}
 	return null;
 };

--- a/src/connectors/radio.de.ts
+++ b/src/connectors/radio.de.ts
@@ -12,4 +12,5 @@ Connector.getArtistTrack = () => {
 };
 
 Connector.isPlaying = () =>
-	Util.getAttrFromSelectors('[data-testid=global-player-pause]', 'title') !== 'Wiedergabe';
+	Util.getAttrFromSelectors('[data-testid=global-player-pause]', 'title') !==
+	'Wiedergabe';


### PR DESCRIPTION
<!-- 
  Thank you for taking the time to contribute to this project!

  Make sure to check out our guide on contributing with guidelines of how to contribute.

  See: https://github.com/web-scrobbler/web-scrobbler/blob/master/.github/CONTRIBUTING.md

--> 

**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->

This PR adjusts the query selectors, as it seems that radio.de has updated its website. It now uses the `data-testid` attribute since they are using Tailwind, making it difficult to retrieve elements without proper IDs or class names. I believe `data-testid` is more reliable.

**Additional context**
<!-- Add any other context or screenshots here. -->

<img width="421" alt="image" src="https://github.com/user-attachments/assets/1e042501-5f5b-4e41-9288-123ac810e9b5" />

