### PR TITLE
Refactor for the TIDAL design update.

### DIFF
--- a/src/connectors/tidal.ts
+++ b/src/connectors/tidal.ts
@@ -11,10 +11,7 @@ Connector.pauseButtonSelector = `${Connector.playerSelector} button[data-test="p
 Connector.scrobblingDisallowedReason = () =>
 	Util.queryElements(Connector.playButtonSelector) ? null : 'ElementMissing';
 
-Connector.trackSelector = [
-	'#nowPlaying span[data-test="now-playing-track-title"]',
-	`${Connector.playerSelector} div[data-test="footer-track-title"]`,
-];
+Connector.trackSelector = `${Connector.playerSelector} div[data-test="footer-track-title"]`;
 
 Connector.getUniqueID = () => {
 	const trackUrl = Util.getAttrFromSelectors(
@@ -35,10 +32,7 @@ Connector.getArtist = () => {
 	return Util.joinArtists(Array.from(artistNodes));
 };
 
-Connector.albumSelector = [
-	'#nowPlaying div.react-tabs div[class^="_currentMediaInfoContainer"] div[class^="_creditsCell"] a[href^="/album/"]',
-	`${Connector.playerSelector} a[href^="/album/"]`,
-];
+Connector.albumSelector = `${Connector.playerSelector} a[href^="/album/"]`;
 
 Connector.getAlbumArtist = () => {
 	const albumArtistNode = document.querySelectorAll(albumArtistSelector);

--- a/src/connectors/tidal.ts
+++ b/src/connectors/tidal.ts
@@ -25,7 +25,6 @@ Connector.getUniqueID = () => {
 };
 
 const artistSelector = `${Connector.playerSelector} a[data-test="grid-item-detail-text-title-artist"]`;
-const albumArtistSelector = `${artistSelector}:first-child`;
 
 Connector.getArtist = () => {
 	const artistNodes = document.querySelectorAll(artistSelector);
@@ -35,8 +34,25 @@ Connector.getArtist = () => {
 Connector.albumSelector = `${Connector.playerSelector} a[href^="/album/"]`;
 
 Connector.getAlbumArtist = () => {
-	const albumArtistNode = document.querySelectorAll(albumArtistSelector);
-	return Util.joinArtists(Array.from(albumArtistNode));
+	const albumUrlSegments = Util.getAttrFromSelectors(
+		Connector.albumSelector,
+		'href',
+	)?.split('/');
+	const pageUrlSegments = Util.getAttrFromSelectors(
+		'head meta[name="apple-itunes-app"]',
+		'content',
+	)?.split('/');
+	if (
+		'album' === albumUrlSegments?.at(-2) &&
+		'album' === pageUrlSegments?.at(-2) &&
+		albumUrlSegments?.at(-1) === pageUrlSegments?.at(-1)
+	) {
+		const albumArtistNode = document.querySelectorAll(
+			'main div[class^="_detailContainer"] .artist-link a',
+		);
+		return Util.joinArtists(Array.from(albumArtistNode));
+	}
+	return null;
 };
 
 Connector.trackArtSelector = `${Connector.playerSelector} figure[data-test="current-media-imagery"] img`;


### PR DESCRIPTION
# Remove selectors which no longer apply to the TIDAL redesign.

Note that there is no longer any way to get the album for the current track
unless it is being played from that album.

Note that the site appears to no longer install a service worker to operate
offline and manage updates. However, the old service worker will not uninstall
itself, which means that a new tab will open the old UI. A hard refresh loads
the new site; Removing the service worker from the browser prevents the old
code from loading. I noticed this switching between TIDAL versions 2026.03.03
and 2026.04.16.

# Restore old album artist behavior.

Partially reverts #5943.