### PR TITLE
Add support for musicMe

### DIFF
--- a/src/connectors/musicme.ts
+++ b/src/connectors/musicme.ts
@@ -1,0 +1,26 @@
+export {};
+
+const player = '#audio-player';
+const filter = MetadataFilter.createFilter({
+	track: [
+		MetadataFilter.removeRemastered,
+		MetadataFilter.removeVersion,
+		MetadataFilter.removeLive,
+	],
+});
+
+Connector.playerSelector = player;
+
+Connector.artistSelector = `${player} .meta-main > a:first-of-type`;
+
+Connector.trackSelector = `${player} .meta-sub`;
+
+Connector.trackArtSelector = `${player} img.cover`;
+
+Connector.currentTimeSelector = `${player} .timing-elapsed`;
+
+Connector.durationSelector = `${player} .timing-total`;
+
+Connector.playButtonSelector = `${player} .control-play .glyphicons-play`;
+
+Connector.applyFilter(filter);

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2819,4 +2819,11 @@ export default <ConnectorMeta[]>[
 		js: 'escradio.js',
 		id: 'escradio',
 	},
+	{
+		label: 'musicMe',
+		matches: ['*://*.musicme.com/*'],
+		js: 'musicme.js',
+		id: 'musicme',
+		allFrames: true,
+	},
 ];


### PR DESCRIPTION
**Describe the changes you made**
Added connector for [musicMe](https://www.musicme.com/). Resolves #5985.

**Additional context**
Artist sometimes contains multiple names separated by a slash, but they're often the songwriter or producer and not the performer. The connector only captures the first name, which seems to often be the performing artist but not always. However, it seemed best to use that instead of inadvertently creating a bunch of incorrect multiple artists on Last.fm. Occasional manual edits may be required when scrobbling from this site.
Request mentions additional URLs, but they are not accessible without having an account with the participating library. Hopefully, those URLs actually resolve back to musicme.com when accessed.
Also, I was seeing some weird behavior with this while testing it, where the extension would just stop registering anything while playing. I'm not sure if it's due to the iframe or Firefox or something else. But as far as I can tell, this is a pretty straightforward player and should also be a simple connector setup as submitted.

One additional note: I added MetadataFilters to this, but they won't all work until the case insensitive edits submitted in https://github.com/web-scrobbler/metadata-filter/pull/394 are merged, as this site uses lowercase text for additional title info. Since that is also my first submission there, please let me know if there is anything I missed or need to update.