### PR TITLE
Fix YoutubeMusic Album detection

### DIFF
--- a/src/connectors/youtube-music-dom-inject.ts
+++ b/src/connectors/youtube-music-dom-inject.ts
@@ -42,7 +42,7 @@ if ('cleanup' in window && typeof window.cleanup === 'function') {
 	});
 
 	observer.observe(SongInfo as Node, {
-		characterData: true,
+		attributes: true,
 		subtree: true,
 	});
 


### PR DESCRIPTION
**Describe the changes you made**
changed the mutationObserver to observe attributes instead of text, Youtube loads the album name into the text field corretly initially, but on some songs initially sets a wrong link and reports a wrong album in the mediaSession api for some reason, it fixes this quickly, however the extention doesn't detect this change since the observer was only looking at the actual name, which has not changed as it was loaded correctly from the start.

**Additional context**
no longer observing the text should not cause any issues since the links have to change any time the song changes anyways
fixes #5414, fixes #5420
