### PR TITLE
restore dev convenience

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "extends": "@web-scrobbler/eslint-config/solid",
     "parserOptions": {
       "sourceType": "script",
-      "ecmaVersion": 2020
+      "ecmaVersion": 2022
     }
   },
   "prettier": "prettier-config-web-scrobbler",

--- a/scripts/compile-connectors.ts
+++ b/scripts/compile-connectors.ts
@@ -13,6 +13,7 @@ import chokidar from 'chokidar';
  */
 function generateConnectors() {
 	return new Promise<void>((resolve, reject) => {
+		fs.ensureDirSync('build/connectorraw');
 		exec(
 			'esbuild src/connectors/*.ts --bundle --outdir=build/connectorraw --tsconfig=tsconfig.connectors.json',
 			(err, stdout, stderr) => {

--- a/scripts/set-env.ts
+++ b/scripts/set-env.ts
@@ -1,8 +1,8 @@
-import { isDev, releaseTarget } from './util';
+import { isDev, isProd, releaseTarget } from './util';
 
 if (isDev()) {
 	process.env.VITE_DEV = 'true';
-} else {
+} else if (isProd()) {
 	process.env.VITE_PROD = 'true';
 }
 

--- a/scripts/util.ts
+++ b/scripts/util.ts
@@ -28,6 +28,13 @@ export function isDev() {
 }
 
 /**
+ * @returns true if prod build, false otherwise.
+ */
+export function isProd() {
+	return releaseType === 'dist';
+}
+
+/**
  * Get folder name corresponding to current build target
  *
  * @param browser - build target

--- a/vite.configs.ts
+++ b/vite.configs.ts
@@ -4,7 +4,7 @@ import solid from 'vite-plugin-solid';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 import compileConnectors from './scripts/compile-connectors';
 import makeManifest from './scripts/make-manifest';
-import { isDev, releaseTarget, resolvePath } from 'scripts/util';
+import { isDev, isProd, releaseTarget, resolvePath } from 'scripts/util';
 import minifyImages from 'scripts/minify-images';
 import generateIcons from 'scripts/generate-icons';
 import ConditionalCompile from 'vite-plugin-conditional-compiler';
@@ -35,13 +35,18 @@ function distRoot() {
 	return builds[browser as keyof typeof builds];
 }
 
+const watchConfig = {
+	include: ['src/**'],
+	exclude: ['src/connectors/*'],
+};
+
 export const buildBackground: UserConfig = {
 	...common,
 	build: {
-		minify: !isDev(),
+		minify: isProd(),
 		outDir: resolvePath(distRoot(), 'background'),
 		emptyOutDir: true,
-		watch: isDev() ? {} : null,
+		watch: isDev() ? watchConfig : null,
 		lib: {
 			entry: resolvePath(root, 'core', 'background', 'main.ts'),
 			name: manifests.common.name,
@@ -51,6 +56,7 @@ export const buildBackground: UserConfig = {
 			output: {
 				entryFileNames: 'main.js',
 				extend: true,
+				sourcemap: !isProd(),
 			},
 		},
 	},
@@ -63,7 +69,7 @@ export const buildContent: UserConfig = {
 		minify: !isDev(),
 		outDir: resolvePath(distRoot(), 'content'),
 		emptyOutDir: true,
-		watch: isDev() ? {} : null,
+		watch: isDev() ? watchConfig : null,
 		lib: {
 			entry: resolvePath(root, 'core', 'content', 'main.ts'),
 			name: manifests.common.name,
@@ -73,6 +79,7 @@ export const buildContent: UserConfig = {
 			output: {
 				entryFileNames: 'main.js',
 				extend: true,
+				sourcemap: !isProd(),
 			},
 		},
 	},
@@ -85,14 +92,16 @@ export const buildStart: UserConfig = {
 		minify: !isDev(),
 		outDir: distRoot(),
 		emptyOutDir: false,
-		watch: isDev() ? {} : null,
+		watch: isDev() ? watchConfig : null,
 		sourcemap: isDev(),
 		rollupOptions: {
 			input: {
 				popup: resolvePath(root, 'ui', 'popup', 'index.html'),
 				options: resolvePath(root, 'ui', 'options', 'index.html'),
 			},
-			output: {},
+			output: {
+				sourcemap: !isProd(),
+			},
 		},
 	},
 	plugins: [
@@ -110,7 +119,7 @@ export const buildStart: UserConfig = {
 		}),
 		compileConnectors({
 			isDev: isDev(),
-			watchDirectory: 'src/connectors/*',
+			watchDirectory: 'src/connectors/',
 		}),
 		minifyImages({ isDev: isDev() }),
 	],

--- a/vite.configs.ts
+++ b/vite.configs.ts
@@ -43,7 +43,7 @@ const watchConfig = {
 export const buildBackground: UserConfig = {
 	...common,
 	build: {
-		minify: isProd(),
+		minify: !isDev(),
 		outDir: resolvePath(distRoot(), 'background'),
 		emptyOutDir: true,
 		watch: isDev() ? watchConfig : null,
@@ -52,11 +52,11 @@ export const buildBackground: UserConfig = {
 			name: manifests.common.name,
 			formats: ['es'],
 		},
+		sourcemap: !isProd(),
 		rollupOptions: {
 			output: {
 				entryFileNames: 'main.js',
 				extend: true,
-				sourcemap: !isProd(),
 			},
 		},
 	},
@@ -75,11 +75,11 @@ export const buildContent: UserConfig = {
 			name: manifests.common.name,
 			formats: ['es'],
 		},
+		sourcemap: !isProd(),
 		rollupOptions: {
 			output: {
 				entryFileNames: 'main.js',
 				extend: true,
-				sourcemap: !isProd(),
 			},
 		},
 	},
@@ -93,14 +93,11 @@ export const buildStart: UserConfig = {
 		outDir: distRoot(),
 		emptyOutDir: false,
 		watch: isDev() ? watchConfig : null,
-		sourcemap: isDev(),
+		sourcemap: !isProd(),
 		rollupOptions: {
 			input: {
 				popup: resolvePath(root, 'ui', 'popup', 'index.html'),
 				options: resolvePath(root, 'ui', 'options', 'index.html'),
-			},
-			output: {
-				sourcemap: !isProd(),
 			},
 		},
 	},


### PR DESCRIPTION
<!-- 
  Thank you for taking the time to contribute to this project!

  Make sure to check out our guide on contributing with guidelines of how to contribute.

  See: https://github.com/web-scrobbler/web-scrobbler/blob/master/.github/CONTRIBUTING.md

--> 

**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
- fixes file watching
- generates sourcemap files when not running `npm run dist <browser>`

**Additional context**
<!-- Add any other context or screenshots here. -->
there are essentially three "build modes" now

| mode | watch | sourcemap | command |
| ---- | ----- | --------- | ------- |
| dev | yes | yes | npm run dev <browser> |
| normal | no | yes | npm run build <browser> |
| prod | no | no | npm run dist <browser> |

i have found that i was missing a source map badly for tracing errors that users are encountering