### PR TITLE
replace klassikradio with klassikradioplus

### DIFF
--- a/src/connectors/klassikradio.de.ts
+++ b/src/connectors/klassikradio.de.ts
@@ -1,9 +1,0 @@
-export {};
-
-Connector.playerSelector = '#audioPlayer';
-
-Connector.artistSelector = '.trackInfos-artist';
-
-Connector.trackSelector = '.trackInfos-title';
-
-Connector.playButtonSelector = '#playButton';

--- a/src/connectors/klassikradioplus.ts
+++ b/src/connectors/klassikradioplus.ts
@@ -1,0 +1,32 @@
+export {};
+
+const originalConnectorLabel = Connector.meta.label;
+
+Connector.playerSelector = '.kr-webplayer';
+
+Connector.artistSelector = '.meta-info .meta-interpret';
+
+Connector.trackSelector = '.meta-info :nth-last-child(1 of .meta-title)';
+
+// the url redirects to something else for each song, not worth it
+// Connector.trackArtSelector =
+// 	'.kr-webplayer-maxi .metadata-img-info-wrapper img';
+
+Connector.isPlaying = () =>
+	Util.getTextFromSelectors('.play-stop-button')?.trim() === 'stop';
+
+Connector.scrobblingDisallowedReason = () => {
+	const stationText = Util.getTextFromSelectors(
+		'.meta-info :nth-child(1 of .meta-title)',
+	);
+	if (
+		!!document.querySelector('.track-slider-disabled-live') &&
+		stationText
+	) {
+		Connector.meta.label = stationText;
+	} else {
+		Connector.meta.label = originalConnectorLabel;
+	}
+
+	return null;
+};

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -1941,10 +1941,10 @@ export default <ConnectorMeta[]>[
 		id: 'naxosmusiclibrary',
 	},
 	{
-		label: 'Klassik Radio',
-		matches: ['*://*klassikradio.de/*'],
-		js: 'klassikradio.de.js',
-		id: 'klassikradio',
+		label: 'Klassik Radio Plus',
+		matches: ['*://klassikradioplus.de/*'],
+		js: 'klassikradioplus.js',
+		id: 'klassikradioplus',
 	},
 	{
 		label: 'Beetle',


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
klassikradio is not a thing anymore, the stations it was broadcasting are now at klassikradioplus along with other things to listen to. it's essentially a completely new connector

**Additional context**
<!-- Add any other context or screenshots here. -->
- adjusts Connector Label to radio station if listening live (there are three, Klassik Radio, Beats Radio and Movie Radio). all others don't display "Live" and are just labeled as "Klassik Radio Plus"