### PR TITLE
chore: improve deploy pipeline to be re-run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload ${{ github.event.release.tag_name }} web-scrobbler-chrome.zip
+          gh release upload ${{ github.event.release.tag_name }} web-scrobbler-chrome.zip --clobber
 
       - name: Publish the extension for Chrome
         uses: trmcnvn/chrome-addon@v2
@@ -62,7 +62,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload ${{ github.event.release.tag_name }} web-scrobbler-firefox.zip
+          gh release upload ${{ github.event.release.tag_name }} web-scrobbler-firefox.zip --clobber
 
       - name: Publish the extension for Firefox
         uses: yayuyokitano/firefox-addon@v0.0.6-alpha


### PR DESCRIPTION
<!-- 
  Thank you for taking the time to contribute to this project!

  Make sure to check out our guide on contributing with guidelines of how to contribute.

  See: https://github.com/web-scrobbler/web-scrobbler/blob/master/.github/CONTRIBUTING.md

--> 

**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->

Allow the deploy pipeline to be run in case of failure with pushing to the stores by replacing release artifacts instead of erroring.

**Additional context**
<!-- Add any other context or screenshots here. -->
