### PR TITLE
Match Archaic Horizon on non-www

### DIFF
--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2656,7 +2656,7 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'Archaic Horizon',
-		matches: ['*://www.archaichorizon.com/*'],
+		matches: ['*://archaichorizon.com/*', '*://www.archaichorizon.com/*'],
 		js: 'archaichorizon.js',
 		id: 'archaichorizon',
 	},


### PR DESCRIPTION
Site is served on www and non-www so we should support both.