### PR TITLE
chore: change release publish to use gh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,18 +11,6 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v6
 
-      - name: Get the extension version from ref
-        run: echo "EXT_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
       - name: Request website update
         run: |
           curl -X POST \
@@ -33,10 +21,10 @@ jobs:
         env:
           GH_FA_TOKEN: ${{ secrets.GH_FA_TOKEN }}
           WEBSITE_REPO: web-scrobbler/website-resources
-          VERSION: ${{ env.EXT_VERSION }}
+          VERSION: ${{ github.ref_name }}
 
       - name: Publish release on GitHub
-        run: gh release edit "${{ env.EXT_VERSION }}" --draft=false
+        run: gh release edit "${{ github.ref_name }}" --draft=false
         env:
           GH_TOKEN: ${{ secrets.BOT_PAT }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
<!-- 
  Thank you for taking the time to contribute to this project!

  Make sure to check out our guide on contributing with guidelines of how to contribute.

  See: https://github.com/web-scrobbler/web-scrobbler/blob/master/.github/CONTRIBUTING.md

--> 

**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->

The release publish pipeline was using a very old action which failed to trigger last time. Migrated to use github-cli and simplify some steps.

**Additional context**
<!-- Add any other context or screenshots here. -->
