### PR TITLE
require spaces around dashes

### DIFF
--- a/src/core/content/util.ts
+++ b/src/core/content/util.ts
@@ -67,15 +67,18 @@ export const defaultSeparators = [
 	' \u2013 ',
 	' \u2014 ',
 	' // ',
-	'\u002d',
-	'\u2013',
-	'\u2014',
+	' \u002d',
+	' \u2013',
+	' \u2014',
+	'\u002d ',
+	'\u2013 ',
+	'\u2014 ',
 	':',
 	'|',
 	'///',
 	'/',
 	'~',
-];
+] as const;
 
 /**
  * Convert given time-string into seconds.

--- a/tests/content/util.test.ts
+++ b/tests/content/util.test.ts
@@ -659,7 +659,7 @@ const PROCESS_YT_VIDEO_TITLE_DATA = [
 	{
 		description: 'should prioritize dashes over 【】',
 		args: ['Artist -Track-【Official Video】'],
-		expected: { artist: 'Artist ', track: 'Track【Official Video】' },
+		expected: { artist: 'Artist', track: 'Track【Official Video】' },
 	},
 	{
 		description: 'should prioritize other brackets over 【】',


### PR DESCRIPTION

**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->

requires spaces around a dash in the default separators. Specifically for `processYtVideoTitle` since it's the default used there. not removing the no-space variant entirely instead of replacing it with one-sided space variants because a test case relies on it (the `Artist -Title- [whatever]` one but with fancy `[]` symbols). That test case has also been adjusted since the new behaviour does strip the space after the Artist as well.

**Additional context**
<!-- Add any other context or screenshots here. -->
context around this PR / history of the edited files: https://github.com/web-scrobbler/web-scrobbler/issues/2261#issuecomment-4491467404

fixes #2261
fixes #5358
fixes #3947
fixes #6106