### PR TITLE
Fix Spotify (handle negative duration/remaining)

### DIFF
--- a/src/connectors/spotify.ts
+++ b/src/connectors/spotify.ts
@@ -35,12 +35,16 @@ Connector.durationSelector = `${playerBar} [data-testid=playback-duration]`;
 
 Connector.getDuration = () => {
 	const text = Util.getTextFromSelectors(Connector.durationSelector);
-	if (text?.startsWith('-')) return null;
+	if (text?.startsWith('-')) {
+		return null;
+	}
 	return Util.stringToSeconds(text);
 };
 Connector.getRemainingTime = () => {
 	const text = Util.getTextFromSelectors(Connector.durationSelector);
-	if (!text || !text?.startsWith('-')) return null;
+	if (!text || !text?.startsWith('-')) {
+		return null;
+	}
 	return Util.stringToSeconds(text);
 };
 


### PR DESCRIPTION
wrong behaviour discovered by @calvinthefreak in [#5249](https://github.com/web-scrobbler/web-scrobbler/issues/5249#issuecomment-2850255700)

**Describe the changes you made**

parse durationSelector either as duration or as remaining Time depending on if it starts with `-` or not.

the form i'm doing it in might not be ideal but i didn't want to rely on too many details of the current code (that remainingTime only does something when duration is unset, for example.


**Additional context**

fixes #5666
