### PR TITLE
Improve handling of compilations on Bandcamp

### DIFF
--- a/src/connectors/bandcamp.ts
+++ b/src/connectors/bandcamp.ts
@@ -335,11 +335,15 @@ function isArtistVarious(artist: string | null, track: string | null) {
 	 * Example: https://krefeld8ung.bandcamp.com/album/krefeld-8ung-vol-1
 	 */
 	if (trackNodes.length !== 0) {
-		const artists = Iterator.from(trackNodes)
+		const artists = [...trackNodes]
 			.map((trackNode) => trackNode.textContent)
-			.filter((trackName) => Util.findSeparator(trackName ?? '', SEPARATORS))
-			.map((trackName) => Util.splitArtistTrack(trackName, SEPARATORS).artist)
-			.toArray();
+			.filter((trackName) =>
+				Util.findSeparator(trackName ?? '', SEPARATORS),
+			)
+			.map(
+				(trackName) =>
+					Util.splitArtistTrack(trackName, SEPARATORS).artist,
+			);
 
 		/*
 		 * We allow one single track without a separator, as sometimes mixed versions
@@ -347,7 +351,7 @@ function isArtistVarious(artist: string | null, track: string | null) {
 		 * Example: https://leonvynehall.bandcamp.com/album/fabric-presents-leon-vynehall
 		 */
 		if (trackNodes.length - artists.length > 1) {
-			return false
+			return false;
 		}
 
 		/*


### PR DESCRIPTION
<!-- 
  Thank you for taking the time to contribute to this project!

  Make sure to check out our guide on contributing with guidelines of how to contribute.

  See: https://github.com/web-scrobbler/web-scrobbler/blob/master/.github/CONTRIBUTING.md

--> 

**Describe the changes you made**

Instead of *all* tracks of a release needing to have the format `artist - track`, this change allows at most one single track on the release to have a different format.

**Additional context**

I found it quite common for compilations to have mixed versions. See the DJ Kicks series here: https://erisdrew.bandcamp.com/album/dj-kicks-eris-drew (consistently across releases https://modeselektor.bandcamp.com/album/dj-kicks-modeselektor-2) or the example linked in this PR's patch, where the first track is the continuous mix: https://leonvynehall.bandcamp.com/album/fabric-presents-leon-vynehall

Before this change all tracks would be scrobbled as `Release Artist - Track Artist - Track Name`. After this change all linked examples are scrobbled correctly.

I have also refactored the function to no longer use an imperative loop, but express its logic with `.map` and `.filter`. It already used `Array.prototype.every`, so I felt it's easier if it didn't switch between both programming styles. At the moment this means it will construct four arrays. I tried to use the `Iterator` transformation methods, but TypeScript complained, and I did not want to change the TypeScript config for the entire project. Sorry for the noise this caused in the commit messages.

A bit of a meta comment: I think it's very odd that prettier inserts a comma in those arrow functions (for example [here](https://github.com/web-scrobbler/web-scrobbler/pull/5693/commits/f9fc40663bdcbf8d22b65519666f81e9ed34eb04#diff-13c0915e803757a2b69ef4f2bb15dd350c29095ee07de57b07b0937b0411435bR345)). I actually went and executed this code myself because I was afraid this might cause the function to not just return that statement, but apparently it's fine. It's still noise that makes understanding what happens harder in my opinion.