### PR TITLE
fix(listen.moe): update connector for redesigned site layout

### DIFF
--- a/src/connectors/listen.moe.ts
+++ b/src/connectors/listen.moe.ts
@@ -13,16 +13,29 @@ const filterRules = [
 	{ source: /\s+/g, target: ' ' },
 ];
 
-Connector.playerSelector = '#app';
+Connector.playerSelector = '.glass';
 
-Connector.artistSelector = '.player-song-artist';
+Connector.artistSelector = '.glass .text-xs';
 
-Connector.trackSelector = '.player-song-title';
-
-Connector.isPlaying = () => {
-	return !(document.querySelector('#audio-player') as HTMLAudioElement)
-		.paused;
+Connector.getTrack = () => {
+	const element = document.querySelector('.glass .font-semibold');
+	if (!element) {
+		return null;
+	}
+	let text = '';
+	for (const node of element.childNodes) {
+		if (node.nodeType === Node.TEXT_NODE) {
+			text += node.textContent;
+		} else {
+			break;
+		}
+	}
+	return text;
 };
+
+// Pause icon (<rect> elements) visible = playing. The site has no
+// <audio> element (playback via Web Audio API).
+Connector.pauseButtonSelector = '.glass button.rounded-full:has(svg rect)';
 
 Connector.applyFilter(filter);
 


### PR DESCRIPTION
The listen.moe website has been redesigned and the old selectors no longer work.

### Changes
- **playerSelector**: changed from #app to .glass
- **artistSelector**: changed from .player-song-artist to .glass .text-xs (artist now uses 	ext-xs class, while the source link uses 	ext-sm)
- **getTrack**: custom function that extracts only the direct text node, ignoring the nested source link inside the title
- **pauseButtonSelector**: replaces the old isPlaying that relied on the now-removed #audio-player element

### Testing
- Verified the connector loads without type errors
- Track name no longer includes the source text
- Artist is correctly extracted