### PR TITLE
Add Bandcamp playlist page support (music.playlist)

### DIFF
--- a/src/connectors/bandcamp.ts
+++ b/src/connectors/bandcamp.ts
@@ -84,6 +84,9 @@ function setupDesktopConnector() {
 	} else if (isDiscoverPage()) {
 		Util.debugLog('Init props for discover player');
 		initPropertiesForDiscoverPlayer();
+	} else if (isPlaylistPage()) {
+		Util.debugLog('Init props for playlist player');
+		initPropertiesForPlaylistPlayer();
 	} else {
 		Util.debugLog('Init props for home page');
 
@@ -235,6 +238,44 @@ function initPropertiesForFeedPlayer() {
 	Connector.getOriginUrl = () => Util.getOriginUrl('.playing .buy-now a');
 }
 
+// Example: https://bandcamp.com/%USERNAME%/playlist/%PLAYLISTNAME%
+// Selector approach for the new player informed by #5736 (@adam-blackwater).
+function initPropertiesForPlaylistPlayer() {
+	bandcampFilter = bandcampFilter.extend(
+		MetadataFilter.createFilter({
+			artist: [removeByPrefix],
+		}),
+	);
+
+	// Track metadata lives on the currently-playing list item; play state and
+	// the track id/duration live on the persistent floating player bar.
+	const playerContext = '.track-list-item.currently-playing ';
+	const trackMeta = '.floating-player .track-meta';
+
+	Connector.playerSelector = '.floating-player';
+
+	Connector.artistSelector = `${playerContext} .artist-name`;
+	Connector.trackSelector = `${playerContext} .title-text`;
+	Connector.albumSelector = `${playerContext} .album-title > strong`;
+	Connector.trackArtSelector = `${playerContext} .g-image`;
+
+	Connector.isPlaying = () =>
+		document
+			.querySelector('.floating-player .play-pause-button')
+			?.getAttribute('aria-label') === 'Pause';
+
+	// `.track-meta` carries the numeric track id and duration (in seconds).
+	Connector.getUniqueID = () =>
+		document.querySelector(trackMeta)?.getAttribute('id') ?? null;
+
+	Connector.getDuration = () => {
+		const duration = document
+			.querySelector(trackMeta)
+			?.getAttribute('duration');
+		return duration ? parseFloat(duration) : null;
+	};
+}
+
 // Example: https://bandcamp.com/?show=47
 function initPropertiesForHomePage() {
 	/*
@@ -309,6 +350,10 @@ function isCollectionsPage() {
 function isDiscoverPage() {
 	const url = new URL(document.location.href);
 	return url.pathname.startsWith('/discover');
+}
+
+function isPlaylistPage() {
+	return getPageType() === 'music.playlist';
 }
 
 function getTrackNodes() {


### PR DESCRIPTION
**Describe the changes you made**

Adds scrobbling for Bandcamp playlist pages (`bandcamp.com/<user>/playlist/<name>`, `og:type=music.playlist`), which currently don't scrobble at all.

These pages use Bandcamp's floating player, but their now-playing metadata isn't under the selectors the existing connector expects, so the connector never finds a player to watch. This adds a dedicated `isPlaylistPage()` dispatch branch that:

* watches `.floating-player` (the element always present while a track plays)
* reads artist, track, album, and art from the `.track-list-item.currently-playing` item
* reads the track id and duration from `.track-meta`
* detects play state from the `.play-pause-button` `aria-label`

fixes #5347.
fixes #6161

**Additional context**

Tested in Firefox on a playlist page: now-playing updates, the correct Last.fm release is matched, full scrobbles land, and tracks continue to scrobble as the playlist advances. Normal album pages and the feed connector are unaffected.

Selector approach for the new player informed by #5736 (@adam-blackwater).
