### PR TITLE
deploy on publish, add extensions to release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,8 @@
 name: Deploy
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types: [published]
 
 jobs:
   deploy-chrome:
@@ -24,6 +23,12 @@ jobs:
 
       - name: Create zipball
         run: npm run dist chrome
+
+      - name: Attach extension to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} web-scrobbler-chrome.zip
 
       - name: Publish the extension for Chrome
         uses: trmcnvn/chrome-addon@v2
@@ -52,6 +57,12 @@ jobs:
 
       - name: Create zipball
         run: npm run dist firefox
+
+      - name: Attach extension to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} web-scrobbler-firefox.zip
 
       - name: Publish the extension for Firefox
         uses: yayuyokitano/firefox-addon@v0.0.6-alpha


### PR DESCRIPTION
- Change deploy to be after release publish
- Add extensions to release when we release version
  - Perhaps we could eventually fetch the signed XPI eventually so make it easier for installation. 