### PR TITLE
Fix Audacy connector

### DIFF
--- a/src/connectors/audacy.ts
+++ b/src/connectors/audacy.ts
@@ -45,5 +45,8 @@ Connector.scrobblingDisallowedReason = () => {
 Connector.applyFilter(filter);
 
 function removeDashes(text: string) {
+	if (Connector.isPodcast()) {
+		return text;
+	}
 	return text.replace(/-/g, ' ');
 }

--- a/src/connectors/audacy.ts
+++ b/src/connectors/audacy.ts
@@ -1,79 +1,42 @@
 export {};
 
-const audioPlayer = 'div[aria-label="Audio player"]';
-const buttonOpenFullscreen = 'button[aria-label="Open full-screen player"]';
-const buttonCloseFullscreen = 'button[aria-label="Close full-screen player"]';
-const fullArtistTrackSelector = `${buttonCloseFullscreen} + div span`;
+const audioPlayer = '[aria-label="Audio player"]';
+const buttonFullscreen = 'button[aria-label="Open full-screen player"]';
 
 Connector.playerSelector = '#root'; // player not in DOM until initiated by user
 
-Connector.getArtist = () => {
-	const miniArtistStationText = Util.getTextFromSelectors(
-		`${audioPlayer} ${buttonOpenFullscreen} span:nth-of-type(2)`,
-	);
+Connector.playButtonSelector = `${audioPlayer} button[aria-label=Play]`;
 
-	if (miniArtistStationText !== null) {
-		return miniArtistStationText.split(' • ')[0];
-	}
+Connector.isPodcast = () =>
+	Util.isElementVisible(`${audioPlayer} button[aria-label$="15 seconds"]`);
 
-	if (Util.isElementVisible(fullArtistTrackSelector)) {
-		return (
-			Util.getTextFromSelectors(fullArtistTrackSelector)?.split(
-				' - ',
-			)[1] ?? ''
-		);
-	}
+Connector.trackSelector = `${audioPlayer} ${buttonFullscreen} span:first-of-type`;
 
-	return null;
-};
+Connector.artistSelector = `${audioPlayer} ${buttonFullscreen} span:nth-of-type(2)`;
 
-Connector.getTrack = () => {
-	const miniTrackText = Util.getTextFromSelectors(
-		`${audioPlayer} ${buttonOpenFullscreen} span:first-of-type`,
-	);
+Connector.getArtist = () =>
+	Util.getTextFromSelectors(Connector.artistSelector)?.split(' • ')[0];
 
-	if (miniTrackText !== null) {
-		return miniTrackText;
-	}
+Connector.trackArtSelector = `${audioPlayer} ${buttonFullscreen} img`;
 
-	if (Util.isElementVisible(fullArtistTrackSelector)) {
-		return Util.getTextFromSelectors(fullArtistTrackSelector)?.split(
-			' - ',
-		)[0];
-	}
-
-	return null;
-};
-
-Connector.trackArtSelector = [
-	`${audioPlayer} ${buttonOpenFullscreen} img`,
-	`${buttonCloseFullscreen} + div img`,
-];
-
-Connector.isTrackArtDefault = (url) => url?.includes('base64');
-
-Connector.isPlaying = () => {
-	const buttonSvgTitle =
-		'button:not([aria-label=Like], [aria-label*=thumbs]) svg title';
-	const buttonPlaying = Util.getTextFromSelectors([
-		`${audioPlayer} ${buttonSvgTitle}`,
-		`${buttonCloseFullscreen} + div ${buttonSvgTitle}`,
-	]);
-	return buttonPlaying === 'Pause' || buttonPlaying === 'Stop';
-};
+Connector.isTrackArtDefault = (url) =>
+	url?.includes('radioimg.audacy.com') || url?.startsWith('data:image');
 
 Connector.scrobblingDisallowedReason = () => {
 	const artist = Connector.getArtist();
 	const track = Connector.getTrack();
 
-	if (!artist || !track) {
-		return 'Other';
-	}
-	if (artist.includes('Audacy') || artist === track) {
+	if (
+		artist === track ||
+		artist?.includes('Audacy') ||
+		(Util.getTextFromSelectors(Connector.artistSelector) === artist &&
+			!Connector.isPodcast())
+	) {
+		if (track?.startsWith('Advertisement')) {
+			return 'IsAd';
+		}
 		return 'FilteredTag';
 	}
-	if (track.startsWith('Advertisement')) {
-		return 'IsAd';
-	}
+
 	return null;
 };

--- a/src/connectors/audacy.ts
+++ b/src/connectors/audacy.ts
@@ -1,5 +1,6 @@
 export {};
 
+const filter = MetadataFilter.createFilter({ artist: removeDashes });
 const audioPlayer = '[aria-label="Audio player"]';
 const buttonFullscreen = 'button[aria-label="Open full-screen player"]';
 
@@ -40,3 +41,9 @@ Connector.scrobblingDisallowedReason = () => {
 
 	return null;
 };
+
+Connector.applyFilter(filter);
+
+function removeDashes(text: string) {
+	return text.replace(/-/g, ' ');
+}


### PR DESCRIPTION
Finally,* a fix for the long-broken Audacy connector! This will resolve #4789.

Station example: https://www.audacy.com/stations/live105
Podcast example: https://www.audacy.com/podcast/calm-it-down-354c0

**Describe the changes you made**
- Got it working again, first of all. 😅
- Simplified connector functionality.
- Added podcast recognition.
- Updated disabled scrobbles to prevent more bad scrobbles.
- Added filter to remove dashes from artists.

**Additional context**
- After rebuilding the Audacy connector in #3550, they made an update that removed the mini player from the DOM when the large player was active, which broke it again. It was then fixed in #3595 to support both players. After trying to get that version to work again now and being unable to do so, I realized they have since reverted the update that removed the mini player from the DOM, so I could simplify the connector functionality again and only focus on that player. They also seem to have removed their playlist stations.
- Podcasts are signified by having forward and rewind options, which also ends up including some newscasts, but there is no way to differentiate one from the other.
- In addition to the previous disabled scrobbles, I noticed that there is often a delay before the artist loads, so it will now ensure scrobbling something very wrong like "Smooth Operator" by 94.7 The WAVE does not happen.
- As noted in my comments in #5935, some stations have inexplicably added dashes to artist names that are causing issues with lookups and possibly creating bad artists on Last.fm. Adding a simple filter to remove dashes from artist names seems to fix it, while most artists that should have dashes in their names should still scrobble correctly—blink-182 and The B-52's are a couple that specifically came up while testing.

*I have wanted to fix this for years but was unable to set up the project locally without errors after the V3 revamp until just this week when I tried again, and it finally worked for me.