### PR TITLE
Fix scrobbling issues on ytm

### DIFF
--- a/src/connectors/youtube-music.ts
+++ b/src/connectors/youtube-music.ts
@@ -56,18 +56,38 @@ Connector.getTrackArt = () => {
 	return artworks?.[artworks.length - 1].src;
 };
 
+// BETTER ARTIST PARSER - FIXES MISSING ANCHOR TAGS FOR ARTISTS
+function getCleanArtist(rawArtist: string | undefined): string {
+	if (!rawArtist) return '';
+
+	// trim leading / trailing spaces of an artist name, and replace misc whitespace
+	// 	   (e.g. double spaces) with a single space
+	let artist = rawArtist.trim()
+		.replace(/\s+/g, ' ')
+		.replace(/&nbsp;/g, ' ');
+
+	const splitters = /[,/&]|feat\.?|ft\.?|featuring| x | vs | with | x /i;
+	const parts = artist.split(splitters).map(p => p.trim()).filter(Boolean);
+
+	// only return the first artist
+	return parts[0] || artist;
+}
+
 Connector.getArtistTrack = () => {
 	let artist;
 	let track;
 	const metadata = mediaInfo.metadata;
 
 	if (metadata?.album) {
-		artist = metadata.artist;
+		// use new method to 'clean' the artist data
+		artist = getCleanArtist(metadata.artist);
 		track = metadata.title;
 	} else {
 		({ artist, track } = Util.processYtVideoTitle(metadata?.title));
 		if (!artist) {
-			artist = metadata?.artist;
+			artist = getCleanArtist(metadata?.artist);
+		} else {
+			artist = getCleanArtist(artist);
 		}
 	}
 	return { artist, track };


### PR DESCRIPTION
Fix issue where songs that have multiple artists without anchor tags do not scrobble correctly. Will only scrobble first artist now.

<!-- 
  Thank you for taking the time to contribute to this project!

  Make sure to check out our guide on contributing with guidelines of how to contribute.

  See: https://github.com/web-scrobbler/web-scrobbler/blob/master/.github/CONTRIBUTING.md

-->

**Issue**
In the case that a song being scrobbled on youtube music had multiple artists, none of which had an anchor tag, the song wouldn't scrobble correctly. Below is a comparison of the correct scrobble (done with the changes) (first) and the incorrect scrobble (second).

**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
The fix included instead of just looking for anchor tags, it would firstly try for anchor tags, however if not found would resort to common splitters, and would take the first artist to scrobble the song correctly.

This problem of dual instances for albums and artists was present too, and was also fixed with this update.

**Additional context**
<!-- Add any other context or screenshots here. -->
Correct scrobble:
<img width="436" height="48" alt="image" src="https://github.com/user-attachments/assets/80993830-84c5-481c-adb4-1db2c2697ca3" />
Incorrect scrobble:
<img width="434" height="52" alt="image" src="https://github.com/user-attachments/assets/9177fe71-4bc2-4143-8eab-f160febe5f00" />