### PR TITLE
Rewrite BBC Sounds connector for current site structure

### DIFF
--- a/src/connectors/bbc-sounds.ts
+++ b/src/connectors/bbc-sounds.ts
@@ -3,40 +3,48 @@ export {};
 Connector.playerSelector = '[data-testid="rail-recent_tracks"]';
 
 Connector.isPlaying = () => {
-  const btn = document.querySelector('[data-testid="play_pause_button"]');
-  return btn?.getAttribute('aria-label')?.toUpperCase() === 'PAUSE';
+	const btn = document.querySelector('[data-testid="play_pause_button"]');
+	return btn?.getAttribute('aria-label')?.toUpperCase() === 'PAUSE';
 };
 
 Connector.scrobblingDisallowedReason = () => {
-  const firstTrack = document.querySelector('[data-testid="rail-recent_tracks"] li:nth-child(2)');
-  const hasNowPlaying = firstTrack?.textContent?.toLowerCase().includes('now playing');
-  return hasNowPlaying ? null : 'Other';
+	const firstTrack = document.querySelector(
+		'[data-testid="rail-recent_tracks"] li:nth-child(2)',
+	);
+	const hasNowPlaying = firstTrack?.textContent
+		?.toLowerCase()
+		.includes('now playing');
+	return hasNowPlaying ? null : 'Other';
 };
 
 Connector.getArtistTrack = () => {
-  const firstTrack = document.querySelector('[data-testid="rail-recent_tracks"] li:nth-child(2)');
-  
-  if (!firstTrack?.textContent?.toLowerCase().includes('now playing')) {
-    return null;
-  }
+	const firstTrack = document.querySelector(
+		'[data-testid="rail-recent_tracks"] li:nth-child(2)',
+	);
 
-  const cleanText = (firstTrack as HTMLElement).innerText
-    .replace(/(^\d\.|\nnow playing)/gi, '')
-    .trim();
-  
-  const parts = cleanText.split('\n');
-  const track = parts[0]?.trim();
-  const artist = parts[1]?.trim();
-  
-  return artist && track ? { artist, track } : null;
+	if (!firstTrack?.textContent?.toLowerCase().includes('now playing')) {
+		return null;
+	}
+
+	const cleanText = (firstTrack as HTMLElement).innerText
+		.replace(/(^\d\.|\nnow playing)/gi, '')
+		.trim();
+
+	const parts = cleanText.split('\n');
+	const track = parts[0]?.trim();
+	const artist = parts[1]?.trim();
+
+	return artist && track ? { artist, track } : null;
 };
 
 Connector.getTrackArt = () => {
-  const firstTrack = document.querySelector('[data-testid="rail-recent_tracks"] li:nth-child(2)');
-  
-  if (!firstTrack?.textContent?.toLowerCase().includes('now playing')) {
-    return null;
-  }
-  
-  return firstTrack.querySelector('img')?.src || null;
+	const firstTrack = document.querySelector(
+		'[data-testid="rail-recent_tracks"] li:nth-child(2)',
+	);
+
+	if (!firstTrack?.textContent?.toLowerCase().includes('now playing')) {
+		return null;
+	}
+
+	return firstTrack.querySelector('img')?.src || null;
 };


### PR DESCRIPTION
**Context**
The BBC Sounds connector was completely broken due to BBC's site redesign. Old selectors (`.sc-c-tracks`, `.sc-c-basic-tile`, etc.) no longer exist.

FIXES  @ISSUE#5646

**Changes made**
- Complete rewrite to work with current BBC Sounds structure
- Uses "Recent Tracks" list (`<ol>`) to detect currently playing songs
- Detects tracks by finding "Now Playing" text in track list
- Properly handles presenter segments (stops scrobbling when no music)
- Clean extraction of track titles and artist names

**Testing**
Tested on BBC 6 Music live stream with multiple track changes and presenter talk segments.

**Scope**
This PR focuses on live radio streams. Other BBC Sounds content may need separate investigation.
