### PR TITLE
fix cosine.club

### DIFF
--- a/src/connectors/cosine.club.ts
+++ b/src/connectors/cosine.club.ts
@@ -4,17 +4,11 @@ Connector.playerSelector = '#tracks-container';
 
 Connector.getArtistTrack = () => {
 	const trackElement = document.querySelector(
-		'div[data-playing="true"] span',
+		'div[data-playing="true"] .track-name',
 	);
 	return trackElement
 		? Util.splitArtistTrack(trackElement.textContent)
 		: null;
 };
 
-Connector.isPlaying = () => {
-	const currentTrack = document.querySelector('div[data-playing="true"]');
-	const svg = currentTrack?.querySelector('svg');
-	return svg?.getAttribute('aria-label') === 'pause';
-};
-
-setInterval(Connector.onStateChanged, 1000);
+Connector.pauseButtonSelector = 'div[data-playing="true"]';


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
span changed to an anchor since it was added, using `.track-name` instead of `a` now in case they don't have a link to something and fall back to another element maybe.
navigating the website causes reloads, so the interval isn't necessary.

**Additional context**
<!-- Add any other context or screenshots here. -->
fixes #5094 (was working at some point, just cleaning up now)

example link: https://cosine.club/track/479180-livetune-huainda

note for the future: uses youtube embeds, but also provides track info by itself. so.... maybe this will be broken one day if youtube embed functionality returns