### PR TITLE
TIDAL: Get album from navigator.mediaSession.

### DIFF
--- a/src/connectors/tidal.ts
+++ b/src/connectors/tidal.ts
@@ -34,12 +34,12 @@ Connector.getArtist = () => {
 Connector.albumSelector = `${Connector.playerSelector} a[href^="/album/"]`;
 
 Connector.getAlbum = () => {
-	const {mediaSession} = navigator;
+	const { mediaSession } = navigator;
 	if (mediaSession && mediaSession.metadata) {
 		return mediaSession.metadata.album;
 	}
-	return Util.getTextFromSelectors(Connector.albumSelector)
-}
+	return Util.getTextFromSelectors(Connector.albumSelector);
+};
 
 Connector.getAlbumArtist = () => {
 	const albumUrlSegments = Util.getAttrFromSelectors(

--- a/src/connectors/tidal.ts
+++ b/src/connectors/tidal.ts
@@ -33,6 +33,14 @@ Connector.getArtist = () => {
 
 Connector.albumSelector = `${Connector.playerSelector} a[href^="/album/"]`;
 
+Connector.getAlbum = () => {
+	const {mediaSession} = navigator;
+	if (mediaSession && mediaSession.metadata) {
+		return mediaSession.metadata.album;
+	}
+	return Util.getTextFromSelectors(Connector.albumSelector)
+}
+
 Connector.getAlbumArtist = () => {
 	const albumUrlSegments = Util.getAttrFromSelectors(
 		Connector.albumSelector,


### PR DESCRIPTION
Unedited scrobbles from playlists now have proper albums.

Album artist detection is still squirrelly since we match URLs and need the album in the playing bar.

Only switch the album for now since, no matter what, the first artist on a track is listed as that track's artist. I may end up eating some of my words on #5972, as only one artist is ever listed. I don't think it's correct to scrobble tracks like that.