### PR TITLE
Fix self-hosted HTTP-only scrobbling services in Firefox

### DIFF
--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -98,6 +98,10 @@ export const firefoxManifest: Manifest.WebExtensionManifest = {
 			id: '{799c0914-748b-41df-a25c-22d008f9e83f}',
 		},
 	},
+
+	content_security_policy: {
+		extension_pages: "script-src 'self';",
+	},
 };
 
 /**


### PR DESCRIPTION
<!-- 
  Thank you for taking the time to contribute to this project!

  Make sure to check out our guide on contributing with guidelines of how to contribute.

  See: https://github.com/web-scrobbler/web-scrobbler/blob/master/.github/CONTRIBUTING.md

--> 

**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
Disabled 'upgrade-insecure-requests' CSP policy to allow connecting to self-hosted HTTP-only Maloja or other scrobbling servers in Firefox.

**Additional context**
<!-- Add any other context or screenshots here. -->
Firefox's default CSP policy automatically upgrades HTTP connections to HTTPS, which prevents self-hosted HTTP-only servers from working.