### PR TITLE
Update TIDAL URL.

### DIFF
--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -318,7 +318,7 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'Tidal',
-		matches: ['*://listen.tidalhifi.com/*', '*://listen.tidal.com/*'],
+		matches: ['*://tidal.com/*'],
 		js: 'tidal.js',
 		id: 'tidal',
 	},


### PR DESCRIPTION
`tidalhifi.com` was already old and `listen.tidal.com` now redirects to
`tidal.com`.