### PR TITLE
feat: add poeba.lu connector

### DIFF
--- a/src/connectors/poeba.lu.ts
+++ b/src/connectors/poeba.lu.ts
@@ -1,0 +1,26 @@
+export {};
+
+/**
+ * This connector supports poeba.lu music review site.
+ * Reads metadata from the album info section and floating player.
+ */
+
+Connector.playerSelector = '#floating-player-dock';
+
+Connector.artistSelector = '.album-meta dd:nth-child(2)';
+
+Connector.albumSelector = '.album-meta dd:nth-child(4)';
+
+Connector.getArtistTrack = () => {
+  const artist = document.querySelector('.album-meta dd:nth-child(2)')?.textContent?.trim() || null;
+  const album = document.querySelector('.album-meta dd:nth-child(4)')?.textContent?.trim() || null;
+
+  return { artist, track: album };
+};
+
+Connector.isPlaying = () => {
+  const dock = document.querySelector('#floating-player-dock');
+  const title = document.querySelector('#floating-player-dock-title');
+
+  return Boolean(dock && title && title.textContent?.trim().length > 0);
+};

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -69,6 +69,12 @@ export default <ConnectorMeta[]>[
 		id: 'pakartot',
 	},
 	{
+	    label: 'poeba.lu',
+	    matches: ['*://poeba.lu/*'],
+	    js: 'poeba.lu.js',
+	    id: 'poebalu',
+	},
+	{
 		label: 'Deezer',
 		matches: ['*://www.deezer.com/*'],
 		js: 'deezer.js',


### PR DESCRIPTION
<!-- 
  Thank you for taking the time to contribute to this project!

  Make sure to check out our guide on contributing with guidelines of how to contribute.

  See: https://github.com/web-scrobbler/web-scrobbler/blob/master/.github/CONTRIBUTING.md

--> 

**Describe the changes you made**
Adds a connector for poeba.lu, a music review site.

The site uses an embedded Bandcamp player. Since the player runs 
in a cross-origin iframe, metadata is read from the page's own 
album info section and floating player dock.

Currently scrobbles artist and album. Track-level scrobbling is 
not possible without iframe injection support, as the track name 
is only available inside the Bandcamp embed.

**Additional context**
Tested manually on multiple review pages. Scrobbles correct 
artist and album on each page.
