### PR TITLE
fix globalplayer

### DIFF
--- a/src/connectors/globalplayer.ts
+++ b/src/connectors/globalplayer.ts
@@ -4,10 +4,13 @@ Connector.playerSelector = '.globalplayer';
 
 const playbarSelector = '.globalplayer [data-testid="playbar"]';
 
-Connector.trackSelector = `${playbarSelector} [data-testid="show-info-title"]>:first-child`;
-Connector.artistSelector = `${playbarSelector} [data-testid="show-info-title"]>:last-child`;
+const showInfoTitleSelector = `${playbarSelector} [data-testid="show-info-title"]`;
+Connector.trackSelector = `${showInfoTitleSelector}>:first-child`;
+Connector.artistSelector = `${showInfoTitleSelector}>:last-child`;
 Connector.pauseButtonSelector = `${playbarSelector} button[data-testid="play-pause-button"][aria-pressed="true"]`;
 Connector.trackArtSelector = `${playbarSelector} img`;
 
 Connector.scrobblingDisallowedReason = () =>
-	Connector.getTrack() === Connector.getArtist() ? 'FilteredTag' : null;
+	document.querySelector(showInfoTitleSelector)?.childElementCount === 1
+		? 'FilteredTag'
+		: null;

--- a/src/connectors/globalplayer.ts
+++ b/src/connectors/globalplayer.ts
@@ -1,20 +1,13 @@
 export {};
 
-const showNameSelector =
-	'div[class^="style_playbarInfo"] div[data-testid="show-info-title"]';
-
 Connector.playerSelector = '.globalplayer';
-Connector.trackSelector =
-	'div[data-testid="show-info-card"] h1[data-testid="show-info-title"]';
-Connector.artistSelector =
-	'div[data-testid="show-info-card"] h2[data-testid="show-info-subtitle"]';
-Connector.playButtonSelector =
-	'button[data-testid="play-pause-button"][aria-pressed="false"]';
-Connector.trackArtSelector = 'div[class^="style_showInfoCard"] img.current-img';
+
+const playbarSelector = '.globalplayer [data-testid="playbar"]';
+
+Connector.trackSelector = `${playbarSelector} [data-testid="show-info-title"]>:first-child`;
+Connector.artistSelector = `${playbarSelector} [data-testid="show-info-title"]>:last-child`;
+Connector.pauseButtonSelector = `${playbarSelector} button[data-testid="play-pause-button"][aria-pressed="true"]`;
+Connector.trackArtSelector = `${playbarSelector} img`;
 
 Connector.scrobblingDisallowedReason = () =>
-	Connector.getTrack() === getShowName() ? 'FilteredTag' : null;
-
-function getShowName() {
-	return Util.getTextFromSelectors(showNameSelector);
-}
+	Connector.getTrack() === Connector.getArtist() ? 'FilteredTag' : null;


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
it was using a page element that is only there when you're focused on the specific station but you could navigate away. now it uses only info from the playerbar.

**Additional context**
<!-- Add any other context or screenshots here. -->
<details><summary>checks for element count in the info panel to detect moderators speaking</summary>
<img width="1410" height="878" alt="image" src="https://github.com/user-attachments/assets/90e325d6-dcbb-4b25-a574-8266235f71c1" />
</details>

<details><summary>working outside of radio page, with only info from the playbar</summary>
<img width="1410" height="878" alt="image" src="https://github.com/user-attachments/assets/c9569eb2-d5e3-49d4-ae15-019c4897ed37" />
</details>

fixes #2244