### PR TITLE
Add Meloradio connector

### DIFF
--- a/src/connectors/meloradio.ts
+++ b/src/connectors/meloradio.ts
@@ -1,0 +1,11 @@
+export {};
+
+Connector.playerSelector = '#player';
+
+Connector.artistSelector = '#player .player__top__text__line--1';
+
+Connector.trackSelector = '#player .player__top__text__line--2';
+
+Connector.trackArtSelector = '#player .player__rds__image img';
+
+Connector.pauseButtonSelector = '#player .player__controls__pause';

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2777,4 +2777,10 @@ export default <ConnectorMeta[]>[
 		js: 'radiosaw.js',
 		id: 'radiosaw',
 	},
+	{
+		label: 'Meloradio',
+		matches: ['*://player.meloradio.pl/*'],
+		js: 'meloradio.js',
+		id: 'meloradio',
+	},
 ];


### PR DESCRIPTION
## Summary

Add support for [Meloradio](https://player.meloradio.pl/), a Polish internet radio station from the Eurozet group.

The connector extracts artist and track information from the dynamically rendered React player, using the RDS (Radio Data System) data selectors that display the currently playing song.

**Selectors used:**
- `#player .player__top__text__line--1` — artist name
- `#player .player__top__text__line--2` — track title
- `#player .player__rds__image img` — album art
- `#player .player__controls__pause` — pause button (for play state detection)

**URLs matched:**
- `*://player.meloradio.pl/*`

This covers the main player page and all music channel subpages listed in #2337:
- https://player.meloradio.pl/
- https://player.meloradio.pl/Kanaly-muzyczne/Meloradio-Acoustic
- https://player.meloradio.pl/Kanaly-muzyczne/Meloradio-Film
- https://player.meloradio.pl/Kanaly-muzyczne/Meloradio-Classics
- https://player.meloradio.pl/Kanaly-muzyczne/Meloradio-Premium
- https://player.meloradio.pl/Kanaly-muzyczne/Meloradio-Delicate
- https://player.meloradio.pl/Kanaly-muzyczne/Meloradio-Christmas

Closes #2337