### PR TITLE
Fix scrobbler API failure handling

### DIFF
--- a/src/core/object/scrobble-service.ts
+++ b/src/core/object/scrobble-service.ts
@@ -57,6 +57,22 @@ function isScrobblerInArray(scrobbler: Scrobbler, array: Scrobbler[]) {
 	});
 }
 
+type ServiceErrorResult =
+	| ServiceCallResult.ERROR_AUTH
+	| ServiceCallResult.ERROR_OTHER;
+
+function getServiceErrorResult(result: unknown): ServiceErrorResult {
+	const value = result instanceof Error ? result.message : result;
+	if (
+		value === ServiceCallResult.ERROR_OTHER ||
+		value === ServiceCallResult.ERROR_AUTH
+	) {
+		return value;
+	}
+
+	throw new Error(`Invalid result: ${String(value)}`);
+}
+
 class ScrobbleService {
 	/**
 	 * Scrobblers that are bound, meaning they have valid session IDs.
@@ -244,7 +260,8 @@ class ScrobbleService {
 				} catch (result) {
 					return this.processScrobbleErrorResult(
 						scrobbler,
-						result as ServiceCallResult[],
+						result,
+						songs.length,
 					);
 				}
 			}),
@@ -321,14 +338,10 @@ class ScrobbleService {
 	 */
 	async processErrorResult(
 		scrobbler: Scrobbler,
-		result: ServiceCallResult,
+		result: unknown,
 	): Promise<ServiceCallResult> {
-		const isOtherError = result === ServiceCallResult.ERROR_OTHER;
-		const isAuthError = result === ServiceCallResult.ERROR_AUTH;
-
-		if (!(isOtherError || isAuthError)) {
-			throw new Error(`Invalid result: ${result}`);
-		}
+		const errorResult = getServiceErrorResult(result);
+		const isAuthError = errorResult === ServiceCallResult.ERROR_AUTH;
 
 		if (isAuthError) {
 			// Don't unbind scrobblers which have tokens
@@ -339,7 +352,7 @@ class ScrobbleService {
 		}
 
 		// Forward result
-		return result;
+		return errorResult;
 	}
 
 	/**
@@ -351,14 +364,15 @@ class ScrobbleService {
 	 */
 	async processScrobbleErrorResult(
 		scrobbler: Scrobbler,
-		result: ServiceCallResult[],
+		result: unknown,
+		songCount: number,
 	): Promise<ServiceCallResult[]> {
-		const isOtherError = result[0] === ServiceCallResult.ERROR_OTHER;
-		const isAuthError = result[0] === ServiceCallResult.ERROR_AUTH;
-
-		if (!(isOtherError || isAuthError)) {
-			throw new Error(`Invalid result: ${result[0]}`);
-		}
+		const results = Array.isArray(result)
+			? result.map(getServiceErrorResult)
+			: new Array<ServiceErrorResult>(Math.min(songCount, 50)).fill(
+					getServiceErrorResult(result),
+				);
+		const isAuthError = results.includes(ServiceCallResult.ERROR_AUTH);
 
 		if (isAuthError) {
 			// Don't unbind scrobblers which have tokens
@@ -369,7 +383,7 @@ class ScrobbleService {
 		}
 
 		// Forward result
-		return result;
+		return results;
 	}
 }
 

--- a/tests/background/scrobble-service.test.ts
+++ b/tests/background/scrobble-service.test.ts
@@ -1,0 +1,84 @@
+import '#/mocks/webextension-polyfill';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/util/communication', () => ({
+	backgroundListener: (listener: unknown) => listener,
+	sendBackgroundMessage: vi.fn(),
+	sendContentMessage: vi.fn(),
+	setupBackgroundListeners: vi.fn(),
+}));
+
+import scrobbleService from '@/core/object/scrobble-service';
+import { ServiceCallResult } from '@/core/object/service-call-result';
+import Song from '@/core/object/song';
+import scrobbleCache from '@/core/storage/scrobble-cache';
+import { ScrobbleStatus } from '@/core/storage/wrapper';
+
+const connector = {
+	id: 'test',
+	js: 'test.js',
+	label: 'Test',
+	matches: ['https://example.com/*'],
+};
+
+function createSong() {
+	return new Song(
+		{
+			album: null,
+			albumArtist: null,
+			artist: 'Artist',
+			currentTime: 30,
+			duration: 180,
+			isPlaying: true,
+			isPodcast: false,
+			originUrl: 'https://example.com/track',
+			track: 'Track',
+			trackArt: null,
+			uniqueID: null,
+		},
+		connector,
+	);
+}
+
+describe('ScrobbleService API failures', () => {
+	const scrobbler = scrobbleService.getScrobblerByLabel('Last.fm');
+
+	if (!scrobbler) {
+		throw new Error('Last.fm scrobbler is not registered');
+	}
+
+	afterEach(() => {
+		scrobbleService.unbindScrobbler(scrobbler);
+		vi.restoreAllMocks();
+	});
+
+	it('returns an error result when now-playing rejects with an Error', async () => {
+		scrobbleService.bindScrobbler(scrobbler);
+		vi.spyOn(scrobbler, 'sendNowPlaying').mockRejectedValue(
+			new Error(ServiceCallResult.ERROR_OTHER),
+		);
+
+		await expect(
+			scrobbleService.sendNowPlaying(createSong()),
+		).resolves.toEqual([ServiceCallResult.ERROR_OTHER]);
+	});
+
+	it('caches a failed scrobble when the API rejects with an Error', async () => {
+		const song = createSong();
+		scrobbleService.bindScrobbler(scrobbler);
+		vi.spyOn(scrobbler, 'scrobble').mockRejectedValue(
+			new Error(ServiceCallResult.ERROR_OTHER),
+		);
+		const cacheSpy = vi
+			.spyOn(scrobbleCache, 'pushScrobble')
+			.mockResolvedValue(1);
+
+		await expect(scrobbleService.scrobble([song], true)).resolves.toEqual([
+			[ServiceCallResult.ERROR_OTHER],
+		]);
+		expect(cacheSpy).toHaveBeenCalledWith({
+			song: song.getCloneableData(),
+			status: ScrobbleStatus.ERROR,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- normalize rejected scrobbler `Error` objects back to their `ServiceCallResult`
- preserve failed scrobble results so they are recorded in the scrobble cache
- add regressions for now-playing and scrobble API failures

## Root cause

Scrobbler clients reject network failures as `Error` objects whose messages contain
`error-other` or `error-auth`. `ScrobbleService` cast those objects directly to the
result enum (or result array), so its error handlers rejected again with
`Invalid result` instead of returning a controlled service failure.

Fixes #6038

## Validation

- `npx vitest run tests/background/scrobble-service.test.ts`
- `npm run lint`
- `npm run checkts`
- `npm test -- --run` (2086 tests)
- `npm run build chrome`
- `npm run build firefox`
- `git diff --check`

## AI assistance

OpenAI Codex assisted with issue investigation, implementation, regression tests,
and validation. I reviewed the final diff and test results before submission.
