### PR TITLE
Update Mixcloud connector

### DIFF
--- a/src/connectors/mixcloud.ts
+++ b/src/connectors/mixcloud.ts
@@ -1,59 +1,50 @@
 export {};
 
+const playerSelector = '[data-testid=player-container]';
+const artistSelector = '[class*=styles__Artist-]';
+const trackSelector = '[class*=styles__Track-]';
 const filter = MetadataFilter.createFilter({
 	artist: [removeByPrefix, removeBuySuffix],
 });
 
-Connector.playerSelector = '[data-testid="player-container"]';
+Connector.playerSelector = playerSelector;
 
-Connector.playButtonSelector = '[data-testid="player-play-button-Play"]';
-Connector.pauseButtonSelector = '[data-testid="player-play-button-Pause"]';
+Connector.pauseButtonSelector = '[data-testid=player-play-button-Pause]';
 
-const trackArtSelector = `${Connector.playerSelector} img`;
-
-const trackSelector = '[data-testid="player-show-title"]';
-const artistSelector = `${Connector.trackSelector}+*`;
-
-const currentTimeSelector = '[data-testid="startTime"]';
-const durationSelector = '[data-testid="endTime"]';
+Connector.isPodcast = () =>
+	Boolean(!Util.isElementVisible([artistSelector, trackSelector]));
 
 Connector.getTrackInfo = () => {
-	let artistText = Util.getTextFromSelectors('[class*=styles__Artist-]');
-	let trackText = Util.getTextFromSelectors('[class*=styles__Track-]');
-	let trackArtUrl;
-	let currentTimeValue;
-	let durationValue;
-	let podcastBoolean;
+	const showSelector = '[data-testid=player-show-title]';
+	const trackArtSelector = `${playerSelector} img`;
+	const currentTimeSelector = '[data-testid=startTime]';
+	const durationSelector = '[data-testid=endTime]';
+	let artist = Util.getTextFromSelectors(artistSelector);
+	let track = Util.getTextFromSelectors(trackSelector);
+	let trackArt;
+	let currentTime;
+	let duration;
 
-	if (artistText && trackText) {
-		podcastBoolean = false;
-	} else {
-		artistText = Util.getTextFromSelectors(artistSelector);
-		trackText = Util.getTextFromSelectors(trackSelector);
-		trackArtUrl = Util.extractImageUrlFromSelectors(
-			trackArtSelector,
-		)?.replace(/\/\d+x\d+(?=\/)/g, ''); // larger image path
-		currentTimeValue = Util.getSecondsFromSelectors(currentTimeSelector);
-		durationValue = Util.getSecondsFromSelectors(durationSelector);
-		podcastBoolean = true;
+	if (Connector.isPodcast()) {
+		artist = Util.getTextFromSelectors(`${playerSelector} p span`);
+		track = Util.getTextFromSelectors(showSelector);
+		trackArt = Util.extractImageUrlFromSelectors(trackArtSelector)?.replace(
+			/(?<=\/)\d+x\d+(?=\/)/,
+			'580x580', // larger image
+		);
+		currentTime = Util.getSecondsFromSelectors(currentTimeSelector);
+		duration = Util.getSecondsFromSelectors(durationSelector);
 	}
 
-	return {
-		artist: artistText,
-		track: trackText,
-		trackArt: trackArtUrl,
-		currentTime: currentTimeValue,
-		duration: durationValue ?? 0,
-		isPodcast: podcastBoolean,
-	};
+	return { artist, track, trackArt, currentTime, duration };
 };
 
 Connector.applyFilter(filter);
 
 function removeByPrefix(text: string) {
-	return text.replace(/^by\s/g, '');
+	return text.replace(/^by\s/, '');
 }
 
 function removeBuySuffix(text: string) {
-	return text.replace(/[\u2014-]\sbuy$/gi, '');
+	return text.replace(/[\u2014-]\sbuy$/i, '');
 }

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -270,7 +270,7 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'Mixcloud',
-		matches: ['*://mixcloud.com/*', '*://*.mixcloud.com/*'],
+		matches: ['*://*.mixcloud.com/*'],
 		js: 'mixcloud.js',
 		id: 'mixcloud',
 	},


### PR DESCRIPTION
**Describe the changes you made**
Updated Mixcloud connector to better handle streams without playlist info as podcasts; also made it a bit more concise.

**Additional context**
While working on a Mixcloud embed connector in #6041, I noticed that the main Mixcloud connector didn't seem to be handling streams without playlists very well, as it was only registering a track but no artist. Now, if no playlist info is provided, it will be recognized as a podcast with the show as track and user as artist.
However, unlike the embed connector, where I was able to find an extra element in the streams with playlists vs. the streams without, there is nothing like that in the on-site player. As such, some streams may alternate between podcast and not, depending on the playlist setup or a listener scrubbing/seeking through the stream, as the elements with the playlist artist/track info are not always in the DOM. This shouldn't be a major issue—especially if "Scrobble podcasts" is disabled—as the switch between podcast and not should only be temporary.
Example with playlist all the way through: https://www.mixcloud.com/totallywiredradio/the-rough-mix-w-g-mateus-120526/
Example with playlist only when songs are playing: https://www.mixcloud.com/DandelionRadio/the-velvet-underground-etcetera-part-2-202605/
Example without playlist: https://www.mixcloud.com/VoicesRadio/violet-rays-w-edna-120526-voices-radio/
Lastly, I'm not sure if the "removeBuySuffix" filter is still needed, but I left it just in case.