### PR TITLE
Update The Jazz Groove connector

### DIFF
--- a/src/connectors/jazzgroove.ts
+++ b/src/connectors/jazzgroove.ts
@@ -1,29 +1,47 @@
 export {};
 
-Connector.playerSelector = '.jg-player';
+const jgPlayer = '.jg-player';
+const jgSong = `${jgPlayer} .jg-song`;
+const filter = MetadataFilter.createFilter({
+	track: [MetadataFilter.removeRemastered, MetadataFilter.removeLive],
+});
+
+Connector.playerSelector = jgPlayer;
 
 Connector.artistSelector = [
-	'.jg-song .MuiTypography-body2',
-	'.jg-song .MuiTypography-caption',
+	`${jgSong} .MuiTypography-body2`,
+	`${jgSong} .MuiTypography-caption`,
 ];
 
 Connector.trackSelector = [
-	'.jg-song .MuiTypography-h6',
-	'.jg-song .MuiTypography-body1',
+	`${jgSong} .MuiTypography-h6`,
+	`${jgSong} .MuiTypography-body1`,
 ];
 
-Connector.trackArtSelector = '.jg-song .jg-player__album-art__image';
+Connector.trackArtSelector = `${jgSong} .jg-player__album-art__image`;
 
 Connector.isTrackArtDefault = () => {
 	const defaultImages = ['Mix1', 'Mix2', 'Dreams', 'Gems', 'Smooth'];
+
 	return defaultImages.some((image) =>
 		Connector.getTrackArt()?.includes(`${image}.jpg`),
 	);
 };
 
-// station bumpers and other spoken messages play with default images
-Connector.scrobblingDisallowedReason = () =>
-	Connector.isTrackArtDefault() ? 'Other' : null;
+Connector.scrobblingDisallowedReason = () => {
+	const jgRegex = /TJG|Jazz\s?Groove(.org)?/i;
+
+	if (
+		jgRegex.test(Connector.getArtist() ?? Connector.getTrack() ?? '') ||
+		Connector.isTrackArtDefault() // site ads play with default images
+	) {
+		return 'IsAd';
+	}
+
+	return null;
+};
 
 Connector.isPlaying = () =>
-	!Util.hasElementClass(Connector.playerSelector, 'jg-player--paused');
+	!Util.hasElementClass(jgPlayer, 'jg-player--paused');
+
+Connector.applyFilter(filter);

--- a/src/connectors/jazzgroove.ts
+++ b/src/connectors/jazzgroove.ts
@@ -3,7 +3,11 @@ export {};
 const jgPlayer = '.jg-player';
 const jgSong = `${jgPlayer} .jg-song`;
 const filter = MetadataFilter.createFilter({
-	track: [MetadataFilter.removeRemastered, MetadataFilter.removeLive],
+	track: [
+		MetadataFilter.removeLive,
+		MetadataFilter.removeRemastered,
+		MetadataFilter.removeVersion,
+	],
 });
 
 Connector.playerSelector = jgPlayer;


### PR DESCRIPTION
Updates to connector for [jazzgroove.org](https://jazzgroove.org/).

**Describe the changes you made**
Initially, I was just going to change `scrobblingDisallowedReason` to `IsAd`, but then I noticed that logic also needed updating because it wasn't catching all of the ads anymore, and they were more frequent. They now have custom images for their fundraising ads (like [this](https://tjg-apchannels-media-prod.sfo2.cdn.digitaloceanspaces.com/variants/ae794ccd-30f8-4ca3-a9fe-490544f0832a) and [this](https://tjg-apchannels-media-prod.sfo2.cdn.digitaloceanspaces.com/variants/dad34411-7d4b-4005-97ce-007bba627e28), which have nothing in the URL to differentiate them from real track art), so just checking for default images wasn't enough. I added a check for "Jazz Groove," "JazzGroove.org," and "TJG" in artist/track—and even though they seem to consistently use them exactly like that, it is case-insensitive just in case they change it up.
I also noticed the mobile/mini player was now going null, even though the artist and track selectors were still valid. Adding the player class to them seems to fix that.
Additionally, I added a few filters because I noticed tracks coming in with (Remastered), (Live), and (Album Version) that were unnecessary.