### PR TITLE
Handle Safari CSP restriction for script injection (#5740)

### DIFF
--- a/src/core/content/util.ts
+++ b/src/core/content/util.ts
@@ -753,6 +753,23 @@ export function normalizeUrl(url: string | null | undefined): string | null {
  */
 /* istanbul ignore next */
 export function injectScriptIntoDocument(scriptUrl: string): void {
+	// On Safari, script tags with src pointing to safari-web-extension:// URLs
+	// are blocked by Content Security Policy. Fetch and inject inline instead.
+	if (scriptUrl.startsWith('safari-web-extension://')) {
+		fetch(scriptUrl)
+			.then((response) => response.text())
+			.then((scriptContent) => {
+				const script = document.createElement('script');
+				script.textContent = scriptContent;
+				(document.head || document.documentElement).appendChild(script);
+				script.remove();
+			})
+			.catch((err) => {
+				console.error('Failed to inject script on Safari:', err);
+			});
+		return;
+	}
+
 	const script = document.createElement('script');
 	script.src = scriptUrl;
 	script.onload = function () {


### PR DESCRIPTION
Fixed the Safari CSP issue for the YouTube Music connector.
**The Problem:**
On Safari, injecting scripts via <script src="safari-web-extension://..."> is blocked by the page's Content Security Policy.
**The Solution:**
Modified injectScriptIntoDocument in src/core/content/util.ts to detect Safari (when the script URL starts with safari-web-extension://).
**On Safari:** fetch the script content and inject it as inline code using script.textContent instead of script.src.
**On other browsers:** keep the original method (script tag with src).