### PR TITLE
Fix Youtube Music connector album info

### DIFF
--- a/src/connectors/youtube-music-dom-inject.ts
+++ b/src/connectors/youtube-music-dom-inject.ts
@@ -17,7 +17,7 @@ if ('cleanup' in window && typeof window.cleanup === 'function') {
 }
 
 (window as unknown as { cleanup: () => void }).cleanup = (() => {
-	const sendData = () => {
+	let pollInterval: number | null = window.setInterval(() => {
 		window.postMessage(
 			{
 				sender: 'web-scrobbler',
@@ -31,24 +31,12 @@ if ('cleanup' in window && typeof window.cleanup === 'function') {
 			},
 			'*',
 		);
-	};
-	const playPauseButton = document.getElementById('play-pause-button');
-	const SongInfo = document.querySelector('.content-info-wrapper');
-
-	const observer = new MutationObserver(sendData);
-
-	observer.observe(playPauseButton as Node, {
-		attributes: true,
-	});
-
-	observer.observe(SongInfo as Node, {
-		attributes: true,
-		subtree: true,
-	});
+	}, 1000);
 
 	return () => {
-		// remove the subscribers added by this extension from the array.
-		// we dont have a confirmed reference to it so we have to check all of them.
-		observer.disconnect();
+		if (pollInterval !== null) {
+			window.clearInterval(pollInterval);
+			pollInterval = null;
+		}
 	};
 })();

--- a/src/connectors/youtube-music-dom-inject.ts
+++ b/src/connectors/youtube-music-dom-inject.ts
@@ -16,21 +16,44 @@ if ('cleanup' in window && typeof window.cleanup === 'function') {
 	(window as unknown as { cleanup: () => void }).cleanup();
 }
 
+type MessagePayload = {
+	sender: 'web-scrobbler';
+	playbackState: MediaSessionPlaybackState;
+	metadata: {
+		title?: string;
+		artist?: string;
+		artwork?: readonly MediaImage[];
+		album?: string;
+	};
+};
+
 (window as unknown as { cleanup: () => void }).cleanup = (() => {
+	let previousPayload: MessagePayload | null = null;
+
 	let pollInterval: number | null = window.setInterval(() => {
-		window.postMessage(
-			{
-				sender: 'web-scrobbler',
-				playbackState: navigator.mediaSession.playbackState,
-				metadata: {
-					title: navigator.mediaSession.metadata?.title,
-					artist: navigator.mediaSession.metadata?.artist,
-					artwork: navigator.mediaSession.metadata?.artwork,
-					album: navigator.mediaSession.metadata?.album,
-				},
+		const payload: MessagePayload = {
+			sender: 'web-scrobbler',
+			playbackState: navigator.mediaSession.playbackState,
+			metadata: {
+				title: navigator.mediaSession.metadata?.title,
+				artist: navigator.mediaSession.metadata?.artist,
+				artwork: navigator.mediaSession.metadata?.artwork,
+				album: navigator.mediaSession.metadata?.album,
 			},
-			'*',
-		);
+		};
+
+		if (
+			!previousPayload ||
+			payload.playbackState !== previousPayload.playbackState ||
+			payload.metadata.title !== previousPayload.metadata.title ||
+			payload.metadata.artist !== previousPayload.metadata.artist ||
+			payload.metadata.artwork !== previousPayload.metadata.artwork ||
+			payload.metadata.album !== previousPayload.metadata.album
+		) {
+			window.postMessage(payload, '*');
+
+			previousPayload = payload;
+		}
 	}, 1000);
 
 	return () => {


### PR DESCRIPTION
**Describe the changes you made**

The YTM connector was using a MutationObserver to detect changes to the player. However, it seems YTM does not have the `album` value in the `mediaSession` object available at the moment the mutation observer handler is called. It album name seems to get added a short time afterward (about a second). I replaced the mutation observer with a setInterval, which seems to fix the issue. I could have done a combination of the mutation observer combined with a setTimeout, but this seemed like a simpler solution.

**Additional context**
This addresses #5511 and #5759. See those items for more info.
