### PR TITLE
Fix youtube connector using the timeline chapter name as track title

### DIFF
--- a/src/connectors/youtube.ts
+++ b/src/connectors/youtube.ts
@@ -43,6 +43,8 @@ const categoryUnknown = 'YT_DUMMY_CATEGORY_UNKNOWN';
 const categoryMusic = 'Music';
 const categoryEntertainment = 'Entertainment';
 
+const timelineChapterName = 'In this video';
+
 /**
  * Array of categories allowed to be scrobbled.
  */
@@ -491,6 +493,14 @@ function getTrackInfoFromChapters() {
 	}
 
 	const chapterName = Util.getTextFromSelectors(chapterNameSelector);
+
+	if (chapterName === timelineChapterName) {
+		return {
+			artist: null,
+			track: null,
+		};
+	}
+
 	const artistTrack = Util.processYtVideoTitle(chapterName);
 	if (!artistTrack.track) {
 		artistTrack.track = chapterName;


### PR DESCRIPTION
<!-- 
  Thank you for taking the time to contribute to this project!

  Make sure to check out our guide on contributing with guidelines of how to contribute.

  See: https://github.com/web-scrobbler/web-scrobbler/blob/master/.github/CONTRIBUTING.md

--> 

**Describe the changes you made**
I have excluded the chapter name "In this video" from being scrobbled as a track title as YouTube has started using it to show the timeline and/or transcript. I have not found any other distinction from normal chapters except for the name.
<!-- A clear and concise description of changes proposed in this pull request. -->

**Additional context**
This track has been used to test: https://www.youtube.com/watch?v=PeDv1IIVLJg
this fixes #5781 
<!-- Add any other context or screenshots here. -->
