### PR TITLE
Suno Connector: Update selectors for new Playbar markup (Nov 2025)

### DIFF
--- a/src/connectors/suno.ts
+++ b/src/connectors/suno.ts
@@ -1,6 +1,7 @@
 export {};
 
-const durationSelector = 'span[aria-label^="Playbar: Duration for"]';
+const currentTimeSelector = 'div.min-w-8.text-right.text-xs';
+const durationTimeSelector = 'div.min-w-8.text-left.text-xs';
 
 enum TimePart {
 	Current = 'current',
@@ -8,7 +9,7 @@ enum TimePart {
 }
 
 Connector.playerSelector =
-	'div:has(a[aria-label^="Playbar: Title"]):has(button[aria-label^="Playbar: Play button"])';
+	'div:has(a[aria-label^="Playbar: Title"]):has(button[aria-label^="Playbar: Play button"], button[aria-label^="Playbar: Pause button"])';
 
 Connector.artistSelector = 'a[aria-label^="Playbar: Artist"]';
 
@@ -23,27 +24,12 @@ Connector.getDuration = () => getTimeSeconds(TimePart.Duration);
 Connector.playButtonSelector = 'button[aria-label^="Playbar: Play button"]';
 
 /**
- * Retrieves the time value in seconds from the DOM element for the specified time part.
- *
- * This function finds the element using the provided `durationSelector`, splits its text content
- * by the "/" character, and then converts the appropriate segment into seconds using `Util.stringToSeconds`.
- *
- * @param part - Specifies which part of the time to retrieve:
- *               TimePart.Current returns the current playback time,
- *               TimePart.Duration returns the total duration.
- * @returns A number representing the time in seconds.
+ * Get time in seconds from the playbar time elements.
+ * Uses the left (current) and right (duration) time labels.
  */
 function getTimeSeconds(part: TimePart): number {
-	const timeElement = document.querySelector(durationSelector);
-	if (!timeElement || !timeElement.textContent) {
-		return Util.stringToSeconds('');
-	}
-	const [currentTimeStr, durationStr] = timeElement.textContent
-		.split('/')
-		.map((str) => str.trim());
-	if (part === TimePart.Current) {
-		return Util.stringToSeconds(currentTimeStr ?? '');
-	}
-
-	return Util.stringToSeconds(durationStr ?? '');
+	const selector =
+		part === TimePart.Current ? currentTimeSelector : durationTimeSelector;
+	const el = document.querySelector(selector);
+	return Util.stringToSeconds(el?.textContent?.trim() ?? '');
 }


### PR DESCRIPTION
<!-- 
  Thank you for taking the time to contribute to this project!

  Make sure to check out our guide on contributing with guidelines of how to contribute.

  See: https://github.com/web-scrobbler/web-scrobbler/blob/master/.github/CONTRIBUTING.md

--> 

**Describe the changes you made**
- Broaden `playerSelector` to match both Play and Pause button variants so the connector observes state in either UI state.
- Replace the old combined time element parsing with direct selectors for the new left/right time labels:
  - Current time: `div.min-w-8.text-right.text-xs`
  - Duration: `div.min-w-8.text-left.text-xs`
- Kept existing `aria-label`-based selectors for artist, title, and cover image since they still match the new markup.
- Left `playButtonSelector` as the Play button; core uses its visibility to infer playing state, which remains correct with a separate Pause button present.

**Additional context**
- Based on the new Playbar HTML shared in the issue/description.
- Local build verification on Windows: `npm run build chrome` completed successfully.
- File touched: `src/connectors/suno.ts`.

If acceptable, please also update the PR title to the one proposed above. If you prefer, I can update the title/body directly given appropriate permissions.

Fixes #4886