### PR TITLE
more correct detection of the old design Yandex Music

### DIFF
--- a/src/connectors/yandex-music.ts
+++ b/src/connectors/yandex-music.ts
@@ -13,7 +13,7 @@ function setupConnector() {
 function isOldPlayer() {
 	return (
 		(window as unknown as { externalAPI: unknown }).externalAPI !==
-		undefined
+		undefined || document.querySelector('.head-kids__new-design')
 	);
 }
 


### PR DESCRIPTION
**Describe the changes you made**

https://github.com/web-scrobbler/web-scrobbler/pull/5292 added support for the new Yandex Music design, but the implementation of the detection of the old design does not work correctly. WS can be loaded before initializing `window.externalAPI`. So I added an additional check for the presence of a button that suggests switching to a new design:

<img width="537" src="https://github.com/user-attachments/assets/a11c1d67-d6b0-431c-9299-3332916341d1" />


**Additional context**

@mukhinid since you have implemented a new connector, maybe you can add comments
