### PR TITLE
Fix KEXP connector

### DIFF
--- a/src/connectors/kexp.ts
+++ b/src/connectors/kexp.ts
@@ -16,7 +16,7 @@ Connector.getArtistTrack = () => {
 
 Connector.albumSelector = '.Player-album';
 
-Connector.trackArtSelector = '.Player-coverImage.image-is-loaded';
+Connector.trackArtSelector = '.Player-coverImage';
 
 Connector.isTrackArtDefault = (url) => url?.includes('canonical');
 

--- a/src/connectors/kexp.ts
+++ b/src/connectors/kexp.ts
@@ -1,26 +1,26 @@
 export {};
 
 const filter = MetadataFilter.createFilter({
-	artist: replaceSmartQuotes,
-	track: replaceSmartQuotes,
-	album: replaceSmartQuotes,
+	artist: MetadataFilter.replaceSmartQuotes,
+	track: MetadataFilter.replaceSmartQuotes,
+	album: MetadataFilter.replaceSmartQuotes,
 });
 
 Connector.playerSelector = '.Player';
 
-Connector.artistTrackSelector = '.Player-title';
+Connector.getArtistTrack = () => {
+	const artistTrack = Util.getTextFromSelectors('.Player-title');
+
+	return Util.splitArtistTrack(artistTrack, [' \u2022 '], true);
+};
 
 Connector.albumSelector = '.Player-album';
 
-Connector.trackArtSelector = '.Player-coverImage';
+Connector.trackArtSelector = '.Player-coverImage.image-is-loaded';
 
-Connector.isTrackArtDefault = (url) => url?.includes('default');
+Connector.isTrackArtDefault = (url) => url?.includes('canonical');
 
 Connector.isPlaying = () =>
 	Util.hasElementClass(Connector.playerSelector, 'Player--playing');
 
 Connector.applyFilter(filter);
-
-function replaceSmartQuotes(text: string) {
-	return text.replace(/[\u2018\u2019]/g, "'").replace(/[\u201c\u201d]/g, '"');
-}


### PR DESCRIPTION
**Describe the changes you made**
Fixed [KEXP](https://kexp.org/) connector. Resolves #5986.

**Additional context**
Thankfully this player is mostly still the same, but they made some updates to the artist/track display area from how it was [before](https://web.archive.org/web/20260415174544/https://www.kexp.org/). Track now comes before artist and is separated by a bullet. They also added some new child elements, but I left the selector the same to hopefully avoid the connector breaking if they add/remove any of them, rather than change it to one of the children.
Also updated the filter to use MetadataFilter, since it's been added there now.