### PR TITLE
Added extra nullcheck to prevent toString error

### DIFF
--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -934,6 +934,11 @@ export default class Controller {
 			return;
 		}
 
+		// we check if this.currentSong is not null again to prevent toString errors from calling null.toString(); 
+		if (!assertSongNotNull(this.currentSong)) {
+			return;
+		}
+		
 		this.debugLog(
 			`Song finished processing: ${this.currentSong.toString()}`,
 		);


### PR DESCRIPTION
Added null check for currentSong to prevent toString errors.


**Describe the changes you made**
 Added an extra nullcheck to prevent toString errors from calling toString() on null. 
    
**Additional context**
after title gets parsed it returns null ending up in a toString error. 
https://github.com/web-scrobbler/web-scrobbler/issues/6057#issuecomment-4490720990