### PR TITLE
Fixed spotify connector

### DIFF
--- a/src/connectors/spotify.ts
+++ b/src/connectors/spotify.ts
@@ -4,9 +4,9 @@ const playerBar = '.Root [data-testid="now-playing-bar"]';
 
 const artistSelector = `${playerBar} [data-testid="context-item-info-artist"]`;
 const oldPlayingPath =
-	'M2.7 1a.7.7 0 00-.7.7v12.6a.7.7 0 00.7.7h2.6a.7.7 0 00.7-.7V1.7a.7.7 0 00-.7-.7H2.7zm8 0a.7.7 0 00-.7.7v12.6a.7.7 0 00.7.7h2.6a.7.7 0 00.7-.7V1.7a.7.7 0 00-.7-.7h-2.6z';
-const newPlayingPath =
 	'M2.7 1a.7.7 0 0 0-.7.7v12.6a.7.7 0 0 0 .7.7h2.6a.7.7 0 0 0 .7-.7V1.7a.7.7 0 0 0-.7-.7H2.7zm8 0a.7.7 0 0 0-.7.7v12.6a.7.7 0 0 0 .7.7h2.6a.7.7 0 0 0 .7-.7V1.7a.7.7 0 0 0-.7-.7h-2.6z';
+const newPlayingPath =
+	'M2.7 1a.7.7 0 0 0-.7.7v12.6a.7.7 0 0 0 .7.7h2.6a.7.7 0 0 0 .7-.7V1.7a.7.7 0 0 0-.7-.7zm8 0a.7.7 0 0 0-.7.7v12.6a.7.7 0 0 0 .7.7h2.6a.7.7 0 0 0 .7-.7V1.7a.7.7 0 0 0-.7-.7z';
 const spotifyConnectSelector = `${playerBar} [aria-live="polite"]`;
 const oldPauseButtonSelector = `${playerBar} [data-testid=control-button-playpause] svg path[d="${oldPlayingPath}"]`;
 const newPauseButtonSelector = `${playerBar} [data-testid=control-button-playpause] svg path[d="${newPlayingPath}"]`;


### PR DESCRIPTION
To address recent changes on open.spotify.com, I changed the pause selector.

I moved the previously used paths from `newPlayingPath` to `oldPlayingPath` and updated `newPlayingPath` with the path currently used by Spotify. This ensures compatibility for users who may receive the interface update at a later time.

Tested locally with Firefox, it's working again.

Fixes #5384, fixes #5385, fixes #5387, fixes #5395, fixes #5396, fixes #5398, fixes #5412, fixes #5413