### PR TITLE
fix Indie88 connector

### DIFF
--- a/src/connectors/indie88.ts
+++ b/src/connectors/indie88.ts
@@ -1,31 +1,12 @@
+// https://www.indie88.com/player/
+// managed with https://www.socastdigital.com/
+
 export {};
 
-function setupConnector() {
-	if (isCobrPlayer()) {
-		setupCobrPlayer();
-	} else {
-		setupWebsitePlayer();
-	}
-}
+Connector.playerSelector = '#content';
 
-function isCobrPlayer() {
-	return document.querySelector('div.cobrp-page-column') !== null;
-}
+Connector.pauseButtonSelector = '#playBtn.playing';
 
-function setupCobrPlayer() {
-	Connector.playerSelector = 'div.cobrp-player';
-	Connector.trackSelector = 'div.cobrp-player-song';
-	Connector.artistSelector = 'div.cobrp-player-artist';
-	Connector.isPlaying = () =>
-		Util.hasElementClass('img.cobrp-player-footer-icon', 'mod-pause');
-}
-
-// Indie88 has the track and artist flipped on their main web player. The values are intentionally flipped in setupWebsitePlayer
-function setupWebsitePlayer() {
-	Connector.playerSelector = 'div.mediaplayer';
-	Connector.artistSelector = 'p#track-info-title span';
-	Connector.trackSelector = 'p#track-info-artist span';
-	Connector.isPlaying = () => Util.hasElementClass('a.btn-play', 'hidden');
-}
-
-setupConnector();
+Connector.trackArtSelector = '.song:first-child .image img';
+Connector.artistSelector = '.song:first-child .artist';
+Connector.trackSelector = '.song:first-child .name';

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -1810,10 +1810,7 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'Indie88',
-		matches: [
-			'*://indie88.com/lean-stream-player/*',
-			'*://cob.leanplayer.com/CINDFM*',
-		],
+		matches: ['*://www.indie88.com/player/*'],
 		js: 'indie88.js',
 		id: 'indie88',
 	},


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
indie88 has changed their URL for the web-player. both of the old supported styles didn't work anymore with the websites listed.
I've replaced it with a single new connector for the updated main url.
There was a second service listed but they don't have the Track Info anywhere on the page so i didn't bother preserving it

**Additional context**
<!-- Add any other context or screenshots here. -->
not really, no