### PR TITLE
Add support for The Lot Radio

### DIFF
--- a/src/connectors/thelotradio.ts
+++ b/src/connectors/thelotradio.ts
@@ -26,6 +26,10 @@ Util.bindListeners(
 );
 Util.bindListeners(['ul li > button'], ['click'], Connector.onStateChanged);
 
+// TODO the last navigated show's playlist remains on the page for some reason, but with display: none
+// :not([style*=display:none])
+// sometimes there's no tracklist: https://www.thelotradio.com/shows/special-guests/2025-08-08-2000
+// look for crying-nicholas-cage.gif
 const nowPlayingSelector = 'ul li > button.text-purple';
 const nowPlayingNextSelector = 'ul li:has(button.text-purple) + li > button';
 Connector.trackSelector = `${nowPlayingSelector} > div > span:nth-of-type(2) > span:first-of-type`;

--- a/src/connectors/thelotradio.ts
+++ b/src/connectors/thelotradio.ts
@@ -1,0 +1,71 @@
+export {};
+
+Connector.playerSelector = 'video';
+
+const headerPlayer = `.${CSS.escape('[&>*]:h-(--header-height)')}`;
+
+/**
+ * There is always one <video> element on the page.
+ * If there is a live show streaming on page load, it autoplays, muted,
+ * in the top left corner. Once the user starts playing a recorded show,
+ * it takes over the existing <video> element. We want to bind to the
+ * <video> element once but ignore it if it's streaming live.
+ *
+ * TODO test after midnight eastern
+ */
+Connector.isStateChangeAllowed = () => {
+	const liveLabel = Util.getTextFromSelectors(`${headerPlayer} li.bg-purple`);
+	const isLive = liveLabel === 'THE LOT LIVE';
+	return !isLive;
+};
+
+Util.bindListeners(
+	['video'],
+	['playing', 'pause', 'timeupdate'],
+	Connector.onStateChanged,
+);
+Util.bindListeners(['ul li > button'], ['click'], Connector.onStateChanged);
+
+const nowPlayingSelector = 'ul li > button.text-purple';
+const nowPlayingNextSelector = 'ul li:has(button.text-purple) + li > button';
+Connector.trackSelector = `${nowPlayingSelector} > div > span:nth-of-type(2) > span:first-of-type`;
+Connector.artistSelector = `${nowPlayingSelector} > div > span:nth-of-type(2) > span.opacity-40`;
+
+const fullDurationSelector = `${headerPlayer} span.hidden.${CSS.escape('xl:inline')}`;
+
+/**
+ * Compare timestamps of tracks in setlist (last track is compared to full duration)
+ */
+Connector.getDuration = () => {
+	const nowPlayingStart = Util.queryElements(
+		`${nowPlayingSelector} > div > span:first-of-type`,
+	)?.[0] as HTMLSpanElement | undefined;
+	if (!nowPlayingStart) return undefined;
+
+	const nextPlayingStart = Util.queryElements(
+		`${nowPlayingNextSelector} > div > span:first-of-type`,
+	)?.[0] as HTMLSpanElement | undefined;
+	let nextTimestamp;
+	if (nextPlayingStart) {
+		nextTimestamp = nextPlayingStart.innerText;
+	} else {
+		const fullDuration = Util.queryElements(fullDurationSelector)?.[0];
+		nextTimestamp = fullDuration?.innerText.replace(' / ', '0');
+	}
+	if (!nextTimestamp) return undefined;
+
+	const durationMs =
+		timestampToDate(nextTimestamp).getTime() -
+		timestampToDate(nowPlayingStart.innerText).getTime();
+	return Math.ceil(durationMs / 1000);
+};
+
+function timestampToDate(stamp: string): Date {
+	const d = new Date();
+	const [h, m, s] = stamp.split(':').map((s) => parseInt(s));
+	d.setHours(h);
+	d.setMinutes(m);
+	d.setSeconds(s);
+	d.setMilliseconds(0);
+	return d;
+}

--- a/src/connectors/thelotradio.ts
+++ b/src/connectors/thelotradio.ts
@@ -1,5 +1,11 @@
 export {};
 
+/**
+ * Examples for testing:
+ * With tracklist: https://www.thelotradio.com/shows/house-of-diggs-with-dee-diggs/2026-02-25-1300
+ * Missing tracklist: https://www.thelotradio.com/shows/special-guests/2025-08-08-2000
+ */
+
 Connector.playerSelector = 'video';
 
 const headerPlayer = `.${CSS.escape('[&>*]:h-(--header-height)')}`;
@@ -10,8 +16,6 @@ const headerPlayer = `.${CSS.escape('[&>*]:h-(--header-height)')}`;
  * in the top left corner. Once the user starts playing a recorded show,
  * it takes over the existing <video> element. We want to bind to the
  * <video> element once but ignore it if it's streaming live.
- *
- * TODO test after midnight eastern
  */
 Connector.isStateChangeAllowed = () => {
 	const liveLabel = Util.getTextFromSelectors(`${headerPlayer} li.bg-purple`);
@@ -26,14 +30,42 @@ Util.bindListeners(
 );
 Util.bindListeners(['ul li > button'], ['click'], Connector.onStateChanged);
 
-// TODO the last navigated show's playlist remains on the page for some reason, but with display: none
-// :not([style*=display:none])
-// sometimes there's no tracklist: https://www.thelotradio.com/shows/special-guests/2025-08-08-2000
-// look for crying-nicholas-cage.gif
-const nowPlayingSelector = 'ul li > button.text-purple';
-const nowPlayingNextSelector = 'ul li:has(button.text-purple) + li > button';
-Connector.trackSelector = `${nowPlayingSelector} > div > span:nth-of-type(2) > span:first-of-type`;
-Connector.artistSelector = `${nowPlayingSelector} > div > span:nth-of-type(2) > span.opacity-40`;
+/**
+ * Some shows have no tracklist, so we scrobble the whole thing
+ */
+const missingTracklistSelector = 'img[src^="/images/crying-nicolas-cage.gif"]';
+const showTitleSelector =
+	'header h1:has(+ div div button[aria-label="Save Episode"])';
+function isMissingTracklist() {
+	const elements = Util.queryElements(missingTracklistSelector);
+	return (
+		elements !== undefined &&
+		elements?.length !== undefined &&
+		elements.length > 0
+	);
+}
+
+const notDisplayNone = ':not([style*="display: none"])'; // ignores hidden tracklists from previously navigated shows
+const nowPlayingSelector = `.grid${notDisplayNone} ul li > button.text-purple`;
+const nowPlayingNextSelector = `.grid${notDisplayNone} ul li:has(button.text-purple) + li > button`;
+const trackSelector = `${nowPlayingSelector} > div > span:nth-of-type(2) > span:first-of-type`;
+const artistSelector = `${nowPlayingSelector} > div > span:nth-of-type(2) > span.opacity-40`;
+
+Connector.getTrack = () => {
+	if (isMissingTracklist()) {
+		return getTextContentFromSelectors(showTitleSelector);
+	} else {
+		return getTextContentFromSelectors(trackSelector);
+	}
+};
+
+Connector.getArtist = () => {
+	if (isMissingTracklist()) {
+		return 'The Lot Radio';
+	} else {
+		return getTextContentFromSelectors(artistSelector);
+	}
+};
 
 const fullDurationSelector = `${headerPlayer} span.hidden.${CSS.escape('xl:inline')}`;
 
@@ -41,35 +73,59 @@ const fullDurationSelector = `${headerPlayer} span.hidden.${CSS.escape('xl:inlin
  * Compare timestamps of tracks in setlist (last track is compared to full duration)
  */
 Connector.getDuration = () => {
-	const nowPlayingStart = Util.queryElements(
-		`${nowPlayingSelector} > div > span:first-of-type`,
-	)?.[0] as HTMLSpanElement | undefined;
-	if (!nowPlayingStart) return undefined;
-
-	const nextPlayingStart = Util.queryElements(
-		`${nowPlayingNextSelector} > div > span:first-of-type`,
-	)?.[0] as HTMLSpanElement | undefined;
-	let nextTimestamp;
-	if (nextPlayingStart) {
-		nextTimestamp = nextPlayingStart.innerText;
-	} else {
+	if (isMissingTracklist()) {
 		const fullDuration = Util.queryElements(fullDurationSelector)?.[0];
-		nextTimestamp = fullDuration?.innerText.replace(' / ', '0');
-	}
-	if (!nextTimestamp) return undefined;
+		if (!fullDuration) return undefined;
+		return Util.stringToSeconds(
+			fullDuration?.innerText.replace(' / ', '0'),
+		);
+	} else {
+		const nowPlayingStart = Util.queryElements(
+			`${nowPlayingSelector} > div > span:first-of-type`,
+		)?.[0] as HTMLSpanElement | undefined;
+		if (!nowPlayingStart) return undefined;
 
-	const durationMs =
-		timestampToDate(nextTimestamp).getTime() -
-		timestampToDate(nowPlayingStart.innerText).getTime();
-	return Math.ceil(durationMs / 1000);
+		const nextPlayingStart = Util.queryElements(
+			`${nowPlayingNextSelector} > div > span:first-of-type`,
+		)?.[0] as HTMLSpanElement | undefined;
+		let nextTimestamp;
+		if (nextPlayingStart) {
+			nextTimestamp = nextPlayingStart.innerText;
+		} else {
+			const fullDuration = Util.queryElements(fullDurationSelector)?.[0];
+			nextTimestamp = fullDuration?.innerText.replace(' / ', '0');
+		}
+		if (!nextTimestamp) return undefined;
+
+		return (
+			Util.stringToSeconds(nextTimestamp) -
+			Util.stringToSeconds(nowPlayingStart.innerText)
+		);
+	}
 };
 
-function timestampToDate(stamp: string): Date {
-	const d = new Date();
-	const [h, m, s] = stamp.split(':').map((s) => parseInt(s));
-	d.setHours(h);
-	d.setMinutes(m);
-	d.setSeconds(s);
-	d.setMilliseconds(0);
-	return d;
+/**
+ * Util.getTextFromSelectors but using textContent (to avoid text-transform: uppercase)
+ */
+function getTextContentFromSelectors(
+	selectors: string | string[] | null,
+	defaultValue: string | null = null,
+): string | null {
+	if (selectors === null) {
+		return defaultValue;
+	}
+	const elements = Util.queryElements(selectors);
+
+	if (!elements) {
+		return defaultValue;
+	}
+
+	for (const element of elements) {
+		const text = element.textContent;
+		if (text) {
+			return text;
+		}
+	}
+
+	return defaultValue;
 }

--- a/src/connectors/thelotradio.ts
+++ b/src/connectors/thelotradio.ts
@@ -37,12 +37,7 @@ const missingTracklistSelector = 'img[src^="/images/crying-nicolas-cage.gif"]';
 const showTitleSelector =
 	'header h1:has(+ div div button[aria-label="Save Episode"])';
 function isMissingTracklist() {
-	const elements = Util.queryElements(missingTracklistSelector);
-	return (
-		elements !== undefined &&
-		elements?.length !== undefined &&
-		elements.length > 0
-	);
+	return Util.isElementVisible(missingTracklistSelector);
 }
 
 const notDisplayNone = ':not([style*="display: none"])'; // ignores hidden tracklists from previously navigated shows
@@ -54,17 +49,17 @@ const artistSelector = `${nowPlayingSelector} > div > span:nth-of-type(2) > span
 Connector.getTrack = () => {
 	if (isMissingTracklist()) {
 		return getTextContentFromSelectors(showTitleSelector);
-	} else {
-		return getTextContentFromSelectors(trackSelector);
 	}
+
+	return getTextContentFromSelectors(trackSelector);
 };
 
 Connector.getArtist = () => {
 	if (isMissingTracklist()) {
 		return 'The Lot Radio';
-	} else {
-		return getTextContentFromSelectors(artistSelector);
 	}
+
+	return getTextContentFromSelectors(artistSelector);
 };
 
 const fullDurationSelector = `${headerPlayer} span.hidden.${CSS.escape('xl:inline')}`;
@@ -75,33 +70,39 @@ const fullDurationSelector = `${headerPlayer} span.hidden.${CSS.escape('xl:inlin
 Connector.getDuration = () => {
 	if (isMissingTracklist()) {
 		const fullDuration = Util.queryElements(fullDurationSelector)?.[0];
-		if (!fullDuration) return undefined;
+		if (!fullDuration) {
+			return undefined;
+		}
 		return Util.stringToSeconds(
 			fullDuration?.innerText.replace(' / ', '0'),
 		);
-	} else {
-		const nowPlayingStart = Util.queryElements(
-			`${nowPlayingSelector} > div > span:first-of-type`,
-		)?.[0] as HTMLSpanElement | undefined;
-		if (!nowPlayingStart) return undefined;
-
-		const nextPlayingStart = Util.queryElements(
-			`${nowPlayingNextSelector} > div > span:first-of-type`,
-		)?.[0] as HTMLSpanElement | undefined;
-		let nextTimestamp;
-		if (nextPlayingStart) {
-			nextTimestamp = nextPlayingStart.innerText;
-		} else {
-			const fullDuration = Util.queryElements(fullDurationSelector)?.[0];
-			nextTimestamp = fullDuration?.innerText.replace(' / ', '0');
-		}
-		if (!nextTimestamp) return undefined;
-
-		return (
-			Util.stringToSeconds(nextTimestamp) -
-			Util.stringToSeconds(nowPlayingStart.innerText)
-		);
 	}
+
+	const nowPlayingStart = Util.queryElements(
+		`${nowPlayingSelector} > div > span:first-of-type`,
+	)?.[0] as HTMLSpanElement | undefined;
+	if (!nowPlayingStart) {
+		return undefined;
+	}
+
+	const nextPlayingStart = Util.queryElements(
+		`${nowPlayingNextSelector} > div > span:first-of-type`,
+	)?.[0] as HTMLSpanElement | undefined;
+	let nextTimestamp;
+	if (nextPlayingStart) {
+		nextTimestamp = nextPlayingStart.innerText;
+	} else {
+		const fullDuration = Util.queryElements(fullDurationSelector)?.[0];
+		nextTimestamp = fullDuration?.innerText.replace(' / ', '0');
+	}
+	if (!nextTimestamp) {
+		return undefined;
+	}
+
+	return (
+		Util.stringToSeconds(nextTimestamp) -
+		Util.stringToSeconds(nowPlayingStart.innerText)
+	);
 };
 
 /**

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2777,4 +2777,10 @@ export default <ConnectorMeta[]>[
 		js: 'radiosaw.js',
 		id: 'radiosaw',
 	},
+	{
+		label: 'The Lot Radio',
+		matches: ['*://www.thelotradio.com/shows/*'],
+		js: 'thelotradio.js',
+		id: 'thelotradio',
+	},
 ];


### PR DESCRIPTION
**Describe the changes you made**
Added connector for [The Lot Radio](https://www.thelotradio.com/)

**Additional context**
The Lot Radio's markup is unfortunately not semantic at all, so the selectors used here depend on their Tailwind classes and are quite brittle. I also couldn't find a way to re-initialize on navigation change (they use `history.pushState` type navigation), which is why the `isMissingTracklist` check happens inside `getTrack`, `getArtist`, and `getDuration`. 