### PR TITLE
Fix track title scrobbling on YouTube Music

### DIFF
--- a/src/connectors/youtube-music.ts
+++ b/src/connectors/youtube-music.ts
@@ -22,20 +22,7 @@ export {};
 
 const adSelector = '.ytmusic-player-bar.advertisement';
 
-/**
- * Track title is read from the DOM rather than `mediaSession.metadata.title`
- * because YouTube Music sets a pre-cleaned title on the MediaSession object
- * (e.g. strips "(feat. X)"). The DOM element preserves the raw title so
- * the scrobble matches the canonical track on the scrobbling service.
- *
- * If the DOM selector stops matching (YT Music UI changes, element missing),
- * `getArtistTrack` falls back to `mediaSession.metadata.title` so scrobbling
- * still works — just with the pre-cleaned title until the selector is
- * updated.
- *
- * Artist and album still use MediaSession — they're structured fields and
- * don't get the same suffix-strip treatment.
- */
+// track title in `mediaSession` is stripped compared to DOM
 const titleSelector = '.ytmusic-player-bar .title';
 
 const mediaInfo = {

--- a/src/connectors/youtube-music.ts
+++ b/src/connectors/youtube-music.ts
@@ -27,6 +27,12 @@ const adSelector = '.ytmusic-player-bar.advertisement';
  * because YouTube Music sets a pre-cleaned title on the MediaSession object
  * (e.g. strips "(feat. X)"). The DOM element preserves the raw title so
  * the scrobble matches the canonical track on the scrobbling service.
+ *
+ * If the DOM selector stops matching (YT Music UI changes, element missing),
+ * `getArtistTrack` falls back to `mediaSession.metadata.title` so scrobbling
+ * still works — just with the pre-cleaned title until the selector is
+ * updated.
+ *
  * Artist and album still use MediaSession — they're structured fields and
  * don't get the same suffix-strip treatment.
  */

--- a/src/connectors/youtube-music.ts
+++ b/src/connectors/youtube-music.ts
@@ -22,6 +22,16 @@ export {};
 
 const adSelector = '.ytmusic-player-bar.advertisement';
 
+/**
+ * Track title is read from the DOM rather than `mediaSession.metadata.title`
+ * because YouTube Music sets a pre-cleaned title on the MediaSession object
+ * (e.g. strips "(feat. X)"). The DOM element preserves the raw title so
+ * the scrobble matches the canonical track on the scrobbling service.
+ * Artist and album still use MediaSession — they're structured fields and
+ * don't get the same suffix-strip treatment.
+ */
+const titleSelector = '.ytmusic-player-bar .title';
+
 const mediaInfo = {
 	playbackState: 'none',
 	metadata: {
@@ -60,12 +70,14 @@ Connector.getArtistTrack = () => {
 	let artist;
 	let track;
 	const metadata = mediaInfo.metadata;
+	const rawTitle =
+		Util.getTextFromSelectors(titleSelector) || metadata?.title;
 
 	if (metadata?.album) {
 		artist = metadata.artist;
-		track = metadata.title;
+		track = rawTitle;
 	} else {
-		({ artist, track } = Util.processYtVideoTitle(metadata?.title));
+		({ artist, track } = Util.processYtVideoTitle(rawTitle));
 		if (!artist) {
 			artist = metadata?.artist;
 		}


### PR DESCRIPTION
## Problem

On YouTube Music, tracks with `(feat. X)` in the title were scrobbling as the stripped version (`Song` instead of `Song (feat. Artist)`), so they wouldn't match the canonical track on Last.fm. Tracks from the same album ended up as orphan singles detached from the album — splits play counts, breaks album stats.

## Investigation

Started out thinking this was the default-filter issue described in #4644 and was planning to add a toggle to disable it. But the default filter (the one `BaseConnector` applies on top of each connector's filter) only does `trim` + `&nbsp;` normalization, nothing that would strip `(feat. X)`. Checked the per-connector filters too, and none of the major ones (Bandcamp, Tidal, Spotify, YT Music) strip it either.

Real cause on YT Music: the connector was reading the track title from `navigator.mediaSession.metadata.title`, which YouTube Music pre-cleans before exposing. So the stripped title never hit WS's filter layer.

## Fix

Read the track title from `.ytmusic-player-bar .title` in the DOM, same source most other connectors use. Worth flagging: YouTube Music is internally inconsistent here — the DOM element has the raw title with `(feat. X)` preserved, while MediaSession has the stripped version. Switching to the DOM isn't a workaround, just picking the source they themselves expose with the raw label.

Artist and album stay on MediaSession — they're structured fields, less fragile than parsing the byline, and don't get the same suffix-strip treatment.

## Related observation: Amazon Music filter inconsistency

While investigating, noticed that across the built-in filters in `@web-scrobbler/metadata-filter`, **`createAmazonFilter()` is the only one that uses `removeFeature`**. So Amazon Music scrobbles strip `(feat. X)` at the filter layer while every other service preserves it. Same user-visible symptom as this YT Music bug, different mechanism.

Happy to also drop `removeFeature` from `createAmazonFilter()` in this PR to make scrobble behavior consistent across services, or open a separate PR — whichever you prefer.

## Refs

- #4644 — broader default-filter concern this PR doesn't fully address (only fixes the YT Music case users have actually been hitting)
