### PR TITLE
handle last.fm error 9

### DIFF
--- a/src/core/scrobbler/audio-scrobbler/audio-scrobbler.ts
+++ b/src/core/scrobbler/audio-scrobbler/audio-scrobbler.ts
@@ -329,6 +329,13 @@ export default abstract class AudioScrobbler extends BaseScrobbler<'LastFM'> {
 
 		if (!response.ok) {
 			this.debugLog(`${params.method} response:\n${debugMsg}`, 'error');
+			if ('error' in responseData && responseData.error === 9) {
+				// Invalid session key - Please re-authenticate
+				await this.signOut();
+				this.debugLog(
+					'error 9 received, triggering signOut so that user grant access again.',
+				);
+			}
 			throw new Error(ServiceCallResult.ERROR_OTHER);
 		}
 


### PR DESCRIPTION
error means: Invalid session key - Please re-authenticate
see docs: https://www.last.fm/api/errorcodes

which means that last.fm or the user revoked our session key and we have to make the user go through the sign-in flow again.

**Describe the changes you made**
call `signOut` for error 9

**Additional context**
- should this check that we are talking to Last.fm or is this also valid for other AudioScrobblers?