### PR TITLE
KCRW Connector : Support scrobbling on show pages

### DIFF
--- a/src/connectors/kcrw.ts
+++ b/src/connectors/kcrw.ts
@@ -1,71 +1,70 @@
 export {};
 
 const filter = MetadataFilter.createFilter({
-	artist: [removeShowName, replaceSmartQuotes],
+	artist: [replaceSmartQuotes],
 	track: [
-		removeSmartQuotes,
 		replaceSmartQuotes,
 		MetadataFilter.removeVersion,
 		MetadataFilter.removeCleanExplicit,
 	],
 });
-
-Connector.playerSelector = '.site-player'; // supports main and mini players
+// we are using fuzzy matching for the classes in this connector because I think they are generated at run time and thus can potentially change on each build. This would make the only consistent part the suffix of the class name, ex: "AudioPlayer_audioController".
+Connector.playerSelector = '[class*="AudioPlayer_audioController"]';
 
 Connector.getTrackInfo = () => {
-	const metaSelector = '.site-player .meta';
-	const timeSelector = '.site-player .duration';
-	const showNameText = Util.getTextFromSelectors(
-		`${metaSelector} .show-name`,
+	// Tracklist on this page are paginated. When the page is initially loaded this will click the button and it keep clicking "Show More" on each play cycle until all tracks are displayed and the "Show More" button is no longer present. This is necessary because as the tracks play there will be a possiblity that the currently playing track is not in the DOM and thus the connector won't be able to get the track info.
+	const showMoreButton = document.querySelector<HTMLElement>(
+		'[class*="EmbeddedTracklist_pagingShowMore"]',
 	);
-	const artistText = Util.getTextFromSelectors(
-		`${metaSelector} .episode-name`,
+	if (showMoreButton) {
+		showMoreButton.click();
+		return null;
+	}
+	// .shows/... page(s), ex: https://www.kcrw.com/shows/francesca-harding/stories/a-playlist-of-high-energy-indie-delectable-disco-and-groovy-ethio-jazz
+	// the tracklist shows the currently playing track with an SVG playing indicator inside its prefix element
+	const playingItem = document.querySelector(
+		'[class*="EmbeddedTracklist_tracklistItem"]:has([class*="Tracklist_prefix"] svg)',
 	);
-	const trackText = Util.getTextFromSelectors(`${metaSelector} .song-name`);
 
-	if (
-		Util.hasElementClass(metaSelector, 'music') &&
-		trackText &&
-		artistText !== '[BREAK]'
-	) {
-		return {
-			artist: artistText,
-			track: trackText,
-		};
+	Util.debugLog(`playingItem: ${playingItem}`);
+	Util.debugLog(`playingItem innerHTML: ${playingItem?.innerHTML}`);
+
+	if (!playingItem) {
+		return null;
 	}
 
-	if (
-		!Util.hasElementClass(metaSelector, 'music') &&
-		artistText &&
-		showNameText === "Today's Top Tune"
-	) {
-		const artistTrackSplit = artistText.split(/\s+[-\u2013]\s+/);
-		return {
-			artist: artistTrackSplit[0],
-			track: artistTrackSplit[1],
-			currentTime: Util.getSecondsFromSelectors(
-				`${timeSelector} .progress`,
-			),
-			duration: Util.getSecondsFromSelectors(`${timeSelector} .total`),
-		};
+	const trackEl = playingItem.querySelector(
+		'[class*="Tracklist_trackTitle"]',
+	);
+	const artistEl = playingItem.querySelector('[class*="Tracklist_info"]');
+	const trackText =
+		(trackEl as HTMLElement | null)?.innerText?.trim() ?? null;
+	const artistText =
+		(artistEl as HTMLElement | null)?.innerText?.trim() ?? null;
+
+	Util.debugLog(`trackText: ${trackText}`);
+	Util.debugLog(`artistText: ${artistText}`);
+
+	// There may need to be some sort of check here for BREAK if/when it is possible to suppport scrobbling from player.
+	// ex. if (trackText === "BREAK" || artistText === "BREAK") {
+	//     return null;
+	// }
+	if (!trackText) {
+		return null;
 	}
 
-	return null;
+	return {
+		artist: artistText,
+		track: trackText,
+	};
 };
 
-Connector.isPlaying = () => Util.hasElementClass('button.play', 'active');
+Connector.isPlaying = () => {
+	const audio = document.querySelector<HTMLAudioElement>('audio');
+	return audio ? !audio.paused : false;
+};
 
 Connector.applyFilter(filter);
-
-function removeShowName(text: string) {
-	// filter for Today's Top Tune
-	return text.replace(/Today('|\u2019)s Top Tune:\s+/, '');
-}
-
-function removeSmartQuotes(text: string) {
-	// filter for Today's Top Tune
-	return text.replace(/^[\u2018\u201c](.+)[\u2019\u201d](?=\s\(|$)/, '$1');
-}
 
 function replaceSmartQuotes(text: string) {
 	return text.replace(/[\u2018\u2019]/g, "'").replace(/[\u201c\u201d]/g, '"');

--- a/src/connectors/kcrw.ts
+++ b/src/connectors/kcrw.ts
@@ -8,55 +8,91 @@ const filter = MetadataFilter.createFilter({
 		MetadataFilter.removeCleanExplicit,
 	],
 });
-// we are using fuzzy matching for the classes in this connector because I think they are generated at run time and thus can potentially change on each build. This would make the only consistent part the suffix of the class name, ex: "AudioPlayer_audioController".
+
+// We use fuzzy class matching (class*=) throughout this connector because the
+// class names are CSS modules with build-time hashes (e.g. "AudioPlayer_audioController__3dl_S").
+// Only the prefix before the hash is stable across builds.
 Connector.playerSelector = '[class*="AudioPlayer_audioController"]';
 
 Connector.getTrackInfo = () => {
-	// Tracklist on this page are paginated. When the page is initially loaded this will click the button and it keep clicking "Show More" on each play cycle until all tracks are displayed and the "Show More" button is no longer present. This is necessary because as the tracks play there will be a possiblity that the currently playing track is not in the DOM and thus the connector won't be able to get the track info.
-	const showMoreButton = document.querySelector<HTMLElement>(
+	// --- Show More pagination ---
+	// Both page types paginate their tracklist. We click "Show More" on each
+	// poll cycle until it disappears, ensuring the playing track is in the DOM.
+
+	// EmbeddedTracklist pages (e.g. /shows/.../stories/... episode pages):
+	// Show More button has a unique EmbeddedTracklist_pagingShowMore class.
+	const embeddedShowMore = document.querySelector<HTMLElement>(
 		'[class*="EmbeddedTracklist_pagingShowMore"]',
 	);
+
+	// Eclectic24 tracklist page has a Show More button as of right now but we don't need to worry about it because the currently playing track is always in the DOM. If that changes in the future, we can add a selector for it here.
+	const showMoreButton = embeddedShowMore;
 	if (showMoreButton) {
 		showMoreButton.click();
 		return null;
 	}
-	// .shows/... page(s), ex: https://www.kcrw.com/shows/francesca-harding/stories/a-playlist-of-high-energy-indie-delectable-disco-and-groovy-ethio-jazz
-	// the tracklist shows the currently playing track with an SVG playing indicator inside its prefix element
-	const playingItem = document.querySelector(
+
+	// --- EmbeddedTracklist pages (e.g. /shows/.../stories/... episode pages) ---
+	// The currently playing item has an SVG playing indicator inside its prefix element.
+	const embeddedPlayingItem = document.querySelector(
 		'[class*="EmbeddedTracklist_tracklistItem"]:has([class*="Tracklist_prefix"] svg)',
 	);
 
-	Util.debugLog(`playingItem: ${playingItem}`);
-	Util.debugLog(`playingItem innerHTML: ${playingItem?.innerHTML}`);
+	if (embeddedPlayingItem) {
+		const trackEl = embeddedPlayingItem.querySelector(
+			'[class*="Tracklist_trackTitle"]',
+		);
+		const artistEl = embeddedPlayingItem.querySelector(
+			'[class*="Tracklist_artistLabel"]',
+		);
+		const trackText =
+			(trackEl as HTMLElement | null)?.innerText?.trim() ?? null;
+		const artistText =
+			(artistEl as HTMLElement | null)?.innerText?.trim() ?? null;
 
-	if (!playingItem) {
-		return null;
+		Util.debugLog(`[EmbeddedTracklist] trackText: ${trackText}`);
+		Util.debugLog(`[EmbeddedTracklist] artistText: ${artistText}`);
+
+		// There may need to be some sort of check here for BREAK if/when it is
+		// possible to support scrobbling from the player.
+		// ex. if (trackText === "BREAK" || artistText === "BREAK") return null;
+		if (!trackText) {
+			return null;
+		}
+
+		return { artist: artistText, track: trackText };
 	}
 
-	const trackEl = playingItem.querySelector(
-		'[class*="Tracklist_trackTitle"]',
+	// --- Tracklist pages (e.g. /music/eclectic24-7) ---
+	// The currently playing item is marked with a "Now Playing" eyebrow paragraph.
+	// Artist is in a dedicated Tracklist_artistLabel span (not the full info div).
+	const tracklistPlayingItem = document.querySelector(
+		'[class*="Tracklist_tracklistItem"]:has(p.eyebrow)',
 	);
-	const artistEl = playingItem.querySelector('[class*="Tracklist_info"]');
-	const trackText =
-		(trackEl as HTMLElement | null)?.innerText?.trim() ?? null;
-	const artistText =
-		(artistEl as HTMLElement | null)?.innerText?.trim() ?? null;
 
-	Util.debugLog(`trackText: ${trackText}`);
-	Util.debugLog(`artistText: ${artistText}`);
+	if (tracklistPlayingItem) {
+		const trackEl = tracklistPlayingItem.querySelector(
+			'[class*="Tracklist_trackTitle"]',
+		);
+		const artistEl = tracklistPlayingItem.querySelector(
+			'[class*="Tracklist_artistLabel"]',
+		);
+		const trackText =
+			(trackEl as HTMLElement | null)?.innerText?.trim() ?? null;
+		const artistText =
+			(artistEl as HTMLElement | null)?.innerText?.trim() ?? null;
 
-	// There may need to be some sort of check here for BREAK if/when it is possible to suppport scrobbling from player.
-	// ex. if (trackText === "BREAK" || artistText === "BREAK") {
-	//     return null;
-	// }
-	if (!trackText) {
-		return null;
+		Util.debugLog(`[Tracklist] trackText: ${trackText}`);
+		Util.debugLog(`[Tracklist] artistText: ${artistText}`);
+
+		if (!trackText) {
+			return null;
+		}
+
+		return { artist: artistText, track: trackText };
 	}
 
-	return {
-		artist: artistText,
-		track: trackText,
-	};
+	return null;
 };
 
 Connector.isPlaying = () => {


### PR DESCRIPTION
Changes : 
The KCRW site has been redesigned with a new player that doesn't supply the artist name to the DOM. The old connector relied on selectors (.site-player, .meta, .song-name, etc.) that no longer exist in the DOM. Will need an update if metadata is fed to DOM correctly. (submitted support ticket for this and will edit if changes are made)

Added support for` /shows` page(s) : tested on dj show episode pages and eclectic24 page.


addresses : #5696 
