### PR TITLE
Add support for Spotify embeds

### DIFF
--- a/src/connectors/spotify-embed.ts
+++ b/src/connectors/spotify-embed.ts
@@ -1,0 +1,75 @@
+export {};
+
+Connector.playerSelector = '[data-testid=embed-widget-container]';
+
+Connector.getArtist = () => {
+	const tracklistArtistSelector =
+		'li[class*=TracklistRow_isCurrentTrack__] h4';
+	const tracklistArtistElement = document.querySelector(
+		tracklistArtistSelector,
+	);
+	const trackArtistElements = document.querySelectorAll(
+		'[class*=_metadataWrapper__] h2 a',
+	);
+
+	if (tracklistArtistElement) {
+		return tracklistArtistElement?.lastChild?.textContent;
+	}
+
+	if (trackArtistElements) {
+		return Util.joinArtists(Array.from(trackArtistElements));
+	}
+
+	return null;
+};
+
+Connector.trackSelector = [
+	'li[class*=TracklistRow_isCurrentTrack__] h3',
+	'[class^=TrackWidget_metadataWrapper__] h1',
+	'[class^=EpisodeOrShowWidget_metadataWrapper__] h1',
+];
+
+Connector.isPodcast = () =>
+	Boolean(
+		Util.getAttrFromSelectors(Connector.playerSelector, 'class')?.includes(
+			'EpisodeOrShowWidget_',
+		),
+	);
+
+Connector.getTrackArt = () =>
+	Util.extractUrlFromCssProperty(
+		Util.getAttrFromSelectors('[data-testid=main-page]', 'style'),
+	);
+
+Connector.isTrackArtDefault = () =>
+	Util.getAttrFromSelectors(
+		'[class*=_spotifyLogoContainer__] a',
+		'href',
+	)?.includes('/playlist/');
+
+Connector.getTrackInfo = () => {
+	const albumSelector = '[class^=TrackListWidget_metadataContainer__] h1 a';
+	const albumArtistSelector =
+		'[class^=TrackListWidget_metadataContainer__] h2 a';
+	const album = Util.getTextFromSelectors(albumSelector);
+	const albumArtist = Util.getTextFromSelectors(albumArtistSelector);
+
+	if (!Connector.isPodcast() && !Connector.isTrackArtDefault()) {
+		return { album, albumArtist };
+	}
+
+	return null;
+};
+
+Connector.remainingTimeSelector = '[class*=ProgressTimer_actualProgressTime__]';
+
+Connector.durationSelector =
+	'li[class*=TracklistRow_isCurrentTrack__] [class^=TracklistRow_durationCell__]';
+
+Connector.isPlaying = () =>
+	Util.getAttrFromSelectors(
+		'[class^=PlayButton_buttonWrapper___]',
+		'aria-label',
+	) === 'Pause';
+
+Connector.applyFilter(MetadataFilter.createSpotifyFilter());

--- a/src/connectors/spotify-embed.ts
+++ b/src/connectors/spotify-embed.ts
@@ -3,10 +3,8 @@ export {};
 Connector.playerSelector = '[data-testid=embed-widget-container]';
 
 Connector.getArtist = () => {
-	const tracklistArtistSelector =
-		'li[class*=TracklistRow_isCurrentTrack__] h4';
 	const tracklistArtistElement = document.querySelector(
-		tracklistArtistSelector,
+		'li[class*=TracklistRow_isCurrentTrack__] h4',
 	);
 	const trackArtistElements = document.querySelectorAll(
 		'[class*=_metadataWrapper__] h2 a',
@@ -25,9 +23,19 @@ Connector.getArtist = () => {
 
 Connector.trackSelector = [
 	'li[class*=TracklistRow_isCurrentTrack__] h3',
-	'[class^=TrackWidget_metadataWrapper__] h1',
-	'[class^=EpisodeOrShowWidget_metadataWrapper__] h1',
+	'[class*=_metadataWrapper__] h1',
 ];
+
+Connector.getOriginUrl = () =>
+	Util.getAttrFromSelectors('[class*=_spotifyLogoContainer__] a', 'href');
+
+Connector.getTrackArt = () =>
+	Util.extractUrlFromCssProperty(
+		Util.getAttrFromSelectors('[data-testid=main-page]', 'style'),
+	);
+
+Connector.isTrackArtDefault = () =>
+	Connector.getOriginUrl()?.includes('/playlist/');
 
 Connector.isPodcast = () =>
 	Boolean(
@@ -36,23 +44,13 @@ Connector.isPodcast = () =>
 		),
 	);
 
-Connector.getTrackArt = () =>
-	Util.extractUrlFromCssProperty(
-		Util.getAttrFromSelectors('[data-testid=main-page]', 'style'),
-	);
-
-Connector.isTrackArtDefault = () =>
-	Util.getAttrFromSelectors(
-		'[class*=_spotifyLogoContainer__] a',
-		'href',
-	)?.includes('/playlist/');
-
 Connector.getTrackInfo = () => {
-	const albumSelector = '[class^=TrackListWidget_metadataContainer__] h1 a';
-	const albumArtistSelector =
-		'[class^=TrackListWidget_metadataContainer__] h2 a';
-	const album = Util.getTextFromSelectors(albumSelector);
-	const albumArtist = Util.getTextFromSelectors(albumArtistSelector);
+	const album = Util.getTextFromSelectors(
+		'[class^=TrackListWidget_metadataContainer__] h1 a',
+	);
+	const albumArtist = Util.getTextFromSelectors(
+		'[class^=TrackListWidget_metadataContainer__] h2 a',
+	);
 
 	if (!Connector.isPodcast() && !Connector.isTrackArtDefault()) {
 		return { album, albumArtist };

--- a/src/connectors/spotify-embed.ts
+++ b/src/connectors/spotify-embed.ts
@@ -26,16 +26,18 @@ Connector.trackSelector = [
 	'[class*=_metadataWrapper__] h1',
 ];
 
-Connector.getOriginUrl = () =>
-	Util.getAttrFromSelectors('[class*=_spotifyLogoContainer__] a', 'href');
-
 Connector.getTrackArt = () =>
 	Util.extractUrlFromCssProperty(
 		Util.getAttrFromSelectors('[data-testid=main-page]', 'style'),
 	);
 
 Connector.isTrackArtDefault = () =>
-	Connector.getOriginUrl()?.includes('/playlist/');
+	Boolean(
+		Util.getAttrFromSelectors(
+			'[class*=_spotifyLogoContainer__] a',
+			'href',
+		)?.includes('/playlist/'),
+	);
 
 Connector.isPodcast = () =>
 	Boolean(

--- a/src/connectors/spotify-embed.ts
+++ b/src/connectors/spotify-embed.ts
@@ -2,6 +2,9 @@ export {};
 
 Connector.playerSelector = '[data-testid=embed-widget-container]';
 
+Connector.pauseButtonSelector =
+	'[class^=PlayButton_buttonWrapper___][aria-label=Pause]';
+
 Connector.getArtist = () => {
 	const tracklistArtistElement = document.querySelector(
 		'li[class*=TracklistRow_isCurrentTrack__] h4',
@@ -65,11 +68,5 @@ Connector.remainingTimeSelector = '[class*=ProgressTimer_actualProgressTime__]';
 
 Connector.durationSelector =
 	'li[class*=TracklistRow_isCurrentTrack__] [class^=TracklistRow_durationCell__]';
-
-Connector.isPlaying = () =>
-	Util.getAttrFromSelectors(
-		'[class^=PlayButton_buttonWrapper___]',
-		'aria-label',
-	) === 'Pause';
 
 Connector.applyFilter(MetadataFilter.createSpotifyFilter());

--- a/src/connectors/spotify-embed.ts
+++ b/src/connectors/spotify-embed.ts
@@ -39,7 +39,7 @@ Connector.isTrackArtDefault = () =>
 		Util.getAttrFromSelectors(
 			'[class*=_spotifyLogoContainer__] a',
 			'href',
-		)?.includes('/playlist/'),
+		)?.match(/\/artist|playlist\//),
 	);
 
 Connector.isPodcast = () =>

--- a/src/connectors/spotify-embed.ts
+++ b/src/connectors/spotify-embed.ts
@@ -14,7 +14,7 @@ Connector.getArtist = () => {
 	);
 
 	if (tracklistArtistElement) {
-		return tracklistArtistElement?.lastChild?.textContent;
+		return tracklistArtistElement.lastChild?.textContent;
 	}
 
 	if (trackArtistElements) {

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -132,6 +132,13 @@ export default <ConnectorMeta[]>[
 		id: 'tubafm',
 	},
 	{
+		label: 'Spotify Embed',
+		matches: ['*://open.spotify.com/embed/*'],
+		js: 'spotify-embed.js',
+		id: 'spotify-embed',
+		allFrames: true,
+	},
+	{
 		label: 'Spotify',
 		matches: ['*://open.spotify.com/*'],
 		js: 'spotify.js',


### PR DESCRIPTION
**Describe the changes you made**
Adding support for Spotify embeds, including podcast and playlist recognition. This will allow Spotify embedded players to scrobble from any site, without having to explicitly include the site itself in the connectors list.

**Additional context**
Building off of the ideas in #6004 and #6009, this adds support for Spotify embedded players. As noted in the latter PR, there is a minor issue where if multiple players are on a page ([example](https://www.brooklynvegan.com/classic-goths-13-greatest-albums/)) and one is played then paused and another is played after it, the extension pop-up still shows the track from the first player. But the active track is still being scrobbled as expected. This seems like something that could potentially be fixed in a separate PR.
Additionally, here is a [standard playlist](https://www.brooklynvegan.com/our-favorite-songs-of-the-week-playlist-150/) embed and an [artist playlist](https://superdragtour.com/#spotify) embed to see the difference in behavior from an album.
Resolves #2024.