### PR TITLE
Remove special filtering for albumArtist which matches playing artist.

### DIFF
--- a/src/core/content/connector.ts
+++ b/src/core/content/connector.ts
@@ -979,12 +979,7 @@ export default class BaseConnector {
 				let fieldValue = this.currentState[field];
 
 				switch (field) {
-					case 'albumArtist': {
-						if (fieldValue === this.currentState.artist) {
-							fieldValue = this.defaultState[field];
-						}
-					}
-					// eslint-disable-next-line no-fallthrough
+					case 'albumArtist':
 					case 'artist':
 					case 'track':
 					case 'album': {


### PR DESCRIPTION
This is a something of a reversion of 72e61ce7a9a1c347346c0f5c8e46413ce28f30c6, though it appears that the bug described below existed with the behavior before that commit, too.

If someone plays an album and the extension can pull its `albumArtist`, it will fill that state field and then never change it over the course of the album.

If the first track's `artist` matched that `albumArtist`, the filtering function would nullify it. The null would then remain in the filtered state for the rest of the album, even if tracks with a different `artist` played.

On the other hand, if the first played track mismatched, the `albumArtist` would remain in the filtered state for future plays, whether it matched a track's `artist` or not.

Thus, I would argue that this should be removed on at least two bases:

1. The behavior is not even what seems to be intended. There are cases where we send identical `artist` and `albumArtist`, and this doesn't seem to cause a problem.

2. Sending both fields to Last.fm, even when they appear to match, can be a fine problem. Take
https://www.last.fm/music/Iggy+and+The+Stooges/Raw+Power+(The+7-Inch+Edition), which is not a perfect example since it's from physical media, but is the one at hand. Note that
https://www.last.fm/music/Iggy+and+The+Stooges/Raw+Power+(The+7-Inch+Edition)/Search+and+Destroy redirects to https://www.last.fm/music/The+Stooges/_/Search+and+Destroy. If we submit both fields to Last.fm, it can correct each track's `artist` but the particular edition credited to "Iggy and The Stooges" still gets recorded somewhere.
