### PR TITLE
Add support for The Indie Beat Television

### DIFF
--- a/src/connectors/theindiebeattv.ts
+++ b/src/connectors/theindiebeattv.ts
@@ -1,0 +1,27 @@
+export {};
+
+Connector.playerSelector = '#player';
+
+Connector.pauseButtonSelector = '#player button.vjs-playing';
+
+Connector.artistSelector = '#nowplaying .song-artist';
+
+Connector.trackSelector = '#nowplaying .song-title';
+
+// Duration is available in a `data-duration` attribute on #nowplaying.
+Connector.getDuration = () => {
+	const elements = Util.queryElements('#nowplaying');
+	if (!elements) {
+		return null;
+	}
+	for (const element of elements) {
+		if (element.dataset.duration) {
+			try {
+				return parseFloat(element.dataset.duration);
+			} catch {
+				// Ignore, try next element, though there probably isn't one.
+			}
+		}
+	}
+	return null;
+};

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2720,4 +2720,10 @@ export default <ConnectorMeta[]>[
 		js: 'teleplay.js',
 		id: 'teleplay',
 	},
+	{
+		label: 'The Indie Beat Television',
+		matches: ['*://tv.theindiebeat.fm/*'],
+		js: 'theindiebeattv.js',
+		id: 'theindiebeattv',
+	},
 ];


### PR DESCRIPTION
**Describe the changes you made**
Add a new connector for [The Indie Beat Television](https://tv.theindiebeat.fm/).

**Additional context**
Tested and verified locally.

Since this is a livestream with slightly different latency for each visitor, it doesn't have an "elapsed time" indicator (because it wouldn't be precise enough), but Web Scrobbler can deal with that just fine.

We are however provided with the duration of the track, allowing Web Scrobbler to be smart about when to scrobble.