### PR TITLE
Fix Meloradio connector

### DIFF
--- a/src/connectors/meloradio.ts
+++ b/src/connectors/meloradio.ts
@@ -2,9 +2,9 @@ export {};
 
 Connector.playerSelector = '#player';
 
-Connector.artistSelector = '#player .player__top__text__line--1';
+Connector.artistSelector = '#player .player__rds__desc';
 
-Connector.trackSelector = '#player .player__top__text__line--2';
+Connector.trackSelector = '#player .player__rds__title';
 
 Connector.trackArtSelector = '#player .player__rds__image img';
 


### PR DESCRIPTION
**Describe the changes you made**
Updated selectors to select song info instead of the audition name.

**Additional context**
Previous selector was too generic and was applying for both the on air audition name and the current song, because of that audition name was being chosen as it is first.

<img width="1636" height="923" alt="screenshot" src="https://github.com/user-attachments/assets/9137ed81-4d70-4c84-870c-27b1419a565b" />

