### PR TITLE
translate anchor

### DIFF
--- a/src/ui/components/util.tsx
+++ b/src/ui/components/util.tsx
@@ -69,6 +69,7 @@ export function Anchor(props: {
 	href: string;
 	class?: string;
 	title?: string;
+	target?: '_blank' | '_top' | '_self' | '_parent';
 }) {
 	return (
 		<a
@@ -146,14 +147,25 @@ export function TPopupAnchor(props: Localization): JSXElement {
 	);
 }
 
-export function TAnchor(props: Localization): JSXElement {
+export function TAnchor(
+	props: Localization & {
+		class?: string;
+		target?: '_blank' | '_top' | '_self' | '_parent';
+	},
+): JSXElement {
 	const [res, setRes] = createSignal<(string | [string, string])[]>([]);
 	onMount(() => anchorOnMount(props, setRes));
 	return (
 		<For each={res()}>
 			{(item) => (
 				<Show when={typeof item !== 'string'} fallback={item}>
-					<Anchor href={item[0]}>{item[1]}</Anchor>
+					<Anchor
+						href={item[0]}
+						class={props.class}
+						target={props.target}
+					>
+						{item[1]}
+					</Anchor>
 				</Show>
 			)}
 		</For>

--- a/src/ui/components/util.tsx
+++ b/src/ui/components/util.tsx
@@ -1,5 +1,5 @@
-import type { JSXElement, Setter } from 'solid-js';
-import { For, Show, createSignal, onMount } from 'solid-js';
+import type { JSXElement } from 'solid-js';
+import { For, Show, createMemo } from 'solid-js';
 import { t } from '../../util/i18n';
 import browser from 'webextension-polyfill';
 
@@ -77,6 +77,7 @@ export function Anchor(props: {
 			title={props.title}
 			aria-label={props.title}
 			class={props.class}
+			target={props.target}
 		>
 			{props.children}
 		</a>
@@ -86,46 +87,26 @@ export function Anchor(props: {
 /**
  * Regex that finds anchor tag
  */
-const anchorRegex = /<a.*?href=("|')((?:(?!\1).)+)\1.*?>([^<]+)<\/a>/;
+const anchorRegex = /<a.*?href=("|')((?:(?!\1).)+)\1.*?>([^<]+)<\/a>/g;
 type Localization = {
 	messageName: string;
 	substitutions?: string | string[];
 };
-const anchorOnMount = (
-	props: Localization,
-	setRes: Setter<(string | [string, string])[]>,
-) => {
-	let message = t(props.messageName, props.substitutions);
-	const maxIterations = 5;
-	let i = 0;
-	while (message) {
-		// check if we've gone over the max iterations
-		i++;
-		if (i > maxIterations) {
-			break;
-		}
-
-		// get match and break if there is none, inserting remaining message
-		const match = message.match(anchorRegex);
-		if (!match) {
-			// eslint-disable-next-line
-			setRes((prev) => [...prev, message]);
-			break;
-		}
-
-		// get full string, href from capture group 2, and tag content from capture group 3
+const anchorTuples = (props: Localization) => {
+	const message = t(props.messageName, props.substitutions);
+	const matches = message.matchAll(anchorRegex);
+	const segments = [];
+	let previousMatchEnd = 0;
+	for (const match of matches) {
 		// prettier-ignore
 		const [str, /* delimiter */, href, content] = match;
-
-		// push the content before the anchor, the anchor, and then slice the message to repeat the loop on remaining text.
-		// eslint-disable-next-line
-		setRes((prev) => [
-			...prev,
-			message.slice(0, match.index),
-			[href, content],
-		]);
-		message = message.slice((match.index ?? 0) + str.length);
+		segments.push(message.slice(previousMatchEnd, match.index));
+		segments.push([href, content]);
+		previousMatchEnd = match.index + str.length;
 	}
+	segments.push(message.slice(previousMatchEnd));
+
+	return segments;
 };
 
 /**
@@ -133,11 +114,10 @@ const anchorOnMount = (
  * Has a maximum iterations count just for safety's sake because while loop with janky code moment.
  */
 export function TPopupAnchor(props: Localization): JSXElement {
-	const [res, setRes] = createSignal<(string | [string, string])[]>([]);
-	onMount(() => anchorOnMount(props, setRes));
+	const anchorMemo = createMemo(() => anchorTuples(props));
 	// convert the array of strings and tuples into a JSX element
 	return (
-		<For each={res()}>
+		<For each={anchorMemo()}>
 			{(item) => (
 				<Show when={typeof item !== 'string'} fallback={item}>
 					<PopupAnchor href={item[0]}>{item[1]}</PopupAnchor>
@@ -153,10 +133,9 @@ export function TAnchor(
 		target?: '_blank' | '_top' | '_self' | '_parent';
 	},
 ): JSXElement {
-	const [res, setRes] = createSignal<(string | [string, string])[]>([]);
-	onMount(() => anchorOnMount(props, setRes));
+	const anchorMemo = createMemo(() => anchorTuples(props));
 	return (
-		<For each={res()}>
+		<For each={anchorMemo()}>
 			{(item) => (
 				<Show when={typeof item !== 'string'} fallback={item}>
 					<Anchor

--- a/src/ui/components/util.tsx
+++ b/src/ui/components/util.tsx
@@ -1,4 +1,4 @@
-import type { JSXElement } from 'solid-js';
+import type { JSXElement, Setter } from 'solid-js';
 import { For, Show, createSignal, onMount } from 'solid-js';
 import { t } from '../../util/i18n';
 import browser from 'webextension-polyfill';
@@ -64,58 +64,96 @@ export function PopupAnchor(props: {
 	);
 }
 
+export function Anchor(props: {
+	children: JSXElement | string;
+	href: string;
+	class?: string;
+	title?: string;
+}) {
+	return (
+		<a
+			href={props.href}
+			title={props.title}
+			aria-label={props.title}
+			class={props.class}
+		>
+			{props.children}
+		</a>
+	);
+}
+
 /**
  * Regex that finds anchor tag
  */
-const anchorRegex = /<a.*?href="([^"]+)".*?>([^<]+)<\/a>/;
+const anchorRegex = /<a.*?href=("|')((?:(?!\1).)+)\1.*?>([^<]+)<\/a>/;
+type Localization = {
+	messageName: string;
+	substitutions?: string | string[];
+};
+const anchorOnMount = (
+	props: Localization,
+	setRes: Setter<(string | [string, string])[]>,
+) => {
+	let message = t(props.messageName, props.substitutions);
+	const maxIterations = 5;
+	let i = 0;
+	while (message) {
+		// check if we've gone over the max iterations
+		i++;
+		if (i > maxIterations) {
+			break;
+		}
+
+		// get match and break if there is none, inserting remaining message
+		const match = message.match(anchorRegex);
+		if (!match) {
+			// eslint-disable-next-line
+			setRes((prev) => [...prev, message]);
+			break;
+		}
+
+		// get full string, href from capture group 2, and tag content from capture group 3
+		// prettier-ignore
+		const [str, /* delimiter */, href, content] = match;
+
+		// push the content before the anchor, the anchor, and then slice the message to repeat the loop on remaining text.
+		// eslint-disable-next-line
+		setRes((prev) => [
+			...prev,
+			message.slice(0, match.index),
+			[href, content],
+		]);
+		message = message.slice((match.index ?? 0) + str.length);
+	}
+};
 
 /**
  * Gets localized string from locale and turns anchors into popup anchors.
  * Has a maximum iterations count just for safety's sake because while loop with janky code moment.
  */
-export function TPopupAnchor(props: {
-	messageName: string;
-	substitutions?: string | string[];
-}): JSXElement {
+export function TPopupAnchor(props: Localization): JSXElement {
 	const [res, setRes] = createSignal<(string | [string, string])[]>([]);
-	onMount(() => {
-		let message = t(props.messageName, props.substitutions);
-		const maxIterations = 5;
-		let i = 0;
-		while (message) {
-			// check if we've gone over the max iterations
-			i++;
-			if (i > maxIterations) {
-				break;
-			}
-
-			// get match and break if there is none, inserting remaining message
-			const match = message.match(anchorRegex);
-			if (!match) {
-				// eslint-disable-next-line
-				setRes((prev) => [...prev, message]);
-				break;
-			}
-
-			// get full string, href from capture group 1, and tag content from capture group 2
-			const [str, href, content] = match;
-
-			// push the content before the anchor, the anchor, and then slice the message to repeat the loop on remaining text.
-			// eslint-disable-next-line
-			setRes((prev) => [
-				...prev,
-				message.slice(0, match.index),
-				[href, content],
-			]);
-			message = message.slice((match.index ?? 0) + str.length);
-		}
-	});
+	onMount(() => anchorOnMount(props, setRes));
 	// convert the array of strings and tuples into a JSX element
 	return (
 		<For each={res()}>
 			{(item) => (
 				<Show when={typeof item !== 'string'} fallback={item}>
 					<PopupAnchor href={item[0]}>{item[1]}</PopupAnchor>
+				</Show>
+			)}
+		</For>
+	);
+}
+
+export function TAnchor(props: Localization): JSXElement {
+	const [res, setRes] = createSignal<(string | [string, string])[]>([]);
+	onMount(() => anchorOnMount(props, setRes));
+	return (
+		<For each={res()}>
+			{(item) => (
+				<Show when={typeof item !== 'string'} fallback={item}>
+					<Anchor href={item[0]}>{item[1]}</Anchor>
 				</Show>
 			)}
 		</For>

--- a/src/ui/options/components/connector-override.tsx
+++ b/src/ui/options/components/connector-override.tsx
@@ -59,7 +59,7 @@ export default function ConnectorOverrideOptions(props: {
 		<>
 			<h1>{t('optionsSupportedWebsites')}</h1>
 			<p>{t('optionsEnableDisableHint')}</p>
-			<TAnchor messageName="optionsCustomPatternsHint" />
+			<TAnchor messageName="optionsCustomPatternsHint" target="_blank" />
 			<ul class={`${styles.connectorOptionsList} ${styles.optionList}`}>
 				<li>
 					<SettingsOutlined />

--- a/src/ui/options/components/connector-override.tsx
+++ b/src/ui/options/components/connector-override.tsx
@@ -28,7 +28,6 @@ import browser from 'webextension-polyfill';
 import { t } from '@/util/i18n';
 import BlockedChannels from './edit-options/blocked-channels';
 import type { ModalType } from './navigator';
-import { TAnchor } from '@/ui/components/util';
 
 const globalOptions = BrowserStorage.getStorage(BrowserStorage.OPTIONS);
 const connectorOverrideOptions = BrowserStorage.getStorage(

--- a/src/ui/options/components/connector-override.tsx
+++ b/src/ui/options/components/connector-override.tsx
@@ -28,6 +28,7 @@ import browser from 'webextension-polyfill';
 import { t } from '@/util/i18n';
 import BlockedChannels from './edit-options/blocked-channels';
 import type { ModalType } from './navigator';
+import { TAnchor } from '@/ui/components/util';
 
 const globalOptions = BrowserStorage.getStorage(BrowserStorage.OPTIONS);
 const connectorOverrideOptions = BrowserStorage.getStorage(
@@ -58,7 +59,7 @@ export default function ConnectorOverrideOptions(props: {
 		<>
 			<h1>{t('optionsSupportedWebsites')}</h1>
 			<p>{t('optionsEnableDisableHint')}</p>
-			<p innerHTML={t('optionsCustomPatternsHint')} />
+			<TAnchor messageName="optionsCustomPatternsHint" />
 			<ul class={`${styles.connectorOptionsList} ${styles.optionList}`}>
 				<li>
 					<SettingsOutlined />

--- a/src/ui/options/components/connector-override.tsx
+++ b/src/ui/options/components/connector-override.tsx
@@ -59,7 +59,7 @@ export default function ConnectorOverrideOptions(props: {
 		<>
 			<h1>{t('optionsSupportedWebsites')}</h1>
 			<p>{t('optionsEnableDisableHint')}</p>
-			<TAnchor messageName="optionsCustomPatternsHint" target="_blank" />
+			<p>{t('optionsCustomPatternsHint')}</p>
 			<ul class={`${styles.connectorOptionsList} ${styles.optionList}`}>
 				<li>
 					<SettingsOutlined />

--- a/src/ui/options/components/faq.tsx
+++ b/src/ui/options/components/faq.tsx
@@ -1,4 +1,5 @@
-import { CUSTOM_URLS_DOCS_URL, ISSUES_URL, t } from '@/util/i18n';
+import { TAnchor } from '@/ui/components/util';
+import { CUSTOM_URLS_DOCS_URL, ISSUES_URL, REPO_URL, t } from '@/util/i18n';
 
 /**
  * Component that shows some frequently asked questions
@@ -29,10 +30,16 @@ export default function FAQ() {
 				<li>{t('faqAnswer4b3')}</li>
 				<li>{t('faqAnswer4b4')}</li>
 			</ol>
-			<p innerHTML={t('faqAnswer4c', CUSTOM_URLS_DOCS_URL)} />
+			<TAnchor
+				messageName="faqAnswer4c"
+				substitutions={CUSTOM_URLS_DOCS_URL}
+			/>
 
 			<h2>{t('faqQuestion5')}</h2>
-			<p innerHTML={t('faqAnswer5', ISSUES_URL)} />
+			<TAnchor
+				messageName="faqAnswer5"
+				substitutions={[ISSUES_URL, REPO_URL]}
+			/>
 
 			<h2>{t('faqQuestion6')}</h2>
 			<p>{t('faqAnswer6')}</p>

--- a/src/ui/options/components/faq.tsx
+++ b/src/ui/options/components/faq.tsx
@@ -33,12 +33,14 @@ export default function FAQ() {
 			<TAnchor
 				messageName="faqAnswer4c"
 				substitutions={CUSTOM_URLS_DOCS_URL}
+				target="_blank"
 			/>
 
 			<h2>{t('faqQuestion5')}</h2>
 			<TAnchor
 				messageName="faqAnswer5"
 				substitutions={[ISSUES_URL, REPO_URL]}
+				target="_blank"
 			/>
 
 			<h2>{t('faqQuestion6')}</h2>

--- a/src/ui/options/components/info.tsx
+++ b/src/ui/options/components/info.tsx
@@ -28,11 +28,13 @@ export default function InfoComponent() {
 			<TAnchor
 				messageName="contributorsText"
 				substitutions={CONTRIBUTORS_URL}
+				target="_blank"
 			/>
 			// #v-ifdef !VITE_SAFARI
 			<TAnchor
 				messageName="contributorsContribute"
 				substitutions={CONTRIBUTING_URL}
+				target="_blank"
 			/>
 			// #v-endif
 		</>

--- a/src/ui/options/components/info.tsx
+++ b/src/ui/options/components/info.tsx
@@ -1,3 +1,4 @@
+import { TAnchor } from '@/ui/components/util';
 import {
 	currentChangelog,
 	t,
@@ -24,9 +25,15 @@ export default function InfoComponent() {
 			<h2>{t('versionTitle')}</h2>
 			<p innerHTML={t('versionText', getExtensionVersion())}></p>
 			<h2>{t('contributorsTitle')}</h2>
-			<p innerHTML={t('contributorsText', CONTRIBUTORS_URL)}></p>
+			<TAnchor
+				messageName="contributorsText"
+				substitutions={CONTRIBUTORS_URL}
+			/>
 			// #v-ifdef !VITE_SAFARI
-			<p innerHTML={t('contributorsContribute', CONTRIBUTING_URL)}></p>
+			<TAnchor
+				messageName="contributorsContribute"
+				substitutions={CONTRIBUTING_URL}
+			/>
 			// #v-endif
 		</>
 	);


### PR DESCRIPTION
currently `innerHTML` is used to display links, this removes many unnecessary uses of it

**Describe the changes you made**
- changes regex for anchors in translation strings to support both `'` and `"` as `href` delimiters
- introduces a new TAnchor similar to TPopupAnchor which sanitizes translation strings

**Additional context**
- Popup Anchor was broken as seen in #5821, #5970 because of `'` instead of `"` for delimiting the href url in a translation string