### PR TITLE
fix: Resolve issue in Ampwall connector where multi-artist tracks not tracked correctly

### DIFF
--- a/src/connectors/ampwall.ts
+++ b/src/connectors/ampwall.ts
@@ -74,7 +74,7 @@ function parseArtistTrackData(text: string, track: string) {
 	let updatedTrack = track;
 	if (artists.length > 1) {
 		const joinedArtists = artists.slice(1).join(', ');
-		updatedTrack = `${track} (ft. {joinedArtists})`;
+		updatedTrack = `${track} (ft. ${joinedArtists})`;
 	}
 
 	return { artist: artists[0], track: updatedTrack };


### PR DESCRIPTION
Typo in string formatting was causing mult-artist tracks to be tracked incorrectly. Fixes this typo.