### PR TITLE
fix nrk-radio: new selectors

### DIFF
--- a/src/connectors/nrk-radio.ts
+++ b/src/connectors/nrk-radio.ts
@@ -6,7 +6,7 @@ const filter = MetadataFilter.createFilter({
 
 Connector.playerSelector = ['#mini-player', '#fullscreen-dialog'];
 
-Connector.artistTrackSelector = `${Connector.playerSelector[0]} [class*="currentlyPlaying"] .nrk-font-footnote`;
+Connector.artistTrackSelector = `${Connector.playerSelector[0]} [class*="_currentlyPlaying"] .nrk-font-footnote`;
 
 Connector.pauseButtonSelector = `${Connector.playerSelector[0]} .nrk-button .nrk-media-pause`;
 

--- a/src/connectors/nrk-radio.ts
+++ b/src/connectors/nrk-radio.ts
@@ -4,11 +4,11 @@ const filter = MetadataFilter.createFilter({
 	artist: cleanUpArtist,
 });
 
-Connector.playerSelector = '.app';
+Connector.playerSelector = '#mini-player';
 
-Connector.artistTrackSelector = '[data-test="playingEpisodeDesc"]';
+Connector.artistTrackSelector = `${Connector.playerSelector} [class*="currentlyPlaying"] .nrk-font-footnote`;
 
-Connector.pauseButtonSelector = '.MiniPlayer button[aria-label="Pause"]';
+Connector.pauseButtonSelector = `${Connector.playerSelector} .nrk-button .nrk-media-pause`;
 
 Connector.applyFilter(filter);
 

--- a/src/connectors/nrk-radio.ts
+++ b/src/connectors/nrk-radio.ts
@@ -4,11 +4,13 @@ const filter = MetadataFilter.createFilter({
 	artist: cleanUpArtist,
 });
 
-Connector.playerSelector = '#mini-player';
+Connector.playerSelector = ['#mini-player', '#fullscreen-dialog'];
 
-Connector.artistTrackSelector = `${Connector.playerSelector} [class*="currentlyPlaying"] .nrk-font-footnote`;
+Connector.artistTrackSelector = `${Connector.playerSelector[0]} [class*="currentlyPlaying"] .nrk-font-footnote`;
 
-Connector.pauseButtonSelector = `${Connector.playerSelector} .nrk-button .nrk-media-pause`;
+Connector.pauseButtonSelector = `${Connector.playerSelector[0]} .nrk-button .nrk-media-pause`;
+
+Connector.trackArtSelector = `${Connector.playerSelector[1]} [class*="_image"] img`;
 
 Connector.applyFilter(filter);
 


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
the selectors changed. the miniplayer bar is targeted with selectors and still exists even in full screen mode.
ad breaks and information segments are filtered out by the nature of there not being ` - ` in the NRK station titles
full screen mode displayed image is used for trackArt, seems to also be updated if fullscreen mode is disabled.

no support for podcasts.

**Additional context**
<!-- Add any other context or screenshots here. -->
fixes #5971