### PR TITLE
Fix Nashville Boombox url

### DIFF
--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -724,7 +724,7 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'Nashville BoomBox',
-		matches: ['*://boombox.library.nashville.org/*'],
+		matches: ['*://boombox.nashvillepubliclibrary.org/*'],
 		js: 'musicat.js',
 		id: 'nashville-library-boombox',
 	},


### PR DESCRIPTION
it redirected in 2025 and then turned into NXDOMAIN which it is now.
https://web.archive.org/web/20250803002514/https://boombox.library.nashville.org/