### PR TITLE
Fix iHeart connector

### DIFF
--- a/src/connectors/iheart.ts
+++ b/src/connectors/iheart.ts
@@ -5,6 +5,13 @@ export {};
 const playerBar = '[data-test=player-container]';
 const controlBar = '[data-test=player-controls]';
 const artistSelector = `${playerBar} [data-test=description-link]`;
+const filter = MetadataFilter.createFilter({
+	track: [
+		MetadataFilter.removeRemastered,
+		MetadataFilter.removeVersion,
+		MetadataFilter.removeLive,
+	],
+});
 let artistTrack: ArtistTrackInfo | null = null;
 let timeout: ReturnType<typeof setTimeout> | undefined;
 
@@ -49,6 +56,8 @@ Connector.isPlaying = () => {
 	return svgLabel === 'Stop';
 };
 
+Connector.applyFilter(filter);
+
 function getArtistTrack() {
 	const artist = Util.getTextFromSelectors(artistSelector);
 	let trackSelector = `${playerBar} [data-test=title-link]`;
@@ -57,7 +66,10 @@ function getArtistTrack() {
 		trackSelector = `${playerBar} [data-test=subtitle-link]`;
 	}
 
-	const track = Util.getTextFromSelectors(trackSelector)?.replace('•', '-');
+	const track = Util.getTextFromSelectors(trackSelector)?.replace(
+		'\u2022',
+		'-',
+	);
 
 	return { artist, track };
 }

--- a/src/connectors/iheart.ts
+++ b/src/connectors/iheart.ts
@@ -1,8 +1,12 @@
+import type { ArtistTrackInfo } from '@/core/types';
+
 export {};
 
 const playerBar = '[data-test=player-container]';
 const controlBar = '[data-test=player-controls]';
 const artistSelector = `${playerBar} [data-test=description-link]`;
+let artistTrack: ArtistTrackInfo | null = null;
+let timeout: ReturnType<typeof setTimeout> | undefined;
 
 Connector.playerSelector = playerBar;
 
@@ -10,17 +14,19 @@ Connector.isPodcast = () =>
 	Util.isElementVisible(`${playerBar} [data-test=forward-30-player-button]`);
 
 Connector.getArtistTrack = () => {
-	const artist = Util.getTextFromSelectors(artistSelector);
-	let trackSelector = `${playerBar} [data-test=title-link]`;
+	const newArtistTrack = getArtistTrack();
 
-	if (Connector.isPodcast()) {
-		trackSelector = `${playerBar} [data-test=subtitle-link]`;
+	if (isArtistTrackValid(newArtistTrack)) {
+		artistTrack = newArtistTrack;
+		renewTimeout();
 	}
 
-	const track = Util.getTextFromSelectors(trackSelector);
-
-	return { artist, track };
+	return artistTrack;
 };
+
+Connector.currentTimeSelector = `${playerBar} span:has(+ [data-test=progress-bar-player-control])`;
+
+Connector.durationSelector = `${playerBar} [data-test=progress-bar-player-control] + span`;
 
 Connector.getTrackArt = () => {
 	const artist = Util.getTextFromSelectors(artistSelector);
@@ -30,7 +36,7 @@ Connector.getTrackArt = () => {
 	return trackArtUrl?.replace(/(?<=fit%28)\d{3}%2C\d{1,3}(?=%29)/, '400%2C0'); // larger image
 };
 
-Connector.isTrackArtDefault = (url) => url?.includes('assets.streams');
+Connector.isTrackArtDefault = (url) => url?.includes('assets');
 
 Connector.isPlaying = () => {
 	const playButtonSvg = `${controlBar} button[data-test=player-play-button] svg`;
@@ -42,3 +48,32 @@ Connector.isPlaying = () => {
 
 	return svgLabel === 'Stop';
 };
+
+function getArtistTrack() {
+	const artist = Util.getTextFromSelectors(artistSelector);
+	let trackSelector = `${playerBar} [data-test=title-link]`;
+
+	if (Connector.isPodcast()) {
+		trackSelector = `${playerBar} [data-test=subtitle-link]`;
+	}
+
+	const track = Util.getTextFromSelectors(trackSelector);
+
+	return { artist, track };
+}
+
+function isArtistTrackValid(artistTrack: ArtistTrackInfo) {
+	if (!artistTrack.track) {
+		return false;
+	}
+
+	return true;
+}
+
+function renewTimeout() {
+	clearTimeout(timeout);
+	timeout = setTimeout(() => {
+		artistTrack = null;
+		Connector.onStateChanged();
+	}, 10000); // 10 second delay to mitigate frequent empty state on some stations
+}

--- a/src/connectors/iheart.ts
+++ b/src/connectors/iheart.ts
@@ -62,12 +62,8 @@ function getArtistTrack() {
 	return { artist, track };
 }
 
-function isArtistTrackValid(artistTrack: ArtistTrackInfo) {
-	if (!artistTrack.track) {
-		return false;
-	}
-
-	return true;
+function isArtistTrackValid(artistTrack: ArtistTrackInfo): boolean {
+	return !!artistTrack.track;
 }
 
 function renewTimeout() {

--- a/src/connectors/iheart.ts
+++ b/src/connectors/iheart.ts
@@ -16,7 +16,7 @@ Connector.isPodcast = () =>
 Connector.getArtistTrack = () => {
 	const newArtistTrack = getArtistTrack();
 
-	if (isArtistTrackValid(newArtistTrack)) {
+	if (!Util.isArtistTrackEmpty(newArtistTrack)) {
 		artistTrack = newArtistTrack;
 		renewTimeout();
 	}
@@ -60,10 +60,6 @@ function getArtistTrack() {
 	const track = Util.getTextFromSelectors(trackSelector)?.replace('•', '-');
 
 	return { artist, track };
-}
-
-function isArtistTrackValid(artistTrack: ArtistTrackInfo): boolean {
-	return !!artistTrack.track;
 }
 
 function renewTimeout() {

--- a/src/connectors/iheart.ts
+++ b/src/connectors/iheart.ts
@@ -57,7 +57,7 @@ function getArtistTrack() {
 		trackSelector = `${playerBar} [data-test=subtitle-link]`;
 	}
 
-	const track = Util.getTextFromSelectors(trackSelector);
+	const track = Util.getTextFromSelectors(trackSelector)?.replace('•', '-');
 
 	return { artist, track };
 }

--- a/src/connectors/iheart.ts
+++ b/src/connectors/iheart.ts
@@ -1,19 +1,44 @@
 export {};
 
 const playerBar = '[data-test=player-container]';
-const controlBar = '[data-test=controls-container]';
+const controlBar = '[data-test=player-controls]';
+const artistSelector = `${playerBar} [data-test=description-link]`;
 
 Connector.playerSelector = playerBar;
 
-Connector.pauseButtonSelector = `${controlBar} button[data-test-state=PLAYING]`;
+Connector.isPodcast = () =>
+	Util.isElementVisible(
+		`${playerBar} [data-test=progress-bar-player-control]`,
+	);
 
-Connector.artistSelector = `${playerBar} [data-test=line-text]:nth-child(3)`;
+Connector.getArtistTrack = () => {
+	const artist = Util.getTextFromSelectors(artistSelector);
+	let trackSelector = `${playerBar} [data-test=title-link]`;
 
-Connector.trackSelector = `${playerBar} [data-test=line-text]:nth-child(2)`;
+	if (Connector.isPodcast()) {
+		trackSelector = `${playerBar} [data-test=subtitle-link]`;
+	}
 
-Connector.scrobblingDisallowedReason = () => {
-	const track = Connector.getTrack();
-	return track && !track.startsWith('Thanks for listening')
-		? null
-		: 'FilteredTag';
+	return { artist, track: Util.getTextFromSelectors(trackSelector) };
+};
+
+Connector.getTrackArt = () => {
+	const artist = Util.getTextFromSelectors(artistSelector);
+	const trackArtSelector = `${playerBar} img[alt="${artist}"]`;
+	const trackArtUrl = Util.extractImageUrlFromSelectors(trackArtSelector);
+
+	return trackArtUrl?.replace(/(?<=fit%28)\d{3}%2C\d{1,3}(?=%29)/, '328%2C0'); // larger image
+};
+
+Connector.isTrackArtDefault = (url) => url?.includes('assets.streams');
+
+Connector.isPlaying = () => {
+	const playButtonSvg = `${controlBar} button[data-test=player-play-button] svg`;
+	const svgLabel = Util.getAttrFromSelectors(playButtonSvg, 'aria-label');
+
+	if (Connector.isPodcast()) {
+		return svgLabel === 'Pause';
+	}
+
+	return svgLabel === 'Stop';
 };

--- a/src/connectors/iheart.ts
+++ b/src/connectors/iheart.ts
@@ -7,9 +7,7 @@ const artistSelector = `${playerBar} [data-test=description-link]`;
 Connector.playerSelector = playerBar;
 
 Connector.isPodcast = () =>
-	Util.isElementVisible(
-		`${playerBar} [data-test=progress-bar-player-control]`,
-	);
+	Util.isElementVisible(`${playerBar} [data-test=forward-30-player-button]`);
 
 Connector.getArtistTrack = () => {
 	const artist = Util.getTextFromSelectors(artistSelector);
@@ -19,7 +17,9 @@ Connector.getArtistTrack = () => {
 		trackSelector = `${playerBar} [data-test=subtitle-link]`;
 	}
 
-	return { artist, track: Util.getTextFromSelectors(trackSelector) };
+	const track = Util.getTextFromSelectors(trackSelector);
+
+	return { artist, track };
 };
 
 Connector.getTrackArt = () => {
@@ -27,7 +27,7 @@ Connector.getTrackArt = () => {
 	const trackArtSelector = `${playerBar} img[alt="${artist}"]`;
 	const trackArtUrl = Util.extractImageUrlFromSelectors(trackArtSelector);
 
-	return trackArtUrl?.replace(/(?<=fit%28)\d{3}%2C\d{1,3}(?=%29)/, '328%2C0'); // larger image
+	return trackArtUrl?.replace(/(?<=fit%28)\d{3}%2C\d{1,3}(?=%29)/, '400%2C0'); // larger image
 };
 
 Connector.isTrackArtDefault = (url) => url?.includes('assets.streams');
@@ -36,8 +36,8 @@ Connector.isPlaying = () => {
 	const playButtonSvg = `${controlBar} button[data-test=player-play-button] svg`;
 	const svgLabel = Util.getAttrFromSelectors(playButtonSvg, 'aria-label');
 
-	if (Connector.isPodcast()) {
-		return svgLabel === 'Pause';
+	if (Util.isElementVisible('[data-test=next-player-button]')) {
+		return svgLabel === 'Pause'; // podcasts and playlists
 	}
 
 	return svgLabel === 'Stop';

--- a/src/connectors/iheart.ts
+++ b/src/connectors/iheart.ts
@@ -24,9 +24,9 @@ Connector.getArtistTrack = () => {
 	return artistTrack;
 };
 
-Connector.currentTimeSelector = `${playerBar} span:has(+ [data-test=progress-bar-player-control])`;
+Connector.currentTimeSelector = `${playerBar} span:has(~ [data-test=progress-bar-player-control])`;
 
-Connector.durationSelector = `${playerBar} [data-test=progress-bar-player-control] + span`;
+Connector.durationSelector = `${playerBar} [data-test=progress-bar-player-control] ~ span`;
 
 Connector.getTrackArt = () => {
 	const artist = Util.getTextFromSelectors(artistSelector);
@@ -39,10 +39,10 @@ Connector.getTrackArt = () => {
 Connector.isTrackArtDefault = (url) => url?.includes('assets');
 
 Connector.isPlaying = () => {
-	const playButtonSvg = `${controlBar} button[data-test=player-play-button] svg`;
+	const playButtonSvg = `${controlBar} [data-test=player-play-button] svg`;
 	const svgLabel = Util.getAttrFromSelectors(playButtonSvg, 'aria-label');
 
-	if (Util.isElementVisible('[data-test=next-player-button]')) {
+	if (Util.isElementVisible(`${controlBar} [data-test=next-player-button]`)) {
 		return svgLabel === 'Pause'; // podcasts and playlists
 	}
 

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -114,7 +114,7 @@ export default <ConnectorMeta[]>[
 		id: 'megalyrics',
 	},
 	{
-		label: 'iHeartRadio',
+		label: 'iHeart',
 		matches: ['*://*.iheart.com/*'],
 		js: 'iheart.js',
 		id: 'iheart',


### PR DESCRIPTION
Fixes for iHeart connector after site updates. Resolves #5809 and resolves #5951.

**Describe the changes you made**
In addition to updating the connector for the current site, I also added podcast and track art support.

Example station: https://www.iheart.com/live/alt-987-201
Example playlist: https://www.iheart.com/playlist/newly-released-312064750-JwZCfk5kxHoV7u2yFQ7hQC
Example podcast: https://www.iheart.com/podcast/1119-stuff-you-should-know-26940277

**Additional context**
The player does this buggy thing where it randomly switches between the artist/track info and the station information. When this switch happens, the track goes null and the artist changes to the station name. Sometimes a song can play all the way through without it happening, in which case a scrobble can be completed without issue. But often, the switch will happen every few seconds, making the connector continually go into an empty/reset state and making completing a scrobble impossible. Playlists and podcasts don't seem to have this issue.
In an attempt to mitigate this issue, a 10 second delay has been added. If, after 10 seconds, the track is still null and artist is the station name, empty/reset state can proceed because it typically means either a DJ is talking or an ad is playing and nothing should scrobble anyway. Sometimes the switch can be longer than 10 seconds, and sometimes it never goes back to the artist/track info while the song is playing, so there will occasionally be missed or duplicate scrobbles, but there's only so much we can do with the connector when the site is wack.
Thanks very much to @rob9315 for providing a solution to implement the delay that was needed for this connector.
(There was a temporary glitch where Firefox and Safari were getting the old version of the site while Chrome was still getting the new site, which seems to be resolved now.)

Also, while digging around the site, I noticed that full albums are available to stream with a paid subscription. So, I wonder if the album title is made available in the player when listening to one. Unfortunately, there is no way to even preview that without an account.