### PR TITLE
add privacy url fallback

### DIFF
--- a/src/ui/options/components/contact.tsx
+++ b/src/ui/options/components/contact.tsx
@@ -61,7 +61,10 @@ export default function ContactComponent() {
 					</li>
 				</a>
 				<a
-					href={t('contactPrivacyPolicyUrl')}
+					href={
+						t('contactPrivacyPolicyUrl') ||
+						'/_locales/en/privacy.md'
+					}
 					target="_blank"
 					rel="noopener noreferrer"
 				>


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
add a fallback for when the privacy url has not been translated, to open the english one as a text file.
not the prettiest but i don't know how to make a proper ui for this

**Additional context**
<!-- Add any other context or screenshots here. -->
fixes #6027

<details><summary>alternative?</summary>

alternatively maybe we should use this?
https://github.com/web-scrobbler/web-scrobbler/blob/ea09c2dfb8b46a9ba473b3e4b108b7cfed6aa46b/src/util/util-browser.ts#L51
but it's async and that sucks for ui, someone else would have to do that but in that case i'd suggest that someone who knows web technologies better make a builtin ui which actually renders the markdown? (or link to the exact commit on github?)
</details>