### PR TITLE
Add support for Mixcloud embeds

### DIFF
--- a/src/connectors/mixcloud-embed.ts
+++ b/src/connectors/mixcloud-embed.ts
@@ -1,0 +1,58 @@
+export {};
+
+const playerSelector = '[data-testid=widgetTopClass]';
+const playButtonSelector = `${playerSelector} [data-testid=widget-play-button]`;
+const trackSelector = `${playerSelector} span strong:has(+ span)`;
+const artistSelector = `${trackSelector} + span span:last-of-type`;
+
+Connector.playerSelector = playerSelector;
+
+Connector.isPodcast = () => {
+	const playerWrap = document.querySelector(playerSelector);
+
+	return Boolean(playerWrap && playerWrap?.childElementCount < 2);
+};
+
+Connector.getTrackInfo = () => {
+	const showSelector = `${playButtonSelector} + div > a`;
+	const trackArtSelector = `${playerSelector} [data-testid=widget-cloudcast-image] img`;
+	const currentTimeSelector = '[data-testid=widget-current-time]';
+	const remainingTimeSelector = `${currentTimeSelector} ~ span > span`;
+	let artist = Util.getTextFromSelectors(artistSelector);
+	let track = Util.getTextFromSelectors(trackSelector);
+	let trackArt;
+	let currentTime;
+	let duration;
+
+	if (Connector.isPodcast()) {
+		artist = Util.getTextFromSelectors(
+			`${showSelector} + div > a:first-of-type`,
+		);
+		track = Util.getTextFromSelectors(showSelector);
+		trackArt = Util.extractImageUrlFromSelectors(trackArtSelector)?.replace(
+			/(?<=\/)\d+x\d+(?=\/)/,
+			'360x360', // larger image
+		);
+		currentTime = Util.getSecondsFromSelectors(currentTimeSelector);
+		duration =
+			(currentTime ?? 0) -
+			(Util.getSecondsFromSelectors(remainingTimeSelector) ?? 0);
+	}
+
+	return { artist, track, trackArt, currentTime, duration };
+};
+
+Connector.isPlaying = () =>
+	Boolean(
+		Util.getAttrFromSelectors(playButtonSelector, 'style')?.includes(
+			'backgroundPosition: -18.75rem', // pause icon sprite position
+		),
+	);
+
+Connector.isStateChangeAllowed = () => {
+	if (!Connector.isPodcast()) {
+		return Boolean(Util.isElementVisible([artistSelector, trackSelector]));
+	}
+
+	return true;
+};

--- a/src/connectors/mixcloud-embed.ts
+++ b/src/connectors/mixcloud-embed.ts
@@ -7,11 +7,8 @@ const artistSelector = `${trackSelector} + span > span:last-of-type`;
 
 Connector.playerSelector = playerSelector;
 
-Connector.isPodcast = () => {
-	const playerWrapper = document.querySelector(playerSelector);
-
-	return Boolean(playerWrapper && playerWrapper?.childElementCount < 2);
-};
+Connector.isPodcast = () =>
+	Boolean(!Util.isElementVisible([artistSelector, trackSelector]));
 
 Connector.getTrackInfo = () => {
 	const showSelector = `${playButtonSelector} + div > a`;
@@ -48,11 +45,3 @@ Connector.isPlaying = () =>
 			'backgroundPosition: -18.75rem', // pause icon sprite position
 		),
 	);
-
-Connector.isStateChangeAllowed = () => {
-	if (!Connector.isPodcast()) {
-		return Boolean(Util.isElementVisible([artistSelector, trackSelector]));
-	}
-
-	return true;
-};

--- a/src/connectors/mixcloud-embed.ts
+++ b/src/connectors/mixcloud-embed.ts
@@ -2,8 +2,8 @@ export {};
 
 const playerSelector = '[data-testid=widgetTopClass]';
 const playButtonSelector = `${playerSelector} [data-testid=widget-play-button]`;
-const trackSelector = `${playerSelector} span strong:has(+ span)`;
-const artistSelector = `${trackSelector} + span span:last-of-type`;
+const trackSelector = `${playerSelector} span > strong:has(+ span)`;
+const artistSelector = `${trackSelector} + span > span:last-of-type`;
 
 Connector.playerSelector = playerSelector;
 
@@ -15,7 +15,7 @@ Connector.isPodcast = () => {
 
 Connector.getTrackInfo = () => {
 	const showSelector = `${playButtonSelector} + div > a`;
-	const trackArtSelector = `${playerSelector} [data-testid=widget-cloudcast-image] img`;
+	const trackArtSelector = '[data-testid=widget-cloudcast-image] img';
 	const currentTimeSelector = '[data-testid=widget-current-time]';
 	const remainingTimeSelector = `${currentTimeSelector} ~ span > span`;
 	let artist = Util.getTextFromSelectors(artistSelector);

--- a/src/connectors/mixcloud-embed.ts
+++ b/src/connectors/mixcloud-embed.ts
@@ -1,16 +1,16 @@
 export {};
 
 const playerSelector = '[data-testid=widgetTopClass]';
-const playButtonSelector = `${playerSelector} [data-testid=widget-play-button]`;
+const playButtonSelector = '[data-testid=widget-play-button]';
 const trackSelector = `${playerSelector} span > strong:has(+ span)`;
 const artistSelector = `${trackSelector} + span > span:last-of-type`;
 
 Connector.playerSelector = playerSelector;
 
 Connector.isPodcast = () => {
-	const playerWrap = document.querySelector(playerSelector);
+	const playerWrapper = document.querySelector(playerSelector);
 
-	return Boolean(playerWrap && playerWrap?.childElementCount < 2);
+	return Boolean(playerWrapper && playerWrapper?.childElementCount < 2);
 };
 
 Connector.getTrackInfo = () => {

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -269,6 +269,13 @@ export default <ConnectorMeta[]>[
 		id: 'tunein',
 	},
 	{
+		label: 'Mixcloud Embed',
+		matches: ['*://player-widget.mixcloud.com/*'],
+		js: 'mixcloud-embed.js',
+		id: 'mixcloud-embed',
+		allFrames: true,
+	},
+	{
 		label: 'Mixcloud',
 		matches: ['*://mixcloud.com/*', '*://*.mixcloud.com/*'],
 		js: 'mixcloud.js',


### PR DESCRIPTION
**Describe the changes you made**
Adding support for Mixcloud embeds. This will allow Mixcloud embedded players to scrobble from any site, without having to explicitly include the site itself in the connectors list.

**Additional context**
Supports Mixcloud streams with playlist metadata and without; the latter will be considered a podcast.
Example with playlist: https://sohoradio.com/show/insomniac-monthly-with-jon-more-14-04-2026/
Example without playlist: https://sohoradio.com/show/soph-nathan-and-mina-wood-09-02-2026/
Example with multiple embeds of both types: https://arts.britishcouncil.org/selector-radio/highlights
Logic and selectors may be a bit fragile due to use of randomly generated classes and lots of nested divs and spans, but this is the best I could do with what their player provides. Unfortunately, not all embedded players have the extra child element I was initially using to differentiate between players with and without playlists, so, like the main Mixcloud connector, there may be a temporary switch between podcast detection on some shows.
Resolves #5959.
