### PR TITLE
Target ES2022.

### DIFF
--- a/src/core/scrobbler/listenbrainz/listenbrainz-scrobbler.ts
+++ b/src/core/scrobbler/listenbrainz/listenbrainz-scrobbler.ts
@@ -22,8 +22,8 @@ const listenBrainzTokenPage = 'https://listenbrainz.org/settings/';
 const baseUrl = 'https://api.listenbrainz.org/1';
 const apiUrl = `${baseUrl}/submit-listens`;
 export default class ListenBrainzScrobbler extends BaseScrobbler<'ListenBrainz'> {
-	public userApiUrl!: string;
-	public userToken!: string;
+	declare public userApiUrl: string;
+	declare public userToken: string;
 	public isLocalOnly = false;
 
 	public async getSongInfo(): Promise<Record<string, never>> {

--- a/src/core/scrobbler/maloja/maloja-scrobbler.ts
+++ b/src/core/scrobbler/maloja/maloja-scrobbler.ts
@@ -12,8 +12,8 @@ import type { MalojaTrackMetadata } from '@/core/scrobbler/maloja/maloja.types';
  */
 
 export default class MalojaScrobbler extends BaseScrobbler<'Maloja'> {
-	public userToken!: string;
-	public userApiUrl!: string;
+	declare public userToken: string;
+	declare public userApiUrl: string;
 	public isLocalOnly = true;
 
 	/** @override */

--- a/src/core/scrobbler/pleroma/pleroma-scrobbler.ts
+++ b/src/core/scrobbler/pleroma/pleroma-scrobbler.ts
@@ -15,8 +15,8 @@ import type {
  */
 
 export default class PleromaScrobbler extends BaseScrobbler<'Pleroma'> {
-	public userToken!: string;
-	public userApiUrl!: string;
+	declare public userToken: string;
+	declare public userApiUrl: string;
 	public isLocalOnly = true;
 
 	/** @override */

--- a/src/core/scrobbler/webhook-scrobbler.ts
+++ b/src/core/scrobbler/webhook-scrobbler.ts
@@ -23,7 +23,7 @@ type WebhookRequest = {
  */
 
 export default class WebhookScrobbler extends BaseScrobbler<'Webhook'> {
-	public userApiUrl!: string;
+	declare public userApiUrl: string;
 	public isLocalOnly = true;
 
 	/** @override */

--- a/tsconfig.connectors.json
+++ b/tsconfig.connectors.json
@@ -12,7 +12,7 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
-    "target": "ES2020"
+    "target": "ES2022"
   },
   "include": ["src/connectors"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
-    "target": "ES2020"
+    "target": "ES2022"
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
The bang trick doens't work any more, but declare does the same thing.

Note this isn't actually necessary for the way the ListenBrainz scrobbler is written, but I've kept it isomorphic.