### PR TITLE
Update Bandcamp Daily connector

### DIFF
--- a/src/connectors/bandcamp-daily.ts
+++ b/src/connectors/bandcamp-daily.ts
@@ -1,6 +1,11 @@
 export {};
 
 const nowPlaying = '#p-now-playing';
+const filter = MetadataFilter.createFilter({
+	artist: MetadataFilter.replaceSmartQuotes,
+	track: MetadataFilter.replaceSmartQuotes,
+	album: MetadataFilter.replaceSmartQuotes,
+});
 
 Connector.playerSelector = '#p-daily-article';
 
@@ -29,3 +34,5 @@ Connector.durationSelector =
 	'.mplayer.playing .mptime [data-bind$=durationStr]';
 
 Connector.isPlaying = () => Util.hasElementClass('.mplayer', 'playing');
+
+Connector.applyFilter(filter);

--- a/src/connectors/bandcamp-daily.ts
+++ b/src/connectors/bandcamp-daily.ts
@@ -1,24 +1,31 @@
 export {};
 
-/**
- * This connector supports Bandcamp embedded player.
- * Currently used for Bandcamp Daily.
- */
+const nowPlaying = '#p-now-playing';
 
 Connector.playerSelector = '#p-daily-article';
 
-Connector.artistSelector = '.player.playing .mpartist';
+Connector.artistSelector = `${nowPlaying} .albumtitle > span`;
 
-Connector.trackSelector = '.player.playing .mptracktitle';
+Connector.trackSelector = `${nowPlaying} .trackname > span:last-of-type`;
 
-Connector.albumSelector = '.player.playing .mptralbum';
+Connector.albumSelector = `${nowPlaying} .albumtitle > b`;
 
-Connector.currentTimeSelector = '.player.playing .mptime > span:first-child';
+Connector.getTrackArt = () => {
+	const trackArtUrl = Util.extractImageUrlFromSelectors(
+		`${nowPlaying} .art-text > img`,
+	);
 
-Connector.durationSelector = '.player.playing .mptime > span:last-child';
+	if (trackArtUrl) {
+		return trackArtUrl.replace(/(?<=_)\d{1,2}(?=\.jpg)/, '16'); // larger image
+	}
 
-Connector.trackArtSelector = '.player.playing .mpaa img';
+	return null;
+};
 
-Connector.isPlaying = () => Boolean(document.querySelector('.player.playing'));
+Connector.currentTimeSelector =
+	'.mplayer.playing .mptime [data-bind$=positionStr]';
 
-Connector.getOriginUrl = () => Util.getOriginUrl('.player.playing a.buy-now');
+Connector.durationSelector =
+	'.mplayer.playing .mptime [data-bind$=durationStr]';
+
+Connector.isPlaying = () => Util.hasElementClass('.mplayer', 'playing');


### PR DESCRIPTION
**Describe the changes you made**
Bandcamp Daily was previously confused with Bandcamp embeds, but the section now has its own player that is not embedded, and embeds also now have a separate connector.
Updated the connector to pull most metadata from the persistent "NOW PLAYING" box, which now allows pausing a playing track without setting the connector state to empty. This means that pausing won't cause a scrobble to restart when unpaused and potentially be missed or repeated.
Current time and duration still come from the active player because they are not provided in the "NOW PLAYING" box.
Origin URL override has been removed because it is not needed.
Test from https://daily.bandcamp.com/