### PR TITLE
Fix qobuz.ts Connector

### DIFF
--- a/src/connectors/qobuz.ts
+++ b/src/connectors/qobuz.ts
@@ -5,7 +5,7 @@ const timeInfoSelector = '.player__track-time-content';
 
 Connector.playerSelector = '.player';
 
-Connector.trackSelector = '.player__track-title';
+Connector.trackSelector = '.player__track-overflow';
 
 Connector.albumSelector = '.player__track-album > a:nth-of-type(2)';
 

--- a/src/connectors/qobuz.ts
+++ b/src/connectors/qobuz.ts
@@ -3,7 +3,7 @@ export {};
 const artistSelector = '.player__track-album [href*=artist]';
 const timeInfoSelector = '.player__track-time-content';
 
-Connector.playerSelector = '.player';
+Connector.playerSelector = '.ui-layout--root--panel-bottom';
 
 Connector.trackSelector = '.player__track-overflow';
 


### PR DESCRIPTION
<!-- 
  Thank you for taking the time to contribute to this project!

  Make sure to check out our guide on contributing with guidelines of how to contribute.

  See: https://github.com/web-scrobbler/web-scrobbler/blob/master/.github/CONTRIBUTING.md

--> 

**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
They updated the app so that the track title is nestled in a few more divs, so the class name of the TrackSelector changed.

Also apparently the .player element gets thrown away when you select a new track on the homepage, so moving the playerSelector up one element fixed it. 

Tested on Edge and working. I of course do not know if this new player is a slow rollout and some people might still have the old player? I suspect not though. 

**Additional context**
<!-- Add any other context or screenshots here. -->
