### PR TITLE
Fix Poolsuite metadata parsing for most common track formats

### DIFF
--- a/src/connectors/poolsuite.ts
+++ b/src/connectors/poolsuite.ts
@@ -1,5 +1,18 @@
 export {};
 
 Connector.playerSelector = 'body';
-Connector.useMediaSessionApi();
 Connector.useTabAudibleApi();
+
+Connector.getArtistTrack = () => {
+  const title = navigator.mediaSession.metadata?.title ?? '';
+  const artist = navigator.mediaSession.metadata?.artist ?? '';
+
+  if (title === 'Poolsuite ON AIR') {
+    const text = document.querySelector('h2.font-everyday')?.textContent ?? '';
+    return Util.processSoundCloudTrack(text);
+  }
+
+  const result = Util.processSoundCloudTrack(title);
+  if (result.artist && result.track) return result;
+  return { artist, track: title };
+};

--- a/src/connectors/poolsuite.ts
+++ b/src/connectors/poolsuite.ts
@@ -4,15 +4,18 @@ Connector.playerSelector = 'body';
 Connector.useTabAudibleApi();
 
 Connector.getArtistTrack = () => {
-  const title = navigator.mediaSession.metadata?.title ?? '';
-  const artist = navigator.mediaSession.metadata?.artist ?? '';
+	const title = navigator.mediaSession.metadata?.title ?? '';
+	const artist = navigator.mediaSession.metadata?.artist ?? '';
 
-  if (title === 'Poolsuite ON AIR') {
-    const text = document.querySelector('h2.font-everyday')?.textContent ?? '';
-    return Util.processSoundCloudTrack(text);
-  }
+	if (title === 'Poolsuite ON AIR') {
+		const text =
+			document.querySelector('h2.font-everyday')?.textContent ?? '';
+		return Util.processSoundCloudTrack(text);
+	}
 
-  const result = Util.processSoundCloudTrack(title);
-  if (result.artist && result.track) return result;
-  return { artist, track: title };
+	const result = Util.processSoundCloudTrack(title);
+	if (result.artist && result.track) {
+		return result;
+	}
+	return { artist, track: title };
 };


### PR DESCRIPTION
## Describe the changes you made

Updates the Poolsuite connector to correctly parse artist and track metadata across the three most common track formats the site uses.

### 1. Hyphenated titles: Splits on the dash using `Util.processSoundCloudTrack`

<img width="623" height="182" alt="poolsuite-hyphenated" src="https://github.com/user-attachments/assets/e75554cb-8d62-4889-bb9b-230df8066f89" />
<img width="483" height="129" alt="scrobbler-hyphenated" src="https://github.com/user-attachments/assets/7a797a30-fb75-4d3b-9357-224541d1dece" />

### 2. Standard titles: Falls back to `MediaSession` artist and title fields directly

<img width="625" height="181" alt="poolsuite-standard" src="https://github.com/user-attachments/assets/ba494d0f-f7cd-401d-80f4-d6d26c148a79" />
<img width="391" height="132" alt="scrobbler-standard" src="https://github.com/user-attachments/assets/08cc03ba-763f-4ef1-8786-f5a7dd594459" />

### 3. Live station a.k.a. "Poolsuite ON AIR": `MediaSession` contains no useful track data, so artist/track is scraped from the DOM

<img width="619" height="180" alt="poolsuite-live" src="https://github.com/user-attachments/assets/bde4babd-a164-4199-956f-e293b5b90f67" />
<img width="402" height="144" alt="scrobbler-live" src="https://github.com/user-attachments/assets/fe39c88d-b9ce-409e-969e-fc2ec020076e" />

## Additional context

Poolsuite was broken entirely until my earlier PR #5981 (released in v3.22.0), which restored playback detection using `useMediaSessionApi()`. However, that approach mapped metadata sub-optimally. The full `Artist - Track` string was coming in as the track title, and the Soundcloud username came in as the artist.

This PR replaces `useMediaSessionApi()` with a custom `getArtistTrack` implementation that handles the three primary formats Poolsuite uses, leveraging the existing `Util.processSoundCloudTrack` utility since Poolsuite streams SoundCloud content.