### PR TITLE
Add missing export to remaining connectors

### DIFF
--- a/src/connectors/azuracast.ts
+++ b/src/connectors/azuracast.ts
@@ -1,3 +1,5 @@
+export {};
+
 Connector.useMediaSessionApi();
 
 Connector.playerSelector = '.radio-player-widget';

--- a/src/connectors/khinsider.ts
+++ b/src/connectors/khinsider.ts
@@ -1,3 +1,5 @@
+export {};
+
 Connector.trackSelector = '#songlist > tbody > tr.plSel > .clickable-row a';
 
 Connector.isPlaying = () =>
@@ -15,6 +17,7 @@ Connector.artistSelector = '#pageContent > p[align="left"]';
 const filter = MetadataFilter.createFilter({
 	artist: cleanupArtist,
 });
+
 Connector.applyFilter(filter);
 
 function cleanupArtist(text: string) {

--- a/src/connectors/subphonic.ts
+++ b/src/connectors/subphonic.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+export {};
+
 Connector.playerSelector = '#playdeck';
 
 Connector.getArtist = () => {

--- a/src/connectors/tidal.ts
+++ b/src/connectors/tidal.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+export {};
+
 Connector.playerSelector = '#footerPlayer';
 
 Connector.playButtonSelector = `${Connector.playerSelector} button[data-test="play"]`;


### PR DESCRIPTION
In #5536 aside from the filter const mismatch there was an issue with tsc flagging the filter const. This change adds export to the remaining connectors missing it.