### PR TITLE
Remove 'PRE-ORDER' from Bandcamp album titles

### DIFF
--- a/src/connectors/bandcamp.ts
+++ b/src/connectors/bandcamp.ts
@@ -14,12 +14,12 @@ const SEPARATORS: Separator[] = [' - ', ' | '];
 /**
  * This filter is applied after all page properties are initialized.
  */
-let bandcampFilter = MetadataFilter.createFilter(
-	MetadataFilter.createFilterSetForFields(
-		['artist', 'track', 'album', 'albumArtist'],
-		MetadataFilter.removeZeroWidth,
-	),
-);
+let bandcampFilter = MetadataFilter.createFilter({
+	artist: MetadataFilter.removeZeroWidth,
+	track: MetadataFilter.removeZeroWidth,
+	album: [MetadataFilter.removeZeroWidth, removePreOrderSuffix],
+	albumArtist: MetadataFilter.removeZeroWidth,
+});
 
 if (document.querySelector('main#p-tralbum-page') === null) {
 	setupDesktopConnector();
@@ -426,4 +426,8 @@ function removeByPrefix(text: string) {
 
 function removeFromPrefix(text: string) {
 	return text.replace('from ', '');
+}
+
+function removePreOrderSuffix(text: string) {
+	return text.replace(/ ?pre-order/i, '');
 }


### PR DESCRIPTION
**Describe the changes you made**

On their mobile browser interface, Bandcamp has added a badge that says 'PRE-ORDER' next to album titles, and this text now makes it into the scrobbled album title. This update fixes that by stripping that text.

**Additional context**

Before this change:

<img width="700" height="744" alt="image" src="https://github.com/user-attachments/assets/cba550dc-6540-412a-8382-076aa6e16a02" />

After this change:

<img width="693" height="743" alt="image" src="https://github.com/user-attachments/assets/9ba91af2-5791-4cbd-a5e6-53a8b2607d70" />
