### PR TITLE
Fix Subvert connector

### DIFF
--- a/src/connectors/subvert.ts
+++ b/src/connectors/subvert.ts
@@ -1,66 +1,17 @@
 export {};
 
-const player = '[class*=globalPlayerContainer]';
-const artistSelector = `${player} .globalPlayerCoverImage > div:nth-child(2) > a:nth-child(2)`;
-const trackSelector = `${player} .globalPlayerCoverImage > div:nth-child(2) > a:nth-child(1)`;
-const trackArtSelector = `${player} .globalPlayerCoverImage > div:nth-child(1) img`;
-const desktopDurationSelector = `${player} div:nth-child(4) > div:nth-child(4)`;
-const desktopCurrentTimeSelector = `${player} div:nth-child(4) > div:nth-child(2)`;
+Connector.playerSelector = '.globalPlayerContainer';
 
-Connector.playerSelector = player;
+Connector.pauseButtonSelector = '.playPauseButton[aria-label=Pause]';
 
-Connector.playButtonSelector = `${player} .playPauseButton`;
+Connector.artistSelector = '.global-audio-player-marquee + a';
 
-Connector.durationSelector = desktopDurationSelector;
+Connector.trackSelector = '.global-audio-player-marquee span';
 
-Connector.currentTimeSelector = desktopCurrentTimeSelector;
+Connector.trackArtSelector = '.globalPlayerCoverImage img';
 
-Connector.getArtistTrack = () => {
-	let track = Util.getTextFromSelectors(trackSelector);
-	let artist = Util.getTextFromSelectors(artistSelector);
-	if (track) {
-		track = track.split('\n')[0].trim();
-	}
-	const titleParts = document.title.split('–');
-	if (!artist && titleParts.length === 3) {
-		artist = titleParts[1].trim();
-	}
-	return { artist, track };
-};
+Connector.currentTimeSelector =
+	'.globalPlayerCoverImage + div > div:nth-of-type(2)';
 
-Connector.getTrackArt = () => {
-	const trackArtUrl = Util.extractImageUrlFromSelectors(trackArtSelector);
-	if (trackArtUrl) {
-		return trackArtUrl.replace('-50h.', '-600h.');
-	}
-
-	return null;
-};
-
-Connector.isPlaying = () => {
-	const svgPlayPause = document.querySelector(
-		`${Connector.playButtonSelector} svg`,
-	);
-	const height = svgPlayPause?.getAttribute('height');
-	const playingHeight = '32';
-	const pauseHeight = '24';
-	if (
-		!svgPlayPause ||
-		!height ||
-		(height !== playingHeight && height !== pauseHeight)
-	) {
-		return null;
-	}
-	if (height === playingHeight) {
-		return true;
-	}
-	return false;
-};
-
-Connector.getOriginUrl = () => {
-	const link = document.querySelector(trackSelector) as HTMLAnchorElement;
-	if (link) {
-		return link.href;
-	}
-	return null;
-};
+Connector.durationSelector =
+	'.globalPlayerCoverImage + div > div:nth-of-type(4)';

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -2768,8 +2768,8 @@ export default <ConnectorMeta[]>[
 		id: 'teleplay',
 	},
 	{
-		label: 'Subvert.fm',
-		matches: ['*://subvert.fm/*', '*://*.subvert.fm/*'],
+		label: 'Subvert',
+		matches: ['*://*.subvert.fm/*'],
 		js: 'subvert.js',
 		id: 'subvert',
 	},


### PR DESCRIPTION
**Describe the changes you made**
Subvert connector previously added in #5801, but connector setup was overly complicated and appears to have already broken before being released. This update is a more simplified connector that only utilizes selectors and has no convoluted logic.

The site is no longer behind a paywall (it seems to have officially opened [today](https://bsky.app/profile/subvert.fm/post/3mlnzh2kqbk22)), and music can now be accessed at https://www.subvert.fm/discover

**Additional context**
Also updated name to just "Subvert," as that is how it is referred to in their [FAQ](https://www.subvert.fm/docs/faq) and elsewhere. And only one URL match is needed.
