### PR TITLE
Fix hoopla connector

### DIFF
--- a/src/connectors/hoopladigital.ts
+++ b/src/connectors/hoopladigital.ts
@@ -16,7 +16,7 @@ Connector.getTrackArt = () => {
 	);
 
 	if (trackArtUrl) {
-		return trackArtUrl.replace(/(?<=_)\d{3}(?=\.jpeg)/g, '916'); // larger image filename
+		return trackArtUrl.replace(/(?<=_)\d{3}(?=\.jpeg)/, '916'); // larger image filename
 	}
 
 	return null;

--- a/src/connectors/hoopladigital.ts
+++ b/src/connectors/hoopladigital.ts
@@ -1,6 +1,6 @@
 export {};
 
-Connector.playerSelector = '#app'; // .duration-700 player wrapper is destroyed when album ends
+Connector.playerSelector = '#root'; // player wrapper is destroyed when album ends
 
 Connector.pauseButtonSelector = 'button[aria-label=Pause]';
 
@@ -8,12 +8,11 @@ Connector.trackSelector = '.text-current > p:first-of-type';
 
 Connector.artistSelector = '.text-current > p:nth-of-type(2)';
 
-Connector.albumSelector =
-	'.duration-700.z-100 .box-border button.text-hoopla-blue-800 > a:last-of-type'; // only available in expanded player
+Connector.albumSelector = 'button.text-hoopla-blue-800 ~ div > a'; // only available in expanded player
 
 Connector.getTrackArt = () => {
 	const trackArtUrl = Util.extractImageUrlFromSelectors(
-		'.duration-700.z-100 .grid > div:first-of-type > img',
+		'#expand-button ~ img',
 	);
 
 	if (trackArtUrl) {
@@ -23,8 +22,6 @@ Connector.getTrackArt = () => {
 	return null;
 };
 
-Connector.durationSelector =
-	'.duration-700.z-100 .grid > div:nth-of-type(2) > div.justify-between > span:last-of-type > span';
+Connector.durationSelector = '.w-64 > span:last-of-type span';
 
-Connector.currentTimeSelector =
-	'.duration-700.z-100 .grid > div:nth-of-type(2) > div.justify-between > span:first-of-type > span';
+Connector.currentTimeSelector = '.w-64 > span:first-of-type span';


### PR DESCRIPTION
Hi! Long time, no see. I was unable to set up the V3 project locally without dependency errors and eventually gave up after a year or so of several tries. However, earlier today I noticed that the hoopla connector was no longer working and decided to give it another shot. Thankfully, it finally worked, and here we are again!

Anyway, hoopla made some changes to their site that required some selector updates. No real changes to the connector setup other than selectors, which are hopefully a bit less fragile and will work for a while again.

Since hoopla access is limited, here is a screenshot of the connector working again with the selector updates:
<img width="1528" height="852" alt="" src="https://github.com/user-attachments/assets/f62251dc-7339-4eec-a894-1a9ca5ffebbf" />

Since I haven't submitted anything in a long time, please let me know if there is anything else needed or anything I should keep in mind for next time. Thanks!