### PR TITLE
Fix Radio Nova connector against the current player

### DIFF
--- a/src/connectors/nova.ts
+++ b/src/connectors/nova.ts
@@ -1,10 +1,8 @@
 export {};
 
-Connector.playerSelector = '.player';
+Connector.playerSelector = '#audio_player';
 
-Connector.artistSelector = `${Connector.playerSelector} .artiste`;
+Connector.isPlaying = () => Util.isElementVisible('#player-pause-btn');
 
-Connector.trackSelector = `${Connector.playerSelector} .titre`;
-
-Connector.isPlaying = () =>
-	Util.hasElementClass('#jp_container_1', 'jp-state-playing');
+Connector.getArtistTrack = () =>
+	Util.splitArtistTrack(Util.getTextFromSelectors('.current-track.title'));


### PR DESCRIPTION
**Describe the changes you made**

Fixes #6140

Rewrites the Radio Nova connector against the player `nova.fr` runs today. 
The old selectors targeted a jPlayer-based player the site dropped, so `isPlaying()` returned `false` at all times and the connector submitted no track.

- `playerSelector` now points at `#audio_player`, the current player container.
- `isPlaying` reads the visibility of `#player-pause-btn`.  
  The player flips the `display` of a play and a pause image, so the pause image shows exactly while a stream plays.
- `getArtistTrack` splits `.current-track.title`, which holds the track as `ARTIST - TITLE`.  
  `defaultSeparators` already covers that ` - `, so the call passes no separator.
- Drops `artistSelector` and `trackSelector`, whose nodes no longer exist.

**Additional context**

The site runs a Dailymotion-backed player and puts no `<audio>` or `<video>` element in the DOM, so no media element can report playback state. `radiofrance.ts` solves the same problem by reading the controls, and this follows it.

I ran a local Firefox build with this connector on top of the DOM checks in #6140.
The extension reports now-playing and scrobbles, neither of which it did before.

I left `getTrackArt` out. `#player-image` holds a plain `<img>` rather than a `background-image`, and it keeps showing the station logo during playback instead of per-track art.

All Nova streams (`radio-nova`, `nova-hip-hop`, and the rest) share this player, so this covers the whole `*://www.nova.fr/*` match.
