### PR TITLE
fix(bandcamp) track selector for tracks on collection page

### DIFF
--- a/src/connectors/bandcamp.ts
+++ b/src/connectors/bandcamp.ts
@@ -202,7 +202,7 @@ function initPropertiesForSongAndAlbumPlayer() {
 function initPropertiesForCollectionsPlayer() {
 	Connector.artistSelector = '.now-playing .artist span';
 
-	Connector.trackSelector = '.info-progress .title span:nth-child(2)';
+	Connector.trackSelector = '.info-progress .title span:last-child';
 
 	Connector.albumSelector = '.now-playing .title';
 
@@ -317,9 +317,7 @@ function getTrackNodes() {
 	if (isAlbumPage()) {
 		trackNodes = document.querySelectorAll('.track_list .track-title');
 	} else if (isCollectionsPage()) {
-		trackNodes = document.querySelectorAll(
-			'.queue .title span:nth-child(2)',
-		);
+		trackNodes = document.querySelectorAll('.queue .title span:last-child');
 	}
 
 	return trackNodes;


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
when playing a track instead of an album on the collection page the index isn't shown and thus the track isn't the second element.
it appears to always be the last element though, i switched it to using `:last-child` instead.

**Additional context**
<!-- Add any other context or screenshots here. -->
<details>
<summary>album still works</summary>
<img width="819" height="555" alt="image" src="https://github.com/user-attachments/assets/cae62f90-db3b-4a1e-b225-a6451e24451d" />
</details>
<details>
<summary>track now works as well</summary>
<img width="819" height="553" alt="image" src="https://github.com/user-attachments/assets/879ddeb8-1acc-4084-8a1f-0e124f23799e" />
</details>

fixes #6007