### PR TITLE
Allow multiple possible album artist locations.

### DIFF
--- a/src/core/content/connector.ts
+++ b/src/core/content/connector.ts
@@ -42,7 +42,7 @@ export default class BaseConnector {
 	 * Only applies when default implementation of
 	 * `BaseConnector.getAlbumArtist` is used.
 	 */
-	public albumArtistSelector: string | null = null;
+	public albumArtistSelector: string | string[] | null = null;
 
 	/**
 	 * Selector of an element containing track current time in h:m:s format.


### PR DESCRIPTION
See tail discussion on #5978.

`scrobbleInfoLocationSelector` is the one outlier *Selector now, but that makes sense since it's a place for output and not input.

I would argue that we can collapse `string | string[] | null` into `string[]`, but that's a bigger refactor and I am open to the argument that `[]` and `null` are worth disambiguating if someone has a use case.

Co-authored-by: hornbuckle <6808988+hornbuckle@users.noreply.github.com>