### PR TITLE
remove uses of innerHTML

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -519,16 +519,40 @@
         "message": "Erstelle ein URL-Muster, das auf die spezielle Bandcamp-Domain-URL zeigt und übernimm die Änderungen.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "<a target='_blank' href='$1'>Hier</a> kannst mehr über benutzerdefinierte URL-Muster erfahren.",
+    "faqAnswer4c1": {
+        "message": "",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "Hier",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": " kannst mehr über benutzerdefinierte URL-Muster erfahren.",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "Werdet ihr Unterstützung für das Scrobblen auf ____ hinzufügen?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "Eröffne ein <a href='$1' target='_blank'>neues Issue</a> auf Github mit deiner Anfrage und wir werden dir sagen ob wir Unterstützung für die Seite hinzufügen können oder nicht. Außerdem kannst du die Unterstützung für die Webseite selbst hinzufügen indem du das <a href='$1'>Github-Repository</a> forkst und uns einen Pull-Request schickst.",
+    "faqAnswer5a": {
+        "message": "Eröffne ein ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "neues Issue",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " auf Github mit deiner Anfrage und wir werden dir sagen ob wir Unterstützung für die Seite hinzufügen können oder nicht. Außerdem kannst du die Unterstützung für die Webseite selbst hinzufügen indem du das ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "Github-Repository",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": " forkst und uns einen Pull-Request schickst.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "Über",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "Das Änderungsprotokoll der aktuellen Version ist <a id='latest-release' target='_blank' href='$1'>hier</a> verfügbar. Besuche für das vollständige Änderungsprotokoll <a target='_blank' href='$2'>diese Seite</a>.",
+    "aboutChangelog1": {
+        "message": "Das Änderungsprotokoll der aktuellen Version ist ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "hier",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": " verfügbar. Besuche für das vollständige Änderungsprotokoll ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "diese Seite",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "Mitwirkende",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "Du kannst die Liste der Mitwirkenden <a href='$1'>direkt auf Github</a> sehen",
+    "contributorsText1": {
+        "message": "Du kannst die Liste der Mitwirkenden ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "direkt auf Github",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": " sehen",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "Du verwendest Version $1 der Erweiterung.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Möchtest du einen Beitrag leisten? Finde alle Möglichkeiten an diesem Projekt mitzuwirken auf <a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">unserer Website</a>.",
+    "contributorsContribute1": {
+        "message": "Möchtest du einen Beitrag leisten? Finde alle Möglichkeiten an diesem Projekt mitzuwirken auf ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "unserer Website",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/el/messages.json
+++ b/src/_locales/el/messages.json
@@ -519,16 +519,40 @@
         "message": "Add URL pattern that matches the Bandcamp custom domain URL and apply the changes.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "You can learn more about the custom URL patterns <a target='_blank' href='$1'>here</a>.",
+    "faqAnswer4c1": {
+        "message": "You can learn more about the custom URL patterns ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "here",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": ".",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "Will you add support for scrobbling at ____ ?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "Open a <a href='$1' target='_blank'>new issue</a> on GitHub with your request, and we'll tell you if we can add support for the website or not. Also, you can add support for the website by forking the <a href='$1'>GitHub repository</a> and sending us a pull request.",
+    "faqAnswer5a": {
+        "message": "Open a ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "new issue",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " on GitHub with your request, and we'll tell you if we can add support for the website or not. Also, you can add support for the website by forking the ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "GitHub repository",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": " and sending us a pull request.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "About",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "The changelog of current version is available <a id='latest-release' target='_blank' href='$1'>here</a>. For the full changelog please visit <a target='_blank' href='$2'>this page</a>.",
+    "aboutChangelog1": {
+        "message": "The changelog of current version is available ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "here",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": ". For the full changelog please visit ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "this page",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "Contributors",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "You can find the list of contributors <a href='$1'>right on the GitHub</a>",
+    "contributorsText1": {
+        "message": "You can find the list of contributors ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "right on the GitHub",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": "",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "You are using version $1 of the extension.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Want to contribute? See all the ways you can contribute to the project at <a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">our website</a>.",
+    "contributorsContribute1": {
+        "message": "Want to contribute? See all the ways you can contribute to the project at ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "our website",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -519,16 +519,40 @@
         "message": "Add URL pattern that matches the Bandcamp custom domain URL and apply the changes.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "You can learn more about the custom URL patterns <a target='_blank' href='$1'>here</a>.",
+    "faqAnswer4c1": {
+        "message": "You can learn more about the custom URL patterns ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "here",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": ".",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "Will you add support for scrobbling at ____ ?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "Open a <a href='$1' target='_blank'>new issue</a> on GitHub with your request, and we'll tell you if we can add support for the website or not. Also, you can add support for the website by forking the <a href='$2' target='_blank'>GitHub repository</a> and sending us a pull request.",
+    "faqAnswer5a": {
+        "message": "Open a ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "new issue",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " on GitHub with your request, and we'll tell you if we can add support for the website or not. Also, you can add support for the website by forking the ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "GitHub repository",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": " and sending us a pull request.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -555,6 +579,26 @@
         "message": "The changelog of current version is available <a id='latest-release' target='_blank' href='$1'>here</a>. For the full changelog please visit <a target='_blank' href='$2'>this page</a>.",
         "description": "'About' section text"
     },
+    "aboutChangelog1": {
+        "message": "The changelog of current version is available ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "here",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": ". For the full changelog please visit ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "this page",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
+        "description": "'About' section text"
+    },
     "aboutExtensionDesc": {
         "message": "Web Scrobbler is a browser extension created for people who listen to music online through their browser, and would like to keep an updated playback history using scrobbling services, such as Last.fm, Libre.fm, ListenBrainz, and Pleroma.",
         "description": "'About' section text"
@@ -563,8 +607,16 @@
         "message": "Contributors",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "You can find the list of contributors <a href='$1'>right on the GitHub</a>",
+    "contributorsText1": {
+        "message": "You can find the list of contributors ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "right on the GitHub",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": "",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +627,16 @@
         "message": "You are using version $1 of the extension.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Want to contribute? See all the ways you can contribute to the project at <a href='$1' target='_blank' rel='noopener noreferrer'>our website</a>.",
+    "contributorsContribute1": {
+        "message": "Want to contribute? See all the ways you can contribute to the project at ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "our website",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/en_GB/messages.json
+++ b/src/_locales/en_GB/messages.json
@@ -519,16 +519,40 @@
         "message": "Add URL pattern that matches the Bandcamp custom domain URL and apply the changes.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "You can learn more about the custom URL patterns <a target='_blank' href='$1'>here</a>.",
+    "faqAnswer4c1": {
+        "message": "You can learn more about the custom URL patterns ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "here",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": ".",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "Will you add support for scrobbling at ____ ?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "Open a <a href='$1' target='_blank'>new issue</a> on GitHub with your request, and we'll tell you if we can add support for the website or not. Also, you can add support for the website by forking the <a href='$2'>GitHub repository</a> and sending us a pull request.",
+    "faqAnswer5a": {
+        "message": "Open a ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "new issue",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " on GitHub with your request, and we'll tell you if we can add support for the website or not. Also, you can add support for the website by forking the ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "GitHub repository",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": " and sending us a pull request.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "About",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "The changelog of current version is available <a id='latest-release' target='_blank' href='$1'>here</a>. For the full changelog please visit <a target='_blank' href='$2'>this page</a>.",
+    "aboutChangelog1": {
+        "message": "The changelog of current version is available ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "here",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": ". For the full changelog please visit ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "this page",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "Contributors",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "You can find the list of contributors <a href='$1'>right on the GitHub</a>",
+    "contributorsText1": {
+        "message": "You can find the list of contributors ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "right on the GitHub",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": "",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "You are using version $1 of the extension.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Want to contribute? See all the ways you can contribute to the project at <a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">our website</a>.",
+    "contributorsContribute1": {
+        "message": "Want to contribute? See all the ways you can contribute to the project at ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "our website",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -519,16 +519,40 @@
         "message": "Agregue un patrón de direcciones URL que coincida con la URL del dominio personalizado de Bandcamp y aplique los cambios.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "Puede saber más acerca de los patrones de direcciones URL personalizados <a target='_blank' href='$1'> aquí </a>.",
+     "faqAnswer4c1": {
+        "message": "Puede saber más acerca de los patrones de direcciones URL personalizados ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": " aquí ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": ".",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "¿Dará soporte al scrobbling en _____ ?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "Abra un <a href='$1' target='_blank'>nuevo problema</a> en GitHub con su solicitud, y le informaremos si podemos agregar soporte para un determinado sitio web o no. Además, puede dar asistencia al sitio web simplemente bifurcando el <a href='$2' target='_blank'>repositorio GitHub</a> y enviándonos una solicitud de integración.",
+    "faqAnswer5a": {
+        "message": "Abra un ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "nuevo problema",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " en GitHub con su solicitud, y le informaremos si podemos agregar soporte para un determinado sitio web o no. Además, puede dar asistencia al sitio web simplemente bifurcando el ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "repositorio GitHub",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": " y enviándonos una solicitud de integración.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "Acerca",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "The changelog of current version is available <a id='latest-release' target='_blank' href='$1'>here</a>. For the full changelog please visit <a target='_blank' href='$2'>this page</a>.",
+    "aboutChangelog1": {
+        "message": "The changelog of current version is available ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "here",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": ". For the full changelog please visit ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "this page",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "Colaboradores",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "Puedes encontrar una lista de los colaboradores <a href='$1'>en GitHub</a>",
+    "contributorsText1": {
+        "message": "Puedes encontrar una lista de los colaboradores ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "en GitHub",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": "",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "You are using version $1 of the extension.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Want to contribute? See all the ways you can contribute to the project at <a href='$1' target='_blank' rel='noopener noreferrer'>our website</a>.",
+    "contributorsContribute1": {
+        "message": "Want to contribute? See all the ways you can contribute to the project at ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "our website",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/es_MX/messages.json
+++ b/src/_locales/es_MX/messages.json
@@ -519,16 +519,40 @@
         "message": "Add URL pattern that matches the Bandcamp custom domain URL and apply the changes.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "Puede saber más acerca de los patrones de direcciones URL personalizados <a target='_blank' href='$1'> aquí </a>.",
+    "faqAnswer4c1": {
+        "message": "Puede saber más acerca de los patrones de direcciones URL personalizados ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": " aquí ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": ".",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "¿Añadirá compatibilidad de scrobbling en ____ ?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "Abra un <a href='$1' target='_blank'>nuevo problema</a> en GitHub con su solicitud, y le informaremos si podemos agregar soporte para un determinado sitio web o no. Además, puede dar asistencia al sitio web simplemente bifurcando el <a href='$1'>repositorio GitHub</a> y enviándonos una solicitud de integración.",
+    "faqAnswer5a": {
+        "message": "Abra un ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "nuevo problema",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " en GitHub con su solicitud, y le informaremos si podemos agregar soporte para un determinado sitio web o no. Además, puede dar asistencia al sitio web simplemente bifurcando el ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "repositorio GitHub",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": " y enviándonos una solicitud de integración.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "Acerca",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "The changelog of current version is available <a id='latest-release' target='_blank' href='$1'>here</a>. For the full changelog please visit <a target='_blank' href='$2'>this page</a>.",
+    "aboutChangelog1": {
+        "message": "The changelog of current version is available ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "here",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": ". For the full changelog please visit ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "this page",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "Colaboradores",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "You can find the list of contributors <a href='$1'>right on the GitHub</a>",
+    "contributorsText1": {
+        "message": "You can find the list of contributors ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "right on the GitHub",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": "",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "You are using version $1 of the extension.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Want to contribute? See all the ways you can contribute to the project at <a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">our website</a>.",
+    "contributorsContribute1": {
+        "message": "Want to contribute? See all the ways you can contribute to the project at ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "our website",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -519,16 +519,40 @@
         "message": "Add URL pattern that matches the Bandcamp custom domain URL and apply the changes.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "You can learn more about the custom URL patterns <a target='_blank' href='$1'>here</a>.",
+    "faqAnswer4c1": {
+        "message": "You can learn more about the custom URL patterns ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "here",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": ".",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "Lisäätkö skrobblaustuen ____-sivustolle?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "Open a <a href='$1' target='_blank'>new issue</a> on GitHub with your request, and we'll tell you if we can add support for the website or not. Also, you can add support for the website by forking the <a href='$1'>GitHub repository</a> and sending us a pull request.",
+    "faqAnswer5a": {
+        "message": "Open a ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "new issue",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " on GitHub with your request, and we'll tell you if we can add support for the website or not. Also, you can add support for the website by forking the ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "GitHub repository",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": " and sending us a pull request.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "Tietoja",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "The changelog of current version is available <a id='latest-release' target='_blank' href='$1'>here</a>. For the full changelog please visit <a target='_blank' href='$2'>this page</a>.",
+    "aboutChangelog1": {
+        "message": "The changelog of current version is available ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "here",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": ". For the full changelog please visit ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "this page",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "Osallistujat",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "You can find the list of contributors <a href='$1'>right on the GitHub</a>",
+    "contributorsText1": {
+        "message": "You can find the list of contributors ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "right on the GitHub",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": "",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "You are using version $1 of the extension.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Want to contribute? See all the ways you can contribute to the project at <a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">our website</a>.",
+    "contributorsContribute1": {
+        "message": "Want to contribute? See all the ways you can contribute to the project at ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "our website",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/fr_FR/messages.json
+++ b/src/_locales/fr_FR/messages.json
@@ -519,16 +519,40 @@
         "message": "Ajoutez le modèle d'URL qui correspond à l'URL du domaine personnalisé Bandcamp et appliquez les changements.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "Vous pouvez en apprendre plus concernant les modèles d'URL personnalisés <a target='_blank' href='$1'>ici</a>.",
+    "faqAnswer4c1": {
+        "message": "Vous pouvez en apprendre plus concernant les modèles d'URL personnalisés ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "ici",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": ".",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "Allez-vous ajouter le support pour scrobblé sur ____ ?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "Ouvrez une <a href='$1' target='_blank'>nouvelle issue</a> sur GitHub avec votre requête et nous vous dirons si nous pouvons ajouter le support pour le site ou non. Vous pouvez aussi ajouter le support du site en forkant le <a href='$1'>repository GitHub</a> et en nous envoyant une pull request.",
+    "faqAnswer5a": {
+        "message": "Ouvrez une ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "nouvelle issue",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " sur GitHub avec votre requête et nous vous dirons si nous pouvons ajouter le support pour le site ou non. Vous pouvez aussi ajouter le support du site en forkant le ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "repository GitHub",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": " et en nous envoyant une pull request.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "À propos",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "The changelog of current version is available <a id='latest-release' target='_blank' href='$1'>here</a>. For the full changelog please visit <a target='_blank' href='$2'>this page</a>.",
+    "aboutChangelog1": {
+        "message": "The changelog of current version is available ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "here",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": ". For the full changelog please visit ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "this page",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "Contributeurs",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "Vous pouvez trouver la liste des contributeurs <a href='$1'>directement sur le repository GitHub</a>",
+     "contributorsText1": {
+        "message": "Vous pouvez trouver la liste des contributeurs ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "directement sur le repository GitHub",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": "",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "You are using version $1 of the extension.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Want to contribute? See all the ways you can contribute to the project at <a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">our website</a>.",
+    "contributorsContribute1": {
+        "message": "Want to contribute? See all the ways you can contribute to the project at ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "our website",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -519,16 +519,40 @@
         "message": "Add URL pattern that matches the Bandcamp custom domain URL and apply the changes.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "You can learn more about the custom URL patterns <a target='_blank' href='$1'>here</a>.",
+    "faqAnswer4c1": {
+        "message": "You can learn more about the custom URL patterns ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "here",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": ".",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "Apakah ektensi ini akan mendukung situs ____ ?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "Open a <a href='$1' target='_blank'>new issue</a> on GitHub with your request, and we'll tell you if we can add support for the website or not. Also, you can add support for the website by forking the <a href='$1'>GitHub repository</a> and sending us a pull request.",
+    "faqAnswer5a": {
+        "message": "Open a ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "new issue",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " on GitHub with your request, and we'll tell you if we can add support for the website or not. Also, you can add support for the website by forking the ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "GitHub repository",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": " and sending us a pull request.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "Tentang",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "The changelog of current version is available <a id='latest-release' target='_blank' href='$1'>here</a>. For the full changelog please visit <a target='_blank' href='$2'>this page</a>.",
+    "aboutChangelog1": {
+        "message": "The changelog of current version is available ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "here",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": ". For the full changelog please visit ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "this page",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "Kontributor",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "Kamu bisa menemukan daftar kontributor melalui <a href='$1'>GitHub.</a>",
+    "contributorsText1": {
+        "message": "Kamu bisa menemukan daftar kontributor melalui ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "GitHub",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "You are using version $1 of the extension.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Want to contribute? See all the ways you can contribute to the project at <a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">our website</a>.",
+    "contributorsContribute1": {
+        "message": "Want to contribute? See all the ways you can contribute to the project at ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "our website",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -519,16 +519,40 @@
         "message": "Add URL pattern that matches the Bandcamp custom domain URL and apply the changes.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "You can learn more about the custom URL patterns <a target='_blank' href='$1'>here</a>.",
+    "faqAnswer4c1": {
+        "message": "You can learn more about the custom URL patterns ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "here",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": ".",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "Will you add support for scrobbling at ____ ?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "Open a <a href='$1' target='_blank'>new issue</a> on GitHub with your request, and we'll tell you if we can add support for the website or not. Also, you can add support for the website by forking the <a href='$1'>GitHub repository</a> and sending us a pull request.",
+    "faqAnswer5a": {
+        "message": "Open a ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "new issue",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " on GitHub with your request, and we'll tell you if we can add support for the website or not. Also, you can add support for the website by forking the ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "GitHub repository",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": " and sending us a pull request.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "소개",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "The changelog of current version is available <a id='latest-release' target='_blank' href='$1'>here</a>. For the full changelog please visit <a target='_blank' href='$2'>this page</a>.",
+    "aboutChangelog1": {
+        "message": "The changelog of current version is available ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "here",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": ". For the full changelog please visit ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "this page",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "Contributors",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "You can find the list of contributors <a href='$1'>right on the GitHub</a>",
+    "contributorsText1": {
+        "message": "You can find the list of contributors ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "right on the GitHub",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": "",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "You are using version $1 of the extension.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Want to contribute? See all the ways you can contribute to the project at <a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">our website</a>.",
+    "contributorsContribute1": {
+        "message": "Want to contribute? See all the ways you can contribute to the project at ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "our website",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/lt/messages.json
+++ b/src/_locales/lt/messages.json
@@ -519,16 +519,40 @@
         "message": "Pridėkite URL šabloną, atitinkantį „Bandcamp“ pasirinktinio domeno URL, ir pritaikykite pakeitimus.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "Galite sužinoti daugiau apie pasirinktinius URL šablonus <a target='_blank' href='$1'>čia</a>.",
+    "faqAnswer4c1": {
+        "message": "Galite sužinoti daugiau apie pasirinktinius URL šablonus ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "čia",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": ".",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "Ar pridėsite palaikymą skrobuolinimui ____ ?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "Atidarykite <a href='$1' target='_blank'>naują problemą</a> platformoje „GitHub“ su savo prašymu ir mes jums pasakysime, ar galime pridėti svetainės palaikymą, ar ne. Be to, galite pridėti svetainės palaikymą iššakodami <a href='$1'>„GitHub“ saugyklą</a> ir siųsdami mums sujungimo prašymą.",
+    "faqAnswer5a": {
+        "message": "Atidarykite ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "naują problemą",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " platformoje „GitHub“ su savo prašymu ir mes jums pasakysime, ar galime pridėti svetainės palaikymą, ar ne. Be to, galite pridėti svetainės palaikymą iššakodami ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "„GitHub“ saugyklą",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": " ir siųsdami mums sujungimo prašymą.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "Apie",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "Dabartinės versijos pakeitimų sąrašas pateikiamas <a id='latest-release' target='_blank' href='$1'>čia</a>. Dėl viso pakeitimų sąrašo aplankykite <a target='_blank' href='$2'>šį puslapį</a>.",
+    "aboutChangelog1": {
+        "message": "Dabartinės versijos pakeitimų sąrašas pateikiamas ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "čia",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": ". Dėl viso pakeitimų sąrašo aplankykite ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "šį puslapį",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "Bendradarbiai",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "Bendradarbių sąrašą galite rasti <a href='$1'>svetainėje „GitHub“</a>",
+    "contributorsText1": {
+        "message": "Bendradarbių sąrašą galite rasti ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "svetainėje „GitHub“",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": "",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "Naudojate $1 plėtinio versiją.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Norite prisidėti? Žiūrėkite visus būdus, kaip galite prisidėti prie projekto, <a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">mūsų svetainėje</a>.",
+    "contributorsContribute1": {
+        "message": "Norite prisidėti? Žiūrėkite visus būdus, kaip galite prisidėti prie projekto, ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "mūsų svetainėje",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -519,16 +519,40 @@
         "message": "Dodaj wzorzec URL który odpowiada niestandardowej domenie Bandcampa i zatwierdź zmiany.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "Możesz dowiedzieć się więcej o niestandardowych wzorcach URL <a target='_blank' href='$1'>tutaj</a>.",
+    "faqAnswer4c1": {
+        "message": "Możesz dowiedzieć się więcej o niestandardowych wzorcach URL ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "tutaj",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": ".",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "Czy dodasz obsługę scrobblowania na stronie ____ ?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "Otwórz na GitHubie <a href='$1' target='_blank'>nowy wniosek</a> ze swoją sugestią, a powiemy Ci czy jesteśmy w stanie dodać wsparcie dla danej usługi. Możesz również samodzielnie dodać wsparcie forkując <a href='$1'>repozytorium na GitHubie</a> i wysyłając nam pull requesta.",
+    "faqAnswer5a": {
+        "message": "Otwórz na GitHubie ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "nowy wniosek",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " ze swoją sugestią, a powiemy Ci czy jesteśmy w stanie dodać wsparcie dla danej usługi. Możesz również samodzielnie dodać wsparcie forkując ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "repozytorium na GitHubie",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": " i wysyłając nam pull requesta.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "O rozszerzeniu",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "Lista nowości w obecnej wersji dostępna jest <a id='latest-release' target='_blank' href='$1'>tutaj</a>. Pełny wykaz zmian dostępny jest na <a target='_blank' href='$2'>stronie projektu</a>.",
+    "aboutChangelog1": {
+        "message": "Lista nowości w obecnej wersji dostępna jest ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "tutaj",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": ". Pełny wykaz zmian dostępny jest na ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "stronie projektu",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "Współtwórcy",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "Możesz znaleźć listę współtwórców <a href='$1'>bezpośrednio na GitHubie</a>",
+    "contributorsText1": {
+        "message": "Możesz znaleźć listę współtwórców ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "bezpośrednio na GitHubie",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": "",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "Używasz rozszerzenia w wersji $1.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Chcesz przyczynić się do rozwoju projektu? Zapoznaj się ze wszystkimi sposobami na jakie jest to możliwe na <a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">naszej stronie</a>.",
+    "contributorsContribute1": {
+        "message": "Chcesz przyczynić się do rozwoju projektu? Zapoznaj się ze wszystkimi sposobami na jakie jest to możliwe na ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "naszej stronie",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -519,16 +519,40 @@
         "message": "Adicione um padrão de URL que corresponda ao URL do domínio personalizado do Bandcamp e aplique as alterações.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "Clique <a target='_blank' href='$1'>aqui</a> para saber mais sobre padrões personalizados de URL.",
+    "faqAnswer4c1": {
+        "message": "Clique ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "aqui",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": " para saber mais sobre padrões personalizados de URL.",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "Você pode adicionar suporte ao site ____?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "Crie um <a href='$1' target='_blank'>novo issue</a> no GitHub com o seu pedido e informaremos se podemos ou não adicionar suporte ao site em questão. Além disso, você mesmo pode adicionar suporte ao site criando uma bifurcação do <a href='$1'>repositório no GitHub</a> e enviando um pull request.",
+    "faqAnswer5a": {
+        "message": "Crie um ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "novo issue",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " no GitHub com o seu pedido e informaremos se podemos ou não adicionar suporte ao site em questão. Além disso, você mesmo pode adicionar suporte ao site criando uma bifurcação do ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "repositório no GitHub",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": " e enviando um pull request.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "Sobre",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "As notas de atualização da versão atual estão disponíveis <a id='latest-release' target='_blank' href='$1'>aqui</a>. Para as notas completas, por favor visite <a target='_blank' href='$2'>esta página.</a>",
+    "aboutChangelog1": {
+        "message": "As notas de atualização da versão atual estão disponíveis ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "aqui",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": ". Para as notas completas, por favor visite ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "esta página",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "Colaboradores",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "Você pode encontrar a lista de colaboradores <a href='$1'>diretamente no GitHub</a>",
+    "contributorsText1": {
+        "message": "Você pode encontrar a lista de colaboradores ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "diretamente no GitHub",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": "",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "Você está usando a versão $1 desta extensão.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Quer contribuir? Veja como você pode contribuir com o projeto no <a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">nosso site</a>.",
+    "contributorsContribute1": {
+        "message": "Quer contribuir? Veja como você pode contribuir com o projeto no ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "nosso site",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -519,16 +519,40 @@
         "message": "Добавьте шаблон URL, который будет соответствовать нестандартному домену Bandcamp, и примените изменения.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "Вы можете узнать больше о пользовательских шаблонах URL <a target='_blank' href='$1'>здесь</a>.",
+    "faqAnswer4c1": {
+        "message": "Вы можете узнать больше о пользовательских шаблонах URL ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "здесь",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": ".",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "Добавите ли вы поддержку ____?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "Создайте <a href='$1' target='_blank'>новый багрепорт</a> на GitHub, и мы вам скажем, сможем ли мы добавить поддержку или нет. Также,  вы можете добавить поддержку сайта самостоятельно, форкнув <a href='$1'>проект на GitHub</a> и отправив нам пулл-реквест.",
+    "faqAnswer5a": {
+        "message": "Создайте ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "новый багрепорт",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " на GitHub, и мы вам скажем, сможем ли мы добавить поддержку или нет. Также,  вы можете добавить поддержку сайта самостоятельно, форкнув ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "проект на GitHub",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": " и отправив нам пулл-реквест.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "О расширении",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "Список изменений текущей версии доступен <a id='latest-release' target='_blank' href='$1'>здесь</a>. Полный список изменений вы можете посмотреть на <a target='_blank' href='$2'>этой странице</a>.",
+    "aboutChangelog1": {
+        "message": "Список изменений текущей версии доступен ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "здесь",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": ". Полный список изменений вы можете посмотреть на ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "этой странице",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "Участники проекта",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "Вы можете посмотреть список участников проекта на <a href='$1'>странице проекта</a> на GitHub.",
+    "contributorsText1": {
+        "message": "Вы можете посмотреть список участников проекта на ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "странице проекта",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": " на GitHub.",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "Вы используете версию расширения $1.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Если вы хотите поучаствовать в разработке, вы можете ознакомиться со способами внести вклад в проект <a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">на нашем сайте</a>.",
+    "contributorsContribute1": {
+        "message": "Если вы хотите поучаствовать в разработке, вы можете ознакомиться со способами внести вклад в проект ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "на нашем сайте",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/sk/messages.json
+++ b/src/_locales/sk/messages.json
@@ -519,16 +519,40 @@
         "message": "Pridajte URL vzor, ktorý vyhovuje neštandartnej adrese na Bandcamp a uložte zmeny.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "O URL vzoroch sa môžte dozvedieť viacej <a target='_blank' href='$1'>tu</a>.",
+    "faqAnswer4c1": {
+        "message": "O URL vzoroch sa môžte dozvedieť viacej ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "tu",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": ".",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "Pridáte podporu pre stránku ____?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "Nahláste <a href='$1' target='_blank'>nový problém</a> na GitHube s vašimi požiadavkami a my Vám povieme, či vieme pridať podporu pre stránku. Prípadne môžete prispieť do projektu pridaním podpory pre stránku vytvorením forku <a href='$1'>GitHub repozitára</a> a zaslaním pull requestu.",
+    "faqAnswer5a": {
+        "message": "Nahláste ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "nový problém",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " na GitHube s vašimi požiadavkami a my Vám povieme, či vieme pridať podporu pre stránku. Prípadne môžete prispieť do projektu pridaním podpory pre stránku vytvorením forku ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "GitHub repozitára",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": " a zaslaním pull requestu.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "O doplnku",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "The changelog of current version is available <a id='latest-release' target='_blank' href='$1'>here</a>. For the full changelog please visit <a target='_blank' href='$2'>this page</a>.",
+    "aboutChangelog1": {
+        "message": "The changelog of current version is available ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "here",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": ". For the full changelog please visit ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "this page",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "Vývojári",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "Úplný zoznam vývojárov môžete nájsť <a href='$1'>priamo na Githube</a>",
+    "contributorsText1": {
+        "message": "Úplný zoznam vývojárov môžete nájsť ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "priamo na Githube",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": "",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "You are using version $1 of the extension.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Want to contribute? See all the ways you can contribute to the project at <a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">our website</a>.",
+    "contributorsContribute1": {
+        "message": "Want to contribute? See all the ways you can contribute to the project at ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "our website",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -519,16 +519,40 @@
         "message": "Bandcamp özel alan URL'siyle eşleşen URL modelini ekleyin ve değişiklikleri uygulayın.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "Özel URL kalıpları hakkında daha fazla bilgiyi <a target='_blank' href='$1'>burada</a> bulabilirsiniz.",
+    "faqAnswer4c1": {
+        "message": "Özel URL kalıpları hakkında daha fazla bilgiyi ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "burada",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": " bulabilirsiniz.",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "____ adresine skroplama desteği ekleyecek misiniz?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "İsteğinizle birlikte GitHub'da <a href='$1' target='_blank'>yeni issue</a> açın, size internet sitesi için destek ekleyip ekleyemeyeceğimizi söyleyeceğiz. Ayrıca <a href='$1'>GitHub deposu</a>nu çatallayarak ve bize bir çekme isteği göndererek web sitesi için destek ekleyebilirsiniz.",
+    "faqAnswer5a": {
+        "message": "İsteğinizle birlikte GitHub'da ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "yeni issue",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " açın, size internet sitesi için destek ekleyip ekleyemeyeceğimizi söyleyeceğiz. Ayrıca ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "GitHub deposu",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": "nu çatallayarak ve bize bir çekme isteği göndererek web sitesi için destek ekleyebilirsiniz.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "Hakkında",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "Mevcut sürümün değişiklik günlüğüne <a id='latest-release' target='_blank' href='$1'>burada</a> ulaşılabilir. Değişiklik günlüğünün tamamı için lütfen <a target='_blank' href='$2'>bu sayfayı</a> ziyaret edin.",
+    "aboutChangelog1": {
+        "message": "Mevcut sürümün değişiklik günlüğüne ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "burada",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": " ulaşılabilir. Değişiklik günlüğünün tamamı için lütfen ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "bu sayfayı",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": " ziyaret edin.",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "Katkıda Bulunanlar",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "Katkıda bulunanların listesini <a href='$1'>doğrudan GitHub</a>'da bulabilirsiniz.",
+    "contributorsText1": {
+        "message": "Katkıda bulunanların listesini ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "doğrudan GitHub",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": "'da bulabilirsiniz.",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "You are using version $1 of the extension.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Katkıda bulunmak ister misiniz? <a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">İnternet sitemiz</a>'de projeye katkıda bulunabileceğiniz tüm yolları görün.",
+    "contributorsContribute1": {
+        "message": "Katkıda bulunmak ister misiniz? ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "İnternet sitemiz",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": "'de projeye katkıda bulunabileceğiniz tüm yolları görün.",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -519,16 +519,40 @@
         "message": "Додайте паттерн URL, який буде відповідати нестандартному домену Bandcamp, та застосуйте зміни.",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "Ви можете дізнатися більше про паттерни URL від користувача <a target='_blank' href='$1'>тут</a>.",
+    "faqAnswer4c1": {
+        "message": "Ви можете дізнатися більше про паттерни URL від користувача ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "тут",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": ".",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "Чи додасте ви підтримку скроблінгу з ____?",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "Створіть <a href='$1' target='_blank'>новий багрепорт</a> на GitHub, і ми вам скажемо, чи зможемо ми додати підтримку чи ні. Також ви можете додати підтримку якогось сайту самостійно, форкнувши <a href='$1'>проект з GitHub</a> і відправивши нам pull-реквест.",
+    "faqAnswer5a": {
+        "message": "Створіть ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "новий багрепорт",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": " на GitHub, і ми вам скажемо, чи зможемо ми додати підтримку чи ні. Також ви можете додати підтримку якогось сайту самостійно, форкнувши ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "проект з GitHub",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": " і відправивши нам pull-реквест.",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "Про розширення",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "The changelog of current version is available <a id='latest-release' target='_blank' href='$1'>here</a>. For the full changelog please visit <a target='_blank' href='$2'>this page</a>.",
+    "aboutChangelog1": {
+        "message": "The changelog of current version is available ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "here",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": ". For the full changelog please visit ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "this page",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "Учасники проекту",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "Ви можете переглянути список учасників проекту на <a href='$1'>сторінці проекту на GitHub</a>",
+    "contributorsText1": {
+        "message": "Ви можете переглянути список учасників проекту на ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "сторінці проекту на GitHub",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": "",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "You are using version $1 of the extension.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Хочете сприяти розвитку проекту? Продивіться всі варіанти на <a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">нашій веб-сторінці</a>",
+    "contributorsContribute1": {
+        "message": "Хочете сприяти розвитку проекту? Продивіться всі варіанти на ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "нашій веб-сторінці",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": "",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -519,16 +519,40 @@
         "message": "添加匹配 Bandcamp 其他域名的网址匹配模板并应用更改。",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "您可以在<a target='_blank' href='$1'>这里</a>进一步了解自定义网址匹配模板。",
+    "faqAnswer4c1": {
+        "message": "您可以在",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "这里",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": "进一步了解自定义网址匹配模板。",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "你会添加对____的追踪支持吗？",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "在 Github 上根据您的需求发布一个<a href='$1' target='_blank'>新问题</a>，我们会告诉您能否添加对网站的支持。您也可以通过派生<a href='$1'>Github 项目</a>并向我们发送拉取请求来添加对网站的支持。",
+    "faqAnswer5a": {
+        "message": "在 Github 上根据您的需求发布一个",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "新问题",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": "，我们会告诉您能否添加对网站的支持。您也可以通过派生",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "Github 项目",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": "并向我们发送拉取请求来添加对网站的支持。",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "关于",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "The changelog of current version is available <a id='latest-release' target='_blank' href='$1'>here</a>. For the full changelog please visit <a target='_blank' href='$2'>this page</a>.",
+    "aboutChangelog1": {
+        "message": "The changelog of current version is available ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "here",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": ". For the full changelog please visit ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "this page",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": ".",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "贡献者",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "您可以直接在 <a href='$1'>GitHub</a> 上找到贡献者列表。",
+    "contributorsText1": {
+        "message": "您可以直接在 ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "GitHub",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": " 上找到贡献者列表。",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "You are using version $1 of the extension.",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "Want to contribute? See all the ways you can contribute to the project at <a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">our website</a>.",
+    "contributorsContribute1": {
+        "message": "Want to contribute? See all the ways you can contribute to the project at ",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "our website",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": ".",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -519,16 +519,40 @@
         "message": "加入符合 Bandcamp 中自訂域名的 URL 規則並套用變更。",
         "description": "Answer #4"
     },
-    "faqAnswer4c": {
-        "message": "您可以在 <a target='_blank' href='$1'>此處</a> 進一步了解 URL 規則。",
+    "faqAnswer4c1": {
+        "message": "您可以在 ",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c2_docs-custom-urls-url": {
+        "message": "此處",
+        "description": "Answer #4"
+    },
+    "faqAnswer4c3": {
+        "message": " 進一步了解 URL 規則。",
         "description": "Answer #4"
     },
     "faqQuestion5": {
         "message": "你會新增對 ____ 的支援嗎？",
         "description": "Question #5"
     },
-    "faqAnswer5": {
-        "message": "在 GitHub 上開啟<a href='$1' target='_blank'>新的 issue</a>，我們會告訴您我們能不能新增對該網站的支援。您也可以自己將 <a href='$1'>GitHub 版本庫</a>進行分支，撰寫支援之後像我們遞交 pull request。",
+    "faqAnswer5a": {
+        "message": "在 GitHub 上開啟",
+        "description": "Answer #5"
+    },
+    "faqAnswer5b_issues-url": {
+        "message": "新的 issue",
+        "description": "Answer #5"
+    },
+    "faqAnswer5c": {
+        "message": "，我們會告訴您我們能不能新增對該網站的支援。您也可以自己將 ",
+        "description": "Answer #5"
+    },
+    "faqAnswer5d_repo-url": {
+        "message": "GitHub 版本庫",
+        "description": "Answer #5"
+    },
+    "faqAnswer5e": {
+        "message": "進行分支，撰寫支援之後像我們遞交 pull request。",
         "description": "Answer #5"
     },
     "faqQuestion6": {
@@ -551,8 +575,24 @@
         "message": "關於",
         "description": "'About' section"
     },
-    "aboutChangelog": {
-        "message": "目前版本的更新日誌可 <a id='latest-release' target='_blank' href='$1'>在此</a> 查看。如要查看完整的更新日誌，請查看 <a target='_blank' href='$2'>此頁面</a>。",
+    "aboutChangelog1": {
+        "message": "目前版本的更新日誌可 ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog2_latest-release-url": {
+        "message": "在此",
+        "description": "'About' section text"
+    },
+    "aboutChangelog3": {
+        "message": " 查看。如要查看完整的更新日誌，請查看 ",
+        "description": "'About' section text"
+    },
+    "aboutChangelog4_all-releases-url": {
+        "message": "此頁面",
+        "description": "'About' section text"
+    },
+    "aboutChangelog5": {
+        "message": "。",
         "description": "'About' section text"
     },
     "aboutExtensionDesc": {
@@ -563,8 +603,16 @@
         "message": "貢獻者",
         "description": "'Contributors' header"
     },
-    "contributorsText": {
-        "message": "您可以在 <a href='$1'>GitHub</a> 上找到貢獻者列表",
+    "contributorsText1": {
+        "message": "您可以在 ",
+        "description": "'About' section text"
+    },
+    "contributorsText2_contributors-url": {
+        "message": "GitHub",
+        "description": "'About' section text"
+    },
+    "contributorsText3": {
+        "message": " 上找到貢獻者列表",
         "description": "'About' section text"
     },
     "versionTitle": {
@@ -575,8 +623,16 @@
         "message": "目前使用擴充元件版本為 $1。",
         "description": "'About' section text"
     },
-    "contributorsContribute": {
-        "message": "希望貢獻嗎？請到<a href='$1' target=\"_blank\" rel=\"noopener noreferrer\">我們的網站</a>查看您可以對此專案進行貢獻的方式。",
+    "contributorsContribute1": {
+        "message": "希望貢獻嗎？請到",
+        "description": "'About' section text"
+    },
+    "contributorsContribute2_contributing-url": {
+        "message": "我們的網站",
+        "description": "'About' section text"
+    },
+    "contributorsContribute3": {
+        "message": "查看您可以對此專案進行貢獻的方式。",
         "description": "'About' section text"
     },
     "showSomeLoveTitle": {

--- a/src/ui/options/components/connector-override.tsx
+++ b/src/ui/options/components/connector-override.tsx
@@ -58,7 +58,7 @@ export default function ConnectorOverrideOptions(props: {
 		<>
 			<h1>{t('optionsSupportedWebsites')}</h1>
 			<p>{t('optionsEnableDisableHint')}</p>
-			<p innerHTML={t('optionsCustomPatternsHint')} />
+			<p>{t('optionsCustomPatternsHint')}</p>
 			<ul class={`${styles.connectorOptionsList} ${styles.optionList}`}>
 				<li>
 					<SettingsOutlined />

--- a/src/ui/options/components/faq.tsx
+++ b/src/ui/options/components/faq.tsx
@@ -1,4 +1,4 @@
-import { CUSTOM_URLS_DOCS_URL, ISSUES_URL, t } from '@/util/i18n';
+import { CUSTOM_URLS_DOCS_URL, ISSUES_URL, REPO_URL, t } from '@/util/i18n';
 
 /**
  * Component that shows some frequently asked questions
@@ -29,10 +29,30 @@ export default function FAQ() {
 				<li>{t('faqAnswer4b3')}</li>
 				<li>{t('faqAnswer4b4')}</li>
 			</ol>
-			<p innerHTML={t('faqAnswer4c', CUSTOM_URLS_DOCS_URL)} />
+			<p>
+				{t('faqAnswer4c1')}
+				<a
+					id="docs-custom-urls"
+					target="_blank"
+					href={CUSTOM_URLS_DOCS_URL}
+				>
+					{t('faqAnswer4c2_docs-custom-urls-url')}
+				</a>
+				{t('faqAnswer4c3')}
+			</p>
 
 			<h2>{t('faqQuestion5')}</h2>
-			<p innerHTML={t('faqAnswer5', ISSUES_URL)} />
+			<p>
+				{t('faqAnswer5a')}
+				<a id="gh-issues" target="_blank" href={ISSUES_URL}>
+					{t('faqAnswer5b_issues-url')}
+				</a>
+				{t('faqAnswer5c')}
+				<a id="gh-repo" target="_blank" href={REPO_URL}>
+					{t('faqAnswer5d_repo-url')}
+				</a>
+				{t('faqAnswer5e')}
+			</p>
 
 			<h2>{t('faqQuestion6')}</h2>
 			<p>{t('faqAnswer6')}</p>

--- a/src/ui/options/components/info.tsx
+++ b/src/ui/options/components/info.tsx
@@ -15,18 +15,44 @@ export default function InfoComponent() {
 		<>
 			<h1>{t('optionsAbout')}</h1>
 			<p>{t('aboutExtensionDesc')}</p>
-			<p
-				innerHTML={t('aboutChangelog', [
-					currentChangelog(),
-					RELEASES_URL,
-				])}
-			></p>
+			<p>
+				{t('aboutChangelog1')}
+				<a
+					id="latest-release"
+					target="_blank"
+					href={currentChangelog()}
+				>
+					{t('aboutChangelog2_latest-release-url')}
+				</a>
+				{t('aboutChangelog3')}
+				<a id="all-releases" target="_blank" href={RELEASES_URL}>
+					{t('aboutChangelog4_all-releases-url')}
+				</a>
+				{t('aboutChangelog5')}
+			</p>
 			<h2>{t('versionTitle')}</h2>
-			<p innerHTML={t('versionText', getExtensionVersion())}></p>
+			<p>{t('versionText', getExtensionVersion())}</p>
 			<h2>{t('contributorsTitle')}</h2>
-			<p innerHTML={t('contributorsText', CONTRIBUTORS_URL)}></p>
+			<p>
+				{t('contributorsText1')}
+				<a id="contributors" href={CONTRIBUTORS_URL}>
+					{t('contributorsText2_contributors-url')}
+				</a>
+				{t('contributorsText3')}
+			</p>
 			// #v-ifdef !VITE_SAFARI
-			<p innerHTML={t('contributorsContribute', CONTRIBUTING_URL)}></p>
+			<p>
+				{t('contributorsContribute1')}
+				<a
+					id="contributing"
+					target="_blank"
+					href={CONTRIBUTING_URL}
+					rel="noopener noreferrer"
+				>
+					{t('contributorsContribute2_contributing-url')}
+				</a>
+				{t('contributorsContribute3')}
+			</p>
 			// #v-endif
 		</>
 	);


### PR DESCRIPTION
uses of innerHTML seem to slow down firefox addon validation (maybe?), and it's basically only been used for links

also it nicely unifies what the links are like because `id`'s, and `rel` attributes sometimes differed.

**Describe the changes you made**
i split the translation strings into their parts which aren't `<a>` tags, it's not pretty, yes.

**Additional context**
for release builds there is one remaining innerHTML use, in `context-menu`... this is from the solidjs template function and can't be avoided (?)

(yes i know `_locales` shouldn't be edited manually, i only did that so the PR can be tested and demonstrated)

(small helper function for splitting the strings by `<a>` tags: [trennen.js](https://github.com/user-attachments/files/26072495/trennen.js))