### PR TITLE
Update the VocaDB connector to gracefully handle blank playlists

### DIFF
--- a/src/connectors/vocadb.ts
+++ b/src/connectors/vocadb.ts
@@ -48,10 +48,14 @@ Connector.playButtonSelector = '.css-1lc7lii button[title="Play"]';
 
 Connector.getDuration = () => {
 	const store = getPlayQueueStore();
-	const current = store.items[store.currentIndex];
-	return current.entry.pvs[0].length;
+	const current = store?.items[store.currentIndex];
+	return current?.entry.pvs[0].length;
 };
 
 function getPlayQueueStore() {
+	if (!localStorage.PlayQueueStore) {
+		return null;
+	}
+
 	return JSON.parse(localStorage.PlayQueueStore);
 }


### PR DESCRIPTION
**Describe the changes you made**
If the player has not been used yet or the playlist was previously empty, Web Scrobbler would fail to initialize because of JavaScript errors and would not detect playing music.

> SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data
> TypeError: can't access property "entry", current is undefined

Somehow, I missed this in my previous tests and I apologize for my lack of attention and the inconvenience caused to the maintainers and users.

I have now verified operation starting from a clean browser session (PlayQueueStore has not been initialized) and starting from a blank playlist.