### PR TITLE
Scrobble BBC Sounds playlists with longer lists

### DIFF
--- a/src/connectors/bbc-sounds.ts
+++ b/src/connectors/bbc-sounds.ts
@@ -23,7 +23,7 @@ Connector.getArtistTrack = () => {
 	}
 
 	const cleanText = (trackElement as HTMLElement).innerText
-		.replace(/(^\d\.|\nnow playing)/gi, '')
+		.replace(/(^\d+\.|\nnow playing)/gi, '')
 		.trim();
 
 	const parts = cleanText.split('\n');


### PR DESCRIPTION
<!-- 
  Thank you for taking the time to contribute to this project!

  Make sure to check out our guide on contributing with guidelines of how to contribute.

  See: https://github.com/web-scrobbler/web-scrobbler/blob/master/.github/CONTRIBUTING.md

--> 

**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->

If a playlist on BBC Sounds have greater than 9 tracks, the track selector would report the track as `["10.", "<track>"]` rather than `["<track>", "<artist>"]. This changes the regex to accept 1 or more digits rather than just a single number.

**Additional context**
<!-- Add any other context or screenshots here. -->

An example of what happens currently:

<img width="1624" height="971" alt="Screenshot 2026-05-01 at 13 40 34" src="https://github.com/user-attachments/assets/2ff34682-1f60-4ddf-9afc-cb5540c31061" />
