### PR TITLE
fix allclassical.org

### DIFF
--- a/src/connectors/allclassical.org.ts
+++ b/src/connectors/allclassical.org.ts
@@ -9,6 +9,4 @@ Connector.artistSelector = '#composer';
 Connector.playButtonSelector = '#live-play';
 
 Connector.scrobblingDisallowedReason = () =>
-	Util.getTextFromSelectors('.nowplaying-label') === 'Now Playing'
-		? null
-		: 'Other';
+	Util.isElementVisible('#song-info') ? null : 'Other';

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -1700,7 +1700,7 @@ export default <ConnectorMeta[]>[
 		id: 'bullofheavencom',
 	},
 	{
-		label: 'All Classical Portland',
+		label: 'All Classical Radio',
 		matches: ['*://player.allclassical.org/*'],
 		js: 'allclassical.org.js',
 		id: 'allclassicalportland',


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
fixed allclassical.org scrobblingDisallowedReason

**Additional context**
<!-- Add any other context or screenshots here. -->
every song was registering as not allowed to play because of 'Other' because the now playing text was now stylized as "NOW PLAYING" when we were checking for "Now Playing". an effect of using .innerText instead of .textContent in the getTextForSelector function. this instead checks whether the `#song-info` element is currently hidden or not (it gets switched out for the `#recently-played` element if the host is talking at the moment