### PR TITLE
Poolsuite scrobbling fixed via Media Session API (fixes #5375)

### DIFF
--- a/src/connectors/poolsuite.ts
+++ b/src/connectors/poolsuite.ts
@@ -1,11 +1,4 @@
 export {};
 
-Connector.playButtonSelector = '.middle.paused';
-Connector.playerSelector = '.inner-size';
-Connector.trackSelector = '.current-track h3';
-Connector.artistSelector = '.current-track h2';
-Connector.currentTimeSelector = '.timer span:nth-child(1)';
-Connector.durationSelector = '.timer span:nth-child(2)';
-
-Connector.scrobblingDisallowedReason = () =>
-	Connector.getTrack() === 'Loading...' ? 'IsLoading' : null;
+Connector.playerSelector = 'body';
+Connector.useMediaSessionApi();

--- a/src/connectors/poolsuite.ts
+++ b/src/connectors/poolsuite.ts
@@ -2,3 +2,4 @@ export {};
 
 Connector.playerSelector = 'body';
 Connector.useMediaSessionApi();
+Connector.useTabAudibleApi();


### PR DESCRIPTION
**Describe the changes you made**

Replaced the old Poolsuite DOM-scraping connector with Media Session API support. Poolsuite now exposes track and artist via `navigator.mediaSession.metadata`, so Web Scrobbler can read it directly without brittle selectors.

**Additional context**

Fixes #5375.

Tested on [poolsuite.net](https://poolsuite.net) in Chrome/Brave for Mac. Track and artist update correctly when skipping tracks and scrobble normally.

Apologies for the [duplicate PR](https://github.com/web-scrobbler/web-scrobbler/pull/5779); I deleted my fork before you completed review. This is an identical fix as previously submitted.