### PR TITLE
Fix Yandex Music connector

### DIFF
--- a/src/connectors/yandex-music.ts
+++ b/src/connectors/yandex-music.ts
@@ -1,23 +1,89 @@
+// Some code used from https://github.com/mukhinid/web-scrobbler/commit/a5c9c955d3143bbb436954c4abd395505e3d6b09
 export {};
 
-let trackInfo = {};
-let isPlaying = false;
+setupConnector();
 
-Connector.isPlaying = () => isPlaying;
-
-Connector.getTrackInfo = () => trackInfo;
-
-Connector.onScriptEvent = (e) => {
-	switch (e.data.type) {
-		case 'YANDEX_MUSIC_STATE':
-			trackInfo = e.data.trackInfo as object;
-			isPlaying = e.data.isPlaying as boolean;
-
-			Connector.onStateChanged();
-			break;
-		default:
-			break;
+function setupConnector() {
+	if (isOldDesign()) {
+		setupOldDesignConnector();
+	} else {
+		setupNewDesignConnector();
 	}
-};
+}
 
-Connector.injectScript('connectors/yandex-music-dom-inject.js');
+function isOldDesign() {
+	return (
+		(window as unknown as { externalAPI: unknown }).externalAPI !==
+		undefined
+	);
+}
+
+function setupNewDesignConnector() {
+	// Player
+	Connector.playerSelector = 'section[class*=PlayerBar_root__]';
+
+	Connector.pauseButtonSelector = [
+		'button[aria-label=Pause]',
+		'button[aria-label=Пауза]',
+		'button[aria-label=Pauza]',
+		'button[aria-label=Үзіліс]',
+	];
+
+	// Track info
+	Connector.trackSelector = `${Connector.playerSelector} span[class*=Meta_title__]`;
+
+	Connector.artistSelector = `${Connector.playerSelector} span[class*=Meta_artistCaption__]`;
+
+	Connector.trackArtSelector = [
+		'section img[class*=PlayerBarDesktop_cover__]',
+		'section img[class*=PlayerBarMobile_cover__]',
+	];
+
+	// Duration
+	Connector.currentTimeSelector =
+		'section span[class*=Timecode_root_start__]';
+	Connector.durationSelector = 'section span[class*=Timecode_root_end__]';
+
+	// Likes
+	Connector.loveButtonSelector = [
+		'div[class*=PlayerBarDesktop_infoButtons__] button',
+		'div[class*=PlayerBarMobile_infoButtons__] button',
+	];
+
+	Connector.isLoved = () => {
+		const loved = Util.getAttrFromSelectors(
+			Connector.loveButtonSelector,
+			'aria-pressed',
+		);
+
+		if (loved === null) {
+			return null;
+		}
+
+		return loved === 'true';
+	};
+}
+
+function setupOldDesignConnector() {
+	let trackInfo = {};
+	let isPlaying = false;
+
+	Connector.isPlaying = () => isPlaying;
+
+	Connector.getTrackInfo = () => trackInfo;
+
+	Connector.onScriptEvent = (e) => {
+		switch (e.data.type) {
+			case 'YANDEX_MUSIC_STATE':
+				trackInfo = e.data.trackInfo as object;
+				isPlaying = e.data.isPlaying as boolean;
+
+				Connector.onStateChanged();
+				break;
+			default:
+				break;
+		}
+	};
+
+	Connector.injectScript('connectors/yandex-music-dom-inject.js');
+}


### PR DESCRIPTION
**Describe the changes you made**
Yandex Music updated its design, which caused the corresponding connector to stop working. This PR fixes the old connector, and also fixes some issues from #5292 (in particular, wrong track title and artist).
In addition to the fixes, the updated connector uses track duration for scrobbling, and adds the ability to like the track.

**Additional context**
Closes #5302 #5254 #5244 #5233 #5194 #5134 #5095 #5025 #4979
