### PR TITLE
last.fm +noredirect for the popup song links

### DIFF
--- a/src/ui/popup/nowplaying.tsx
+++ b/src/ui/popup/nowplaying.tsx
@@ -256,6 +256,7 @@ function TrackData(props: { song: Accessor<ClonedSong | null> }) {
 				class={styles.bold}
 				href={createTrackURL(
 					props.song()?.getArtist(),
+					props.song()?.getAlbum(),
 					props.song()?.getTrack(),
 				)}
 				title={t('infoViewTrackPage', props.song()?.getTrack() ?? '')}
@@ -307,6 +308,7 @@ function TrackMetadata(props: { song: Accessor<ClonedSong | null> }) {
 				href={createTrackLibraryURL(
 					session()?.sessionName,
 					props.song()?.getArtist(),
+					props.song()?.getAlbum(),
 					props.song()?.getTrack(),
 				)}
 				title={t(

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -249,7 +249,7 @@ export function createArtistURL(artist: string | null | undefined): string {
 	if (!artist) {
 		return '';
 	}
-	return `https://www.last.fm/music/${encodeLastFMURIComponent(artist)}`;
+	return `https://www.last.fm/music/+noredirect/${encodeLastFMURIComponent(artist)}`;
 }
 
 /**
@@ -301,7 +301,7 @@ export function createTrackLibraryURL(
 	}
 	return `https://www.last.fm/user/${encodeLastFMURIComponent(
 		username,
-	)}/library/music/${encodeLastFMURIComponent(artist)}/_/${encodeLastFMURIComponent(
+	)}/library/music/+noredirect/${encodeLastFMURIComponent(artist)}/_/${encodeLastFMURIComponent(
 		track,
 	)}`;
 }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -271,39 +271,43 @@ export function createAlbumURL(
 /**
  * Create a URL to a track page on Last.fm.
  * @param artist - Artist name
+ * @param album - Album name (optional)
  * @param track - Track name
  * @returns URL to the track page
  */
 export function createTrackURL(
 	artist: string | null | undefined,
-	track?: string | null,
+	album: string | null | undefined,
+	track: string | null | undefined,
 ): string {
 	if (!track || !artist) {
 		return '';
 	}
-	return `${createArtistURL(artist)}/_/${encodeLastFMURIComponent(track)}`;
+	return `${createAlbumURL(artist, album ?? '_')}/${encodeLastFMURIComponent(track)}`;
 }
 
 /**
  * Create a URL to the page for a track in a user's library on Last.fm.
  * @param username - Username
  * @param artist - Artist name
+ * @param album  - Album name (optional)
  * @param track - Track name
  * @returns URL to the track library page
  */
 export function createTrackLibraryURL(
 	username: string | null | undefined,
 	artist: string | null | undefined,
+	album: string | null | undefined,
 	track: string | null | undefined,
 ): string {
 	if (!track || !artist || !username) {
 		return '';
 	}
-	return `https://www.last.fm/user/${encodeLastFMURIComponent(
-		username,
-	)}/library/music/+noredirect/${encodeLastFMURIComponent(artist)}/_/${encodeLastFMURIComponent(
-		track,
-	)}`;
+	const encUsername = encodeLastFMURIComponent(username);
+	const encArtist = encodeLastFMURIComponent(artist);
+	const encAlbum = encodeLastFMURIComponent(album ?? '_');
+	const encTrack = encodeLastFMURIComponent(track);
+	return `https://www.last.fm/user/${encUsername}/library/music/+noredirect/${encArtist}/${encAlbum}/${encTrack}`;
 }
 
 /**


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
right now if the user has edited the track, they will still be redirected to a "corrected" track

previously the url was:
https://www.last.fm/music/Neves/_/1987, which redirects to `Nenes - 1987`
with this PR it will be:
https://www.last.fm/music/+noredirect/Neves/_/1987

same for the artist, and the personal scrobble link (to show your stats for that specific scrobble)

**Additional context**
<!-- Add any other context or screenshots here. -->
partially addresses #5916

fixes #5678: adds Album to urls if available