### PR TITLE
Fix Poolsuite scrobbling via Media Session API (fixes #5375)

### DIFF
--- a/src/connectors/poolsuite.ts
+++ b/src/connectors/poolsuite.ts
@@ -1,11 +1,4 @@
 export {};
 
-Connector.playButtonSelector = '.middle.paused';
-Connector.playerSelector = '.inner-size';
-Connector.trackSelector = '.current-track h3';
-Connector.artistSelector = '.current-track h2';
-Connector.currentTimeSelector = '.timer span:nth-child(1)';
-Connector.durationSelector = '.timer span:nth-child(2)';
-
-Connector.scrobblingDisallowedReason = () =>
-	Connector.getTrack() === 'Loading...' ? 'IsLoading' : null;
+Connector.playerSelector = 'body';
+Connector.useMediaSessionApi();


### PR DESCRIPTION
**Describe the changes you made**

Replaced the old Poolsuite DOM-scraping connector with Media Session API support. Poolsuite now exposes track and artist via `navigator.mediaSession.metadata`, so Web Scrobbler can read it directly without brittle selectors.

**Additional context**

Fixes #5375.

Tested on [https://poolsuite.net](https://poolsuite.net) - track/artist update correctly when skipping tracks and scrobble normally.