### PR TITLE
Add support for Radio NABA

### DIFF
--- a/src/connectors/naba.ts
+++ b/src/connectors/naba.ts
@@ -1,7 +1,67 @@
+import type { ArtistTrackInfo } from '@/core/types';
+
 export {};
 
-Connector.playerSelector = '#tx_nabalive_live-song';
+const API_URL = 'https://www.lu.lv/api/?r=naba-live/search/';
+const POLL_INTERVAL = 30_000;
 
-Connector.artistTrackSelector = '#tx_nabalive_live-song';
+let currentSong: ArtistTrackInfo | null = null;
+let pendingSong: ArtistTrackInfo | null = null;
 
-Connector.isPlaying = () => true;
+function isNabaChannel(): boolean {
+	return new URLSearchParams(window.location.search).get('channel') === '6';
+}
+
+function checkIsPlaying(): boolean {
+	if (!isNabaChannel()) return false;
+	return Util.hasElementClass('.jwplayer', 'jw-state-playing');
+}
+
+async function fetchCurrentSong(): Promise<ArtistTrackInfo | null> {
+	try {
+		const response = await fetch(API_URL);
+		const data = (await response.json()) as { songString?: string };
+		if (!data.songString) return null;
+
+		return Util.splitArtistTrack(data.songString);
+	} catch {
+		return null;
+	}
+}
+
+function songsMatch(a: ArtistTrackInfo | null, b: ArtistTrackInfo | null): boolean {
+	return a?.artist === b?.artist && a?.track === b?.track;
+}
+
+async function poll(): Promise<void> {
+	if (!checkIsPlaying()) {
+		pendingSong = null;
+		return;
+	}
+
+	const fresh = await fetchCurrentSong();
+	if (!fresh) return;
+
+	if (songsMatch(fresh, currentSong)) {
+		pendingSong = null;
+		return;
+	}
+
+	if (songsMatch(fresh, pendingSong)) {
+		// Same song seen twice (1 minute apart) — promote it
+		currentSong = fresh;
+		pendingSong = null;
+		Connector.onStateChanged();
+	} else {
+		// New song detected — wait for next poll to confirm
+		pendingSong = fresh;
+	}
+}
+
+setInterval(poll, POLL_INTERVAL);
+
+Connector.playerSelector = '.jwplayer';
+
+Connector.getArtistTrack = () => currentSong;
+
+Connector.isPlaying = checkIsPlaying;

--- a/src/connectors/naba.ts
+++ b/src/connectors/naba.ts
@@ -1,0 +1,7 @@
+export {};
+
+Connector.playerSelector = '#tx_nabalive_live-song';
+
+Connector.artistTrackSelector = '#tx_nabalive_live-song';
+
+Connector.isPlaying = () => true;

--- a/src/connectors/naba.ts
+++ b/src/connectors/naba.ts
@@ -13,7 +13,9 @@ function isNabaChannel(): boolean {
 }
 
 function checkIsPlaying(): boolean {
-	if (!isNabaChannel()) return false;
+	if (!isNabaChannel()) {
+		return false;
+	}
 	return Util.hasElementClass('.jwplayer', 'jw-state-playing');
 }
 
@@ -21,15 +23,19 @@ async function fetchCurrentSong(): Promise<ArtistTrackInfo | null> {
 	try {
 		const response = await fetch(API_URL);
 		const data = (await response.json()) as { songString?: string };
-		if (!data.songString) return null;
-
+		if (!data.songString) {
+			return null;
+		}
 		return Util.splitArtistTrack(data.songString);
 	} catch {
 		return null;
 	}
 }
 
-function songsMatch(a: ArtistTrackInfo | null, b: ArtistTrackInfo | null): boolean {
+function songsMatch(
+	a: ArtistTrackInfo | null,
+	b: ArtistTrackInfo | null,
+): boolean {
 	return a?.artist === b?.artist && a?.track === b?.track;
 }
 
@@ -40,7 +46,9 @@ async function poll(): Promise<void> {
 	}
 
 	const fresh = await fetchCurrentSong();
-	if (!fresh) return;
+	if (!fresh) {
+		return;
+	}
 
 	if (songsMatch(fresh, currentSong)) {
 		pendingSong = null;
@@ -48,12 +56,10 @@ async function poll(): Promise<void> {
 	}
 
 	if (songsMatch(fresh, pendingSong)) {
-		// Same song seen twice (1 minute apart) — promote it
 		currentSong = fresh;
 		pendingSong = null;
 		Connector.onStateChanged();
 	} else {
-		// New song detected — wait for next poll to confirm
 		pendingSong = fresh;
 	}
 }

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -1623,7 +1623,7 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'Radio NABA',
-		matches: ['*://naba.lv/*', '*://www.naba.lv/*'],
+		matches: ['*://latvijasradio.lsm.lv/lv/tiesraide/*'],
 		js: 'naba.js',
 		id: 'naba',
 	},

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -1622,6 +1622,12 @@ export default <ConnectorMeta[]>[
 		id: 'radio7lv',
 	},
 	{
+		label: 'Radio NABA',
+		matches: ['*://naba.lv/*', '*://www.naba.lv/*'],
+		js: 'naba.js',
+		id: 'naba',
+	},
+	{
 		label: 'TOWER RECORDS MUSIC',
 		matches: ['*://music.tower.jp/*'],
 		js: 'towerrecordsmusic.js',

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -1632,8 +1632,8 @@ export default <ConnectorMeta[]>[
 		matches: ['*://latvijasradio.lsm.lv/lv/tiesraide/*'],
 		js: 'naba.js',
 		id: 'naba',
-  },
-  {
+	},
+	{
 		label: 'Radio Nemiers',
 		matches: ['*://radionemiers.com/*'],
 		js: 'radionemiers.js',


### PR DESCRIPTION
**Describe the changes you made**
Added a connector for the radio at naba.lv

**Additional context**
While the artist + title is shown on the main page, the player itself opens in a separate pop-up and does not contain the artist/title. Which means the playing state can not be detected in the same tab as where we read what is now playing, so the player has to be assumed to be always playing.