### PR TITLE
Fix Mirlo scrobbling the first track of certain releases repeatedly.

### DIFF
--- a/src/connectors/mirlo.ts
+++ b/src/connectors/mirlo.ts
@@ -1,9 +1,9 @@
 export {};
 
 Connector.playerSelector = '#player';
-Connector.trackSelector = '#player-track-title';
-Connector.artistSelector = '#player-artist-name';
-Connector.albumSelector = '#player-trackGroup-title';
+Connector.trackSelector = '#player #player-track-title';
+Connector.artistSelector = '#player #player-artist-name';
+Connector.albumSelector = '#player #player-trackGroup-title';
 Connector.trackArtSelector = '#player img';
 Connector.isPlaying = () =>
 	Util.getAttrFromSelectors('#player .play-button', 'aria-label') !== 'Play';

--- a/src/connectors/mirlo.ts
+++ b/src/connectors/mirlo.ts
@@ -1,9 +1,9 @@
 export {};
 
 Connector.playerSelector = '#player';
-Connector.trackSelector = '#player #player-track-title';
-Connector.artistSelector = '#player #player-artist-name';
-Connector.albumSelector = '#player #player-trackGroup-title';
-Connector.trackArtSelector = '#player img';
+Connector.trackSelector = `${Connector.playerSelector} #player-track-title`;
+Connector.artistSelector = `${Connector.playerSelector} #player-artist-name`;
+Connector.albumSelector = `${Connector.playerSelector} #player-trackGroup-title`;
+Connector.trackArtSelector = `${Connector.playerSelector} img`;
 Connector.isPlaying = () =>
-	Util.getAttrFromSelectors('#player .play-button', 'aria-label') !== 'Play';
+	Util.getAttrFromSelectors(`${Connector.playerSelector} .play-button`, 'aria-label') !== 'Play';

--- a/src/connectors/mirlo.ts
+++ b/src/connectors/mirlo.ts
@@ -5,9 +5,7 @@ Connector.trackSelector = `${Connector.playerSelector} #player-track-title`;
 Connector.artistSelector = `${Connector.playerSelector} #player-artist-name`;
 Connector.albumSelector = `${Connector.playerSelector} #player-trackGroup-title`;
 Connector.trackArtSelector = `${Connector.playerSelector} img`;
-Connector.playButtonSelector = `${Connector.playerSelector} .play-button`
+Connector.playButtonSelector = `${Connector.playerSelector} .play-button`;
 Connector.isPlaying = () =>
-	Util.getAttrFromSelectors(
-		Connector.playButtonSelector,
-		'aria-label',
-	) !== 'Play';
+	Util.getAttrFromSelectors(Connector.playButtonSelector, 'aria-label') !==
+	'Play';

--- a/src/connectors/mirlo.ts
+++ b/src/connectors/mirlo.ts
@@ -5,5 +5,9 @@ Connector.trackSelector = `${Connector.playerSelector} #player-track-title`;
 Connector.artistSelector = `${Connector.playerSelector} #player-artist-name`;
 Connector.albumSelector = `${Connector.playerSelector} #player-trackGroup-title`;
 Connector.trackArtSelector = `${Connector.playerSelector} img`;
+Connector.playButtonSelector = `${Connector.playerSelector} .play-button`
 Connector.isPlaying = () =>
-	Util.getAttrFromSelectors(`${Connector.playerSelector} .play-button`, 'aria-label') !== 'Play';
+	Util.getAttrFromSelectors(
+		Connector.playButtonSelector,
+		'aria-label',
+	) !== 'Play';


### PR DESCRIPTION
#5582 

Increased specificity of artist and track selectors. It appears Mirlo just had some repeating IDs in the code, so the artist and song were being picked up by the first instance of the ID. Since there is an assumption in valid HTML that there's only one ID per page, and that wasn't true, Web Scrobbler was finding the first instance and stopped looking on the page. 
