### PR TITLE
Fix youtube chapter bug

### DIFF
--- a/src/connectors/youtube.ts
+++ b/src/connectors/youtube.ts
@@ -253,13 +253,14 @@ function areChaptersAvailable() {
 		return false;
 	}
 
-	// YouTube introduced putting text into the current chapter element for
-	// referring users to the timeline ("In this video"). hard to check for
-	// because that text gets translated, we can however check if the
-	// description has a chapter like that, if not it's not a real chapter
+	// Chapters from the description have an "engagement panel" (sidebar),
+	// separate from "auto-chapters" which also have a one, but it's different.
+	// Some Music Videos also get text "In this video" inserted where the chapter
+	// would be, which this also catches because that only gets inserted when
+	// there are no description chapters.
 	if (
 		!document.querySelector(
-			`.ytd-watch-metadata ytd-macro-markers-list-item-renderer #details:has([title]):has(#time)`,
+			'[target-id="engagement-panel-macro-markers-description-chapters"]',
 		)
 	) {
 		return false;

--- a/src/connectors/youtube.ts
+++ b/src/connectors/youtube.ts
@@ -253,18 +253,16 @@ function areChaptersAvailable() {
 		return false;
 	}
 
-	if (text) {
-		// YouTube introduced putting text into the current chapter element for
-		// referring users to the timeline ("In this video"). hard to check for
-		// because that text gets translated, we can however check if the
-		// description has a chapter like that, if not it's not a real chapter
-		if (
-			!document.querySelector(
-				`.ytd-watch-metadata ytd-macro-markers-list-item-renderer #details:has([title="${CSS.escape(text)}"]):has(#time)`,
-			)
-		) {
-			return false;
-		}
+	// YouTube introduced putting text into the current chapter element for
+	// referring users to the timeline ("In this video"). hard to check for
+	// because that text gets translated, we can however check if the
+	// description has a chapter like that, if not it's not a real chapter
+	if (
+		!document.querySelector(
+			`.ytd-watch-metadata ytd-macro-markers-list-item-renderer #details:has([title]):has(#time)`,
+		)
+	) {
+		return false;
 	}
 
 	// Return the text if no sponsorblock text.


### PR DESCRIPTION
do not check for exact chapter name because not all chapters might be loaded yet.

fixes #5872 ("In this video" fix bug issue)
fixes #5781

notes:
I think checking for the exact name is redundant, open to discussion though. I have not had success triggering page loads with the extension so far - had to resort to a userscript to load the thumbnail of "music in this video" for example - because of that I don't think loading the chapters to check for the exact name is a good idea.

edit:
with changes from [e3c87aa](https://github.com/web-scrobbler/web-scrobbler/pull/5873/commits/e3c87aa03ec3ef8faad230b05194c41c37f79ceb) this also fixes auto-chapters.

fixes #5617 (auto-chapter issue)
closes #5655 (alternative auto-chapter fix)