### PR TITLE
Fix warnings around missing await for edit test cases

### DIFF
--- a/tests/background/saved-edits.test.ts
+++ b/tests/background/saved-edits.test.ts
@@ -54,14 +54,14 @@ function testSaveEmptySong() {
 	emptySavedEdits();
 	const emptySong = makeNonProcessedSong();
 
-	it('should throw an error while loading info of an empty song', () => {
-		expect(savedEdits.loadSongInfo(emptySong)).rejects.to.deep.equal(
+	it('should throw an error while loading info of an empty song', async () => {
+		await expect(savedEdits.loadSongInfo(emptySong)).rejects.to.deep.equal(
 			new Error('Empty song'),
 		);
 	});
 
-	it('should throw an error while saving an empty song', () => {
-		expect(
+	it('should throw an error while saving an empty song', async () => {
+		await expect(
 			savedEdits.saveSongInfo(emptySong, editedInfo),
 		).rejects.to.deep.equal(new Error('Empty song'));
 	});


### PR DESCRIPTION
Warnings were being raised about not awaiting