### PR TITLE
Cleanup Radio.co connector

### DIFF
--- a/src/connectors/radioco.ts
+++ b/src/connectors/radioco.ts
@@ -8,7 +8,5 @@ Connector.trackSelector = '.track-name';
 
 Connector.trackArtSelector = '.current-artwork';
 
-Connector.currentTimeSelector = '.streamtime';
-
 Connector.isPlaying = () =>
 	Util.hasElementClass(Connector.playerSelector, 'playing');

--- a/src/connectors/radioco.ts
+++ b/src/connectors/radioco.ts
@@ -1,5 +1,11 @@
 export {};
 
+const filter = MetadataFilter.createFilter({
+	artist: MetadataFilter.replaceSmartQuotes,
+	track: MetadataFilter.replaceSmartQuotes,
+	album: MetadataFilter.replaceSmartQuotes,
+});
+
 Connector.playerSelector = '.radioco-player';
 
 Connector.artistSelector = '.track-artist';
@@ -10,3 +16,5 @@ Connector.trackArtSelector = '.current-artwork';
 
 Connector.isPlaying = () =>
 	Util.hasElementClass(Connector.playerSelector, 'playing');
+
+Connector.applyFilter(filter);

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -1277,23 +1277,10 @@ export default <ConnectorMeta[]>[
 		id: 'funkwhale',
 	},
 	{
-		label: '9128.live',
-		matches: ['*://9128.live/*', '*://embed.radio.co/player/*'],
-		js: 'radioco.js',
-		id: '9128.live',
-		allFrames: true,
-	},
-	{
 		label: 'Radio.co',
 		matches: ['*://embed.radio.co/player/*'],
 		js: 'radioco.js',
 		id: 'radioco',
-	},
-	{
-		label: 'Super45.fm',
-		matches: ['*://super45.fm/'],
-		js: 'radioco.js',
-		id: 'super45fm',
 		allFrames: true,
 	},
 	{
@@ -2161,13 +2148,6 @@ export default <ConnectorMeta[]>[
 		],
 		js: 'securenetsystems.js',
 		id: 'securenetsystems',
-	},
-	{
-		label: 'WBRU',
-		matches: ['*://www.wbru.com/*'],
-		js: 'radioco.js',
-		id: 'wbru',
-		allFrames: true,
 	},
 	{
 		label: 'uwu radio',


### PR DESCRIPTION
**Describe the changes you made**
Radio.co is an embedded player that is used on various sites. A few sites that use it were added to the connectors list separately but use the same connector file. However, one was added above the actual Radio.co connector, so it took priority over it and showed that site name when streaming from a Radio.co player on any other site. (This was noted in an [earlier comment](https://github.com/web-scrobbler/web-scrobbler/pull/5885#issuecomment-4151148038).)
Removing the additional sites and adding `allFrames: true` to the Radio.co connector still allows it to work on those sites and potentially any other site that uses the embedded player. This can be seen on the three sites that were removed, which should still be recognized by the extension with this update: [9128.live](https://9128.live/), [Super45.fm](https://www.super45.fm/), and [WBRU](https://www.wbru.com/).
(Also removed `currentTimeSelector` that I added in a previous edit because it only keeps track of the total streaming time on the player and not individual songs, so it is not useful to the extension.)

**Additional context**
If this is acceptable, then I am wondering why this hasn't been applied to other widely-used embedded players, like Bandcamp, Soundcloud, Mixcloud, etc. This works, and similar implementations would easily allow scrobbling from those embedded players on any site without adding a separate connector for each site. If this was tried before and caused some issue that I'm not seeing, please advise.
There was a previous back and forth that I was involved in when WBRU was added years ago, so I realize this may contradict earlier conversations, but I think we were just making it more complicated by adding these additional sites separately for embedded players. Perhaps something changed since then, but I don't believe it has, so there doesn't currently appear to be any real reason to do so anymore.