### PR TITLE
Fix Youtube Music connector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -173,7 +173,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.5.tgz",
       "integrity": "sha512-Cwc2XjUrG4ilcfOw4wBAK+enbdgwAcAJCfGUItPBKR7Mjw4aEfAFYrLxeRp4jWgtNIKn3n2AlBOfwwafl+42/g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -584,7 +583,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -607,7 +605,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2670,7 +2667,6 @@
       "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
         "@typescript-eslint/types": "8.44.0",
@@ -3154,7 +3150,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4239,7 +4234,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001565",
         "electron-to-chromium": "^1.4.601",
@@ -6134,7 +6128,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6219,7 +6212,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6280,7 +6272,6 @@
       "integrity": "sha512-VZuXTN0RCt70SMa0vVoyX0kq9c6j/A9c3u66U3jsSC5juabbXSILK6pfmJMSItIPnOMYQbVFSpo22Mzpsm36bw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@es-joy/jsdoccomment": "~0.58.0",
         "are-docs-informative": "^0.0.2",
@@ -6307,7 +6298,6 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -6361,7 +6351,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-solid/-/eslint-plugin-solid-0.14.5.tgz",
       "integrity": "sha512-nfuYK09ah5aJG/oEN6P1qziy1zLgW4PDWe75VNPi4CEFYk1x2AEqwFeQfEPR7gNn0F2jOeqKhx2E+5oNCOBYWQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/utils": "^7.13.1 || ^8.0.0",
         "estraverse": "^5.3.0",
@@ -6384,7 +6373,6 @@
       "integrity": "sha512-BlvqjWZdBJDIPO/YU3zcPCF23CvjYT3gyu63yo6b609NNV3D1b6zceAREy2xnweuBoDpZcLNuPyAUq9cvx6bbQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@microsoft/tsdoc": "0.16.0",
         "@microsoft/tsdoc-config": "0.18.1",
@@ -11431,7 +11419,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11446,7 +11433,8 @@
       "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
       "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/postcss-resolve-nested-selector": {
       "version": "0.1.6",
@@ -11500,6 +11488,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0"
       },
@@ -11512,7 +11501,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11658,7 +11646,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12590,7 +12577,6 @@
       "integrity": "sha512-elOcIZRTM76dvxNAjqYrucTSI0teAF/L2Lv0s6f6b7FOwcwIuA357bIE871580AjHJuSvLIRUosgV+lIWx6Rgg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -12695,7 +12681,6 @@
       "integrity": "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12989,7 +12974,6 @@
       "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.5.0",
@@ -13526,7 +13510,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
@@ -13590,6 +13573,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.12.0"
       },
@@ -13603,6 +13587,7 @@
       "integrity": "sha512-bhaMhh1u5dQqSsf6ri2GVWWQW5iUjBYgcHkh7SgDDn92ijoItC/cfO/W+fpXshgTQWhwFkP1rVcewcv4jaftRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "postcss-scss": "^4.0.9",
         "stylelint-config-recommended": "^14.0.1",
@@ -13637,6 +13622,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.12.0"
       },
@@ -13677,6 +13663,7 @@
       "integrity": "sha512-6Pa26D9mHyi4LauJ83ls3ELqCglU6VfCXchovbEqQUiEkezvKdv6VgsIoMy58i00c854wVmOw0k8W5FTpuaVqg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "stylelint-config-recommended-scss": "^14.1.0",
         "stylelint-config-standard": "^36.0.1"
@@ -13710,6 +13697,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.12.0"
       },
@@ -13733,6 +13721,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "stylelint-config-recommended": "^14.0.1"
       },
@@ -13763,6 +13752,7 @@
       "integrity": "sha512-CBqs0jecftIyhic6xba+4OvZUp4B0wNbX19w6Rq1fPo+lBDmTevk+olo8H7u/WQpTSDCDbBN4f3oocQurvXLTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-tree": "^3.0.1",
         "is-plain-object": "^5.0.0",
@@ -13785,14 +13775,16 @@
       "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.35.0.tgz",
       "integrity": "sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/stylelint-scss/node_modules/mdn-data": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.15.0.tgz",
       "integrity": "sha512-KIrS0lFPOqA4DgeO16vI5fkAsy8p++WBlbXtB5P1EQs8ubBgguAInNd1DnrCeTRfGchY0kgThgDOOIPyOLH2dQ==",
       "dev": true,
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/stylelint/node_modules/balanced-match": {
       "version": "2.0.0",
@@ -14179,7 +14171,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14342,7 +14333,6 @@
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -14480,7 +14470,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14495,7 +14484,6 @@
       "integrity": "sha512-ib7mCkYuIzYonCq9XWF5XNw+fkj2zg629PSa9KNIQ47RXFF763S5BIX4wqz1+FLPogTZoiw8KmCiRPRa8bL3qw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.44.0",
         "@typescript-eslint/parser": "8.44.0",
@@ -15368,7 +15356,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -16031,7 +16018,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -176,7 +176,19 @@
         "description": "Option title"
     },
     "optionYtMusicAllArtistsDesc": {
-        "message": "When enabled, the connector will scrobble the complete artist metadata instead of only the first artist.",
+        "message": "When enabled, scrobble the complete artist metadata instead of only the first artist.",
+        "description": "Option description"
+    },
+    "optionYtMusicIgnoreDeviceTransfer": {
+        "message": "Ignore the YouTube Music device Transfer Metadata",
+        "description": "Option label"
+    },
+    "optionYtMusicIgnoreDeviceTransferTitle": {
+        "message": "Ignore YouTube Music transfer metadata",
+        "description": "Option title"
+    },
+    "optionYtMusicIgnoreDeviceTransferDesc": {
+        "message": "Will ignore device transfer metadata such as \"Scrobbling from your _ device\".",
         "description": "Option description"
     },
     "optionYtMusicRecognisedOnly": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -167,6 +167,18 @@
         "message": "Use Youtube Music to get track info, if disabled defaults to using description and video title",
         "description": "Option title"
     },
+    "optionYtMusicAllArtists": {
+        "message": "Scrobble all artists from YouTube Music metadata",
+        "description": "Option label"
+    },
+    "optionYtMusicAllArtistsTitle": {
+        "message": "Use the full artist string instead of only the first artist",
+        "description": "Option title"
+    },
+    "optionYtMusicAllArtistsDesc": {
+        "message": "When enabled, the connector will scrobble the complete artist metadata instead of only the first artist.",
+        "description": "Option description"
+    },
     "optionYtMusicRecognisedOnly": {
         "message": "Scrobble only videos that are recognized by YouTube Music as music",
         "description": "Option label"

--- a/src/_locales/en_GB/messages.json
+++ b/src/_locales/en_GB/messages.json
@@ -176,7 +176,19 @@
         "description": "Option title"
     },
     "optionYtMusicAllArtistsDesc": {
-        "message": "When enabled, the connector will scrobble the complete artist metadata instead of only the first artist.",
+        "message": "When enabled, scrobbles the complete artist metadata instead of only the first artist.",
+        "description": "Option description"
+    },
+    "optionYtMusicIgnoreDeviceTransfer": {
+        "message": "Ignore the YouTube Music device Transfer Metadata",
+        "description": "Option label"
+    },
+    "optionYtMusicIgnoreDeviceTransferTitle": {
+        "message": "Ignore YouTube Music transfer metadata",
+        "description": "Option title"
+    },
+    "optionYtMusicIgnoreDeviceTransferDesc": {
+        "message": "Will ignore device transfer metadata such as \"Scrobbling from your _ device\".",
         "description": "Option description"
     },
     "optionYtMusicRecognisedOnly": {

--- a/src/_locales/en_GB/messages.json
+++ b/src/_locales/en_GB/messages.json
@@ -167,6 +167,18 @@
         "message": "Use Youtube Music to get track info, if disabled defaults to using description and video title",
         "description": "Option title"
     },
+    "optionYtMusicAllArtists": {
+        "message": "Scrobble all artists from YouTube Music metadata",
+        "description": "Option label"
+    },
+    "optionYtMusicAllArtistsTitle": {
+        "message": "Use the full artist string instead of only the first artist",
+        "description": "Option title"
+    },
+    "optionYtMusicAllArtistsDesc": {
+        "message": "When enabled, the connector will scrobble the complete artist metadata instead of only the first artist.",
+        "description": "Option description"
+    },
     "optionYtMusicRecognisedOnly": {
         "message": "Scrobble only videos that are recognised by YouTube Music as music",
         "description": "Option label"

--- a/src/connectors/youtube-music.ts
+++ b/src/connectors/youtube-music.ts
@@ -21,12 +21,17 @@ export {};
  */
 
 const adSelector = '.ytmusic-player-bar.advertisement';
+
 let scrobbleAllArtists = false;
+let ignoreDeviceTransferMetadata = true;
 
 // read option to enable / disable scrobbling by first artist
 async function readConnectorOptions() {
 	if (await Util.getOption('youtube-music', 'scrobbleAllArtists')) {
 		scrobbleAllArtists = true;
+	}
+	if (await Util.getOption('youtube-music', 'ignoreDeviceTransferMetadata')) {
+		ignoreDeviceTransferMetadata = true;
 	}
 }
 
@@ -77,6 +82,21 @@ function getCleanArtist(rawArtist: string | undefined): string {
 		.replace(/\s+/g, ' ')
 		.replace(/&nbsp;/g, ' ');
 
+	if (ignoreDeviceTransferMetadata) {
+		// reject invalid YTM device transfer metadata
+		const invalidArtistPatterns = [
+			/^from your .* device$/i,
+			/^casting$/i,
+			/^connecting$/i,
+			/^youtube music$/i,
+		];
+		for (const pattern of invalidArtistPatterns) {
+			if (pattern.test(artist)) {
+				return '';
+			}
+		}
+	}
+
 	// return early if scrobbling only first artist
 	if (scrobbleAllArtists) {
 		return artist;
@@ -110,6 +130,14 @@ Connector.getArtistTrack = () => {
 			artist = getCleanArtist(artist);
 		}
 	}
+
+	if (ignoreDeviceTransferMetadata) {
+		// prevent temporary invalid metadata states
+		if (!artist || !track) {
+			return null;
+		}
+	}
+
 	return { artist, track };
 };
 

--- a/src/connectors/youtube-music.ts
+++ b/src/connectors/youtube-music.ts
@@ -56,18 +56,38 @@ Connector.getTrackArt = () => {
 	return artworks?.[artworks.length - 1].src;
 };
 
+// BETTER ARTIST PARSER - FIXES MISSING ANCHOR TAGS FOR ARTISTS
+function getCleanArtist(rawArtist: string | undefined): string {
+	if (!rawArtist) return '';
+
+	// trim leading / trailing spaces of an artist name, and replace misc whitespace
+	// 	   (e.g. double spaces) with a single space
+	let artist = rawArtist.trim()
+		.replace(/\s+/g, ' ')
+		.replace(/&nbsp;/g, ' ');
+
+	const splitters = /[,/&]|feat\.?|ft\.?|featuring| x | vs | with | x /i;
+	const parts = artist.split(splitters).map(p => p.trim()).filter(Boolean);
+
+	// only return the first artist
+	return parts[0] || artist;
+}
+
 Connector.getArtistTrack = () => {
 	let artist;
 	let track;
 	const metadata = mediaInfo.metadata;
 
 	if (metadata?.album) {
-		artist = metadata.artist;
+		// use new method to 'clean' the artist data
+		artist = getCleanArtist(metadata.artist);
 		track = metadata.title;
 	} else {
 		({ artist, track } = Util.processYtVideoTitle(metadata?.title));
 		if (!artist) {
-			artist = metadata?.artist;
+			artist = getCleanArtist(metadata?.artist);
+		} else {
+			artist = getCleanArtist(artist);
 		}
 	}
 	return { artist, track };

--- a/src/connectors/youtube-music.ts
+++ b/src/connectors/youtube-music.ts
@@ -21,6 +21,16 @@ export {};
  */
 
 const adSelector = '.ytmusic-player-bar.advertisement';
+let scrobbleAllArtists = false;
+
+// read option to enable / disable scrobbling by first artist
+async function readConnectorOptions() {
+	if (await Util.getOption('youtube-music', 'scrobbleAllArtists')) {
+		scrobbleAllArtists = true;
+	}
+}
+
+void readConnectorOptions();
 
 const mediaInfo = {
 	playbackState: 'none',
@@ -62,12 +72,22 @@ function getCleanArtist(rawArtist: string | undefined): string {
 
 	// trim leading / trailing spaces of an artist name, and replace misc whitespace
 	// 	   (e.g. double spaces) with a single space
-	let artist = rawArtist.trim()
+	const artist = rawArtist
+		.trim()
 		.replace(/\s+/g, ' ')
 		.replace(/&nbsp;/g, ' ');
 
+	// return early if scrobbling only first artist
+	if (scrobbleAllArtists) {
+		return artist;
+	}
+
+	// continue with splitting artist string at common splitters
 	const splitters = /[,/&]|feat\.?|ft\.?|featuring| x | vs | with | x /i;
-	const parts = artist.split(splitters).map(p => p.trim()).filter(Boolean);
+	const parts = artist
+		.split(splitters)
+		.map((p) => p.trim())
+		.filter(Boolean);
 
 	// only return the first artist
 	return parts[0] || artist;

--- a/src/core/storage/options.ts
+++ b/src/core/storage/options.ts
@@ -141,6 +141,7 @@ export interface ConnectorOptions {
 	};
 	'youtube-music': {
 		scrobbleAllArtists: boolean;
+		ignoreDeviceTransferMetadata: boolean;
 	};
 }
 
@@ -156,6 +157,7 @@ const DEFAULT_CONNECTOR_OPTIONS: ConnectorOptions = {
 	},
 	'youtube-music': {
 		scrobbleAllArtists: true,
+		ignoreDeviceTransferMetadata: true,
 	},
 };
 

--- a/src/core/storage/options.ts
+++ b/src/core/storage/options.ts
@@ -139,6 +139,9 @@ export interface ConnectorOptions {
 		scrobbleMusicRecognisedOnly: boolean;
 		enableGetTrackInfoFromYtMusic: boolean;
 	};
+	'youtube-music': {
+		scrobbleAllArtists: boolean;
+	};
 }
 
 /**
@@ -150,6 +153,9 @@ const DEFAULT_CONNECTOR_OPTIONS: ConnectorOptions = {
 		scrobbleEntertainmentOnly: false,
 		scrobbleMusicRecognisedOnly: false,
 		enableGetTrackInfoFromYtMusic: false,
+	},
+	'youtube-music': {
+		scrobbleAllArtists: true,
 	},
 };
 

--- a/src/ui/options/components/options/connector-options.tsx
+++ b/src/ui/options/components/options/connector-options.tsx
@@ -69,6 +69,15 @@ export default function ConnectorOptionsList() {
 					connector="youtube-music"
 					key="scrobbleAllArtists"
 				/>
+				<ConnectorOptionEntry
+					options={options}
+					setOptions={setOptions}
+					connectorOptions={connectorOptions}
+					i18ntitle="optionYtMusicIgnoreDeviceTransferTitle"
+					i18nlabel="optionYtMusicIgnoreDeviceTransfer"
+					connector="youtube-music"
+					key="ignoreDeviceTransferMetadata"
+				/>
 				<li class={styles.muted}>{t('optionYtMusicAllArtistsDesc')}</li>
 			</ul>
 		</>

--- a/src/ui/options/components/options/connector-options.tsx
+++ b/src/ui/options/components/options/connector-options.tsx
@@ -58,6 +58,19 @@ export default function ConnectorOptionsList() {
 				/>
 				<li class={styles.muted}>{t('optionYtDesc')}</li>
 			</ul>
+			<h2>YouTube Music</h2>
+			<ul class={styles.optionList}>
+				<ConnectorOptionEntry
+					options={options}
+					setOptions={setOptions}
+					connectorOptions={connectorOptions}
+					i18ntitle="optionYtMusicAllArtistsTitle"
+					i18nlabel="optionYtMusicAllArtists"
+					connector="youtube-music"
+					key="scrobbleAllArtists"
+				/>
+				<li class={styles.muted}>{t('optionYtMusicAllArtistsDesc')}</li>
+			</ul>
 		</>
 	);
 }


### PR DESCRIPTION
<!-- 
  Thank you for taking the time to contribute to this project!

  Make sure to check out our guide on contributing with guidelines of how to contribute.

  See: https://github.com/web-scrobbler/web-scrobbler/blob/master/.github/CONTRIBUTING.md

--> 

**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
Fixes issue where song does not scrobble correctly on Youtube Music when multiple artists are present on a song, and none are enclosed in anchor tags. When scrobbling, a choice has been added to only scrobble by the first artist in the case that a user doesn't want songs to double up on last.fm.

**Additional context**
<!-- Add any other context or screenshots here. -->
This is a second pull request for this feature. After the prior, I was given feedback to make this setting an option so that users still have the choice to scrobble by ALL artists of a song. This feedback was implemented in this version. 

Please give more feedback if you feel it is necessary!

The old PR: bcff249aa4f01b195ae937293324bb02d125b0e8