### PR TITLE
Add connector for kiss.cz

### DIFF
--- a/src/connectors/kiss.ts
+++ b/src/connectors/kiss.ts
@@ -1,0 +1,27 @@
+export {};
+
+Connector.playerSelector = ['.current', '.player-wrapper'];
+
+Connector.artistSelector = '.artist';
+
+Connector.trackSelector = '.song';
+
+Connector.playButtonSelector = '#play:not(.hidden)';
+
+Connector.pauseButtonSelector = '#stop:not(.hidden)';
+
+Connector.scrobbleInfoLocationSelector = '.current';
+
+Connector.scrobbleInfoStyle = {
+	...Connector.scrobbleInfoStyle,
+	color: '#fff',
+	marginTop: '5px',
+	textShadow: '1px 1px 1px rgba(0,0,0,.5)',
+};
+
+Connector.scrobblingDisallowedReason = () => {
+	if (Util.getTextFromSelectors(Connector.artistSelector) === 'KISS') {
+		return 'FilteredTag';
+	}
+	return null;
+};

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2736,4 +2736,10 @@ export default <ConnectorMeta[]>[
 		js: 'radioswissclassic.js',
 		id: 'radioswissclassic',
 	},
+	{
+		label: 'Kiss rádio',
+		matches: ['*://www.kiss.cz/online/*'],
+		js: 'kiss.js',
+		id: 'kiss',
+	},
 ];


### PR DESCRIPTION

Filters out anything by author "KISS" because it's inserted when no music is playing.
A better version of this connector would intercept the now playing API they have but this should be adequate.

fixes #5822

<details>
  <summary>Looks like this</summary>
  <img width="403" height="676" alt="image" src="https://github.com/user-attachments/assets/e74e6202-18d5-46c4-b9e6-bd95d762acfb" />
</details>
