### PR TITLE
add support for zxart.ee

### DIFF
--- a/src/connectors/zxart.ts
+++ b/src/connectors/zxart.ts
@@ -6,11 +6,6 @@ Connector.playerSelector = 'zx-player .player-bar';
 // - russian
 // - english
 // - spanish
-Connector.playButtonSelector = [
-	`${Connector.playerSelector} button[aria-label="Играть"]`,
-	`${Connector.playerSelector} button[aria-label="Play"]`,
-	`${Connector.playerSelector} button[aria-label="Reproducir"]`,
-];
 Connector.pauseButtonSelector = [
 	`${Connector.playerSelector} button[aria-label="Пауза"]`,
 	`${Connector.playerSelector} button[aria-label="Pause"]`,

--- a/src/connectors/zxart.ts
+++ b/src/connectors/zxart.ts
@@ -1,0 +1,20 @@
+export {};
+
+Connector.playerSelector = 'zx-player .player-bar';
+
+// supported languages on the website at time of writing the connector:
+// - russian
+// - english
+// - spanish
+Connector.playButtonSelector = [
+	`${Connector.playerSelector} button[aria-label="Играть"]`,
+	`${Connector.playerSelector} button[aria-label="Play"]`,
+	`${Connector.playerSelector} button[aria-label="Reproducir"]`,
+];
+Connector.pauseButtonSelector = [
+	`${Connector.playerSelector} button[aria-label="Пауза"]`,
+	`${Connector.playerSelector} button[aria-label="Pause"]`,
+	`${Connector.playerSelector} button[aria-label="Pausa"]`,
+];
+
+Connector.artistTrackSelector = `${Connector.playerSelector} .player-progress-text`;

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2819,4 +2819,10 @@ export default <ConnectorMeta[]>[
 		js: 'escradio.js',
 		id: 'escradio',
 	},
+	{
+		label: 'zxART',
+		matches: ['*://zxart.ee/*'],
+		js: 'zxart.js',
+		id: 'zxart',
+	},
 ];


### PR DESCRIPTION
fixes #5790

website doesn't show track length or currenttime, though there is progress. i don't think we can do anything useful without some actual non-fractional time.