### PR TITLE
Fix Mixcloud connector

### DIFF
--- a/src/connectors/mixcloud.ts
+++ b/src/connectors/mixcloud.ts
@@ -1,8 +1,8 @@
 export {};
 
 const playerSelector = '[data-testid=player-container]';
-const artistSelector = '[class*=styles__Artist-]';
-const trackSelector = '[class*=styles__Track-]';
+const artistSelector = `${playerSelector} p + div > div:last-of-type > div:last-of-type`;
+const trackSelector = `${playerSelector} p + div > div:last-of-type > div:first-of-type`;
 const filter = MetadataFilter.createFilter({
 	artist: [removeByPrefix, removeBuySuffix],
 });


### PR DESCRIPTION
**Describe the changes you made**
An update to the Mixcloud connector (#6045) just went out in the last release, but apparently they have since removed the classes that were used to capture the artist and track information when provided. As a result, the connector is unable to get that info and considers everything playing on Mixcloud to be a podcast.
Updated the selectors for artist/track to get to the correct nested divs without classes.

**Additional context**
Resolves #6095. Here is the show they were trying to play: https://www.mixcloud.com/SelectorRadio/earth-day-2026-shivani-sen-papaoul-baobei-1-may-2026/
