### PR TITLE
feat: update last.fm api endpoint to custom vercel app

### DIFF
--- a/src/core/scrobbler/lastfm/lastfm-scrobbler.ts
+++ b/src/core/scrobbler/lastfm/lastfm-scrobbler.ts
@@ -15,7 +15,7 @@ import { sendBackgroundMessage } from '@/util/communication';
 export default class LastFmScrobbler extends AudioScrobbler {
 	/** @override */
 	getApiUrl(): string {
-		return 'https://ws.audioscrobbler.com/2.0/';
+		return 'https://last-ing.vercel.app/api/2.0/';
 	}
 
 	/** @override */


### PR DESCRIPTION
Updates the `getApiUrl` method in `LastFmScrobbler` to point to a custom Vercel application endpoint instead of the official Last.fm AudioScrobbler endpoint.