### PR TITLE
Fix Tidal connector

### DIFF
--- a/src/connectors/tidal.ts
+++ b/src/connectors/tidal.ts
@@ -27,7 +27,8 @@ Connector.getUniqueID = () => {
 	return null;
 };
 
-const artistSelector = `${Connector.playerSelector} span.artist-link a`;
+const artistSelector = `${Connector.playerSelector} a[data-test="grid-item-detail-text-title-artist"]`;
+const albumArtistSelector = `${artistSelector}:first-child`;
 
 Connector.getArtist = () => {
 	const artistNodes = document.querySelectorAll(artistSelector);
@@ -40,25 +41,8 @@ Connector.albumSelector = [
 ];
 
 Connector.getAlbumArtist = () => {
-	const albumUrlSegments = Util.getAttrFromSelectors(
-		Connector.albumSelector,
-		'href',
-	)?.split('/');
-	const pageUrlSegments = Util.getAttrFromSelectors(
-		'head meta[name="apple-itunes-app"]',
-		'content',
-	)?.split('/');
-	if (
-		'album' === albumUrlSegments?.at(-2) &&
-		'album' === pageUrlSegments?.at(-2) &&
-		albumUrlSegments?.at(-1) === pageUrlSegments?.at(-1)
-	) {
-		const albumArtistNode = document.querySelectorAll(
-			'main div[class^="_detailContainer"] .artist-link a',
-		);
-		return Util.joinArtists(Array.from(albumArtistNode));
-	}
-	return null;
+	const albumArtistNode = document.querySelectorAll(albumArtistSelector);
+	return Util.joinArtists(Array.from(albumArtistNode));
 };
 
 Connector.trackArtSelector = `${Connector.playerSelector} figure[data-test="current-media-imagery"] img`;


### PR DESCRIPTION
<!-- 
  This is my first contribution, so please be lenient if I've missed some requirement of this project since I rushed in my free time. Hope to not have done so, if done please let me know!
--> 

**Describe the changes you made**
- Fixed the `artistSelector` for Tidal's new UI
- Added a new variable called `albumArtistSelector` that extends the `artistSelector` with `:first-child` so it captures the first artist in the artist row _(which match the albumArtist by the platform's design)_
- Cleaned up `Connector.getAlbumArtist` by refactoring the extraction; now it is cleaner and effective, without over-engineering logic

**Additional context**
`Connector.getAlbumArtist` edition must be validated before merged; I may be missed some business rules from Tidal and it might borderline a issue. In my general view it doesn't, but double check is never too much.
