### PR TITLE
Update VK URL.

### DIFF
--- a/src/connectors/vk-dom-inject.ts
+++ b/src/connectors/vk-dom-inject.ts
@@ -1,5 +1,5 @@
 /**
- * This script runs in non-isolated environment (vk.com itself)
+ * This script runs in non-isolated environment (vk.ru itself)
  * for accessing `window.ap` which sends player events.
  *
  * Script is run as an IIFE to ensure variables are scoped, as in the event

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -103,7 +103,7 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'VK',
-		matches: ['*://vk.com/*'],
+		matches: ['*://vk.ru/*'],
 		js: 'vk.js',
 		id: 'vk',
 	},

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -103,7 +103,7 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'VK',
-		matches: ['*://vk.ru/*'],
+		matches: ['*://vk.ru/*', '*://vk.com/*'],
 		js: 'vk.js',
 		id: 'vk',
 	},


### PR DESCRIPTION
**Describe the changes you made**
VK has been moved to `vk.ru`  domain, but still also continues to work on `vk.com`. Based on https://habr.com/ru/news/943232/

**Additional context**
None
