### PR TITLE
fix laut.fm connector

### DIFF
--- a/src/connectors/laut.fm.ts
+++ b/src/connectors/laut.fm.ts
@@ -7,7 +7,7 @@ Connector.artistSelector =
 
 Connector.trackSelector = '.player-display__meta .player-display__meta--title';
 
-Connector.pauseButtonSelector = '.fm-player__btn.playbutton--playing';
+Connector.pauseButtonSelector = '.button-play .btn--icon-playing';
 
 function removeEnclosingQuotes(track: string) {
 	return track.trim().slice(1, -1);


### PR DESCRIPTION
update the selector for the pause button (now `.button-play .btn--icon-playing`)

fixes #5825
