### PR TITLE
core: use of play and pause button selectors

### DIFF
--- a/src/core/content/connector.ts
+++ b/src/core/content/connector.ts
@@ -795,19 +795,19 @@ export default class BaseConnector {
 		};
 
 		this.isPlaying = () => {
-			if (this.playButtonSelector) {
-				return !Util.isElementVisible(this.playButtonSelector);
-			}
+			const notPaused = this.playButtonSelector
+				? !Util.isElementVisible(this.playButtonSelector)
+				: null;
 
-			if (this.pauseButtonSelector) {
-				return Util.isElementVisible(this.pauseButtonSelector);
-			}
+			const playing = this.pauseButtonSelector
+				? Util.isElementVisible(this.pauseButtonSelector)
+				: null;
 
 			/*
 			 * Return true if play/pause button selector is not specified. It's
 			 * better to assume the playback is always playing than otherwise. :)
 			 */
-			return true;
+			return (playing || notPaused) ?? true;
 		};
 
 		this.getTrackArt = () => {

--- a/src/core/content/connector.ts
+++ b/src/core/content/connector.ts
@@ -104,8 +104,6 @@ export default class BaseConnector {
 	 * Selector of a play button element. If the element is not visible,
 	 * the playback is considered to be playing.
 	 *
-	 * Should not be used if Connector#pauseButtonSelector is defined.
-	 *
 	 * Only applies when default implementation of
 	 * `BaseConnector.isPlaying` is used.
 	 */
@@ -114,8 +112,6 @@ export default class BaseConnector {
 	/**
 	 * Selector of a pause button element. If the element is visible,
 	 * the playback is considered to be playing.
-	 *
-	 * Should not be used if `Connector.playButtonSelector` is defined.
 	 *
 	 * Only applies when default implementation of
 	 * `BaseConnector.isPlaying` is used.

--- a/src/core/content/connector.ts
+++ b/src/core/content/connector.ts
@@ -791,9 +791,10 @@ export default class BaseConnector {
 		};
 
 		this.isPlaying = () => {
-			const notPaused = this.playButtonSelector
-				? !Util.isElementVisible(this.playButtonSelector)
-				: null;
+			const notPaused = () =>
+				this.playButtonSelector
+					? !Util.isElementVisible(this.playButtonSelector)
+					: null;
 
 			const playing = this.pauseButtonSelector
 				? Util.isElementVisible(this.pauseButtonSelector)
@@ -803,7 +804,7 @@ export default class BaseConnector {
 			 * Return true if play/pause button selector is not specified. It's
 			 * better to assume the playback is always playing than otherwise. :)
 			 */
-			return (playing || notPaused) ?? true;
+			return (playing || notPaused()) ?? true;
 		};
 
 		this.getTrackArt = () => {


### PR DESCRIPTION
**Describe the changes you made**
add logic to make use of both play and pause button selectors to be used, for when one becomes outdated.

**Additional context**
when brittle selectors break (like checking the svg for play or pause icons) it would be nice to have a fallback.
this will change behaviour for connectors that currently specify both play and pause buttons and make the pauseButtonSelector have precedence, when before only the playButtonSelector was used.

this change retains the fallback to `isPlaying: true` if neither selector is specified.

note that this makes use of the intricate differences of the [`||`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR) and [`??`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) operations

(the code could be changed to avoid the extra element query that will happen when specifying both selectors)