### PR TITLE
Refine the VocaDB connector

### DIFF
--- a/src/connectors/vocadb.ts
+++ b/src/connectors/vocadb.ts
@@ -71,7 +71,7 @@ interface Pv {
 	id: number;
 	length: number;
 	url: string;
-};
+}
 
 Connector.getTrackInfo = () => {
 	const store = getPlayQueueStore();

--- a/src/connectors/vocadb.ts
+++ b/src/connectors/vocadb.ts
@@ -24,7 +24,7 @@ function cleanupArtist(artist: string) {
 						.replace(/Megpoid/, 'GUMI')
 						.replace(/\s\([^()]+\)/g, '')
 						.replace(
-							/\s?\b(Synthesizer V|Synthesizer V)( 2)?( Plus| AI)?\b\s?/g,
+							/\s?\bSynthesizer V( 2)?( Plus| AI)?\b\s?/g,
 							'',
 						)
 						.replace(/^(AI|V\d+X?)\b\s?/g, '')
@@ -73,6 +73,8 @@ interface Pv {
 	url: string;
 }
 
+Connector.getOriginUrl = () => undefined;
+
 Connector.getTrackInfo = () => {
 	const store = getPlayQueueStore();
 	const current = store?.items[store.currentIndex];
@@ -85,7 +87,9 @@ Connector.getTrackInfo = () => {
 		artist: current?.entry.artistString,
 		uniqueID: current?.entry.id,
 		duration: currentPv?.length,
-		currentTime: (currentPv?.length || 0) * getPercentage(),
+		currentTime: currentPv?.length
+			? currentPv.length * getPercentage()
+			: null,
 		trackArt: current?.entry.urlThumb,
 		originUrl: currentPv?.url,
 	};

--- a/src/connectors/vocadb.ts
+++ b/src/connectors/vocadb.ts
@@ -13,21 +13,26 @@ function cleanupArtist(artist: string) {
 				const feat = match.split(', ');
 				for (let i = 0; i < feat.length; i++) {
 					feat[i] = feat[i]
-						.replace(/\s+\([^()]+\)/g, '')
 						.replace(
-							/(\s(V\d+X?|Append|English|AI|NT|Sugar|Spicy|ROCKS|2S|Standard|II|TALK)\b.*)+$/gi,
+							/^(結月ゆかり|音街ウナ|星尘|桜乃そら|重音テト|波音リツ).+$/,
+							'$1',
+						)
+						.replace(/^(VY\d)V\d/, '$1')
+						.replace(/^(IA) .+$/, '$1')
+						.replace(/^.+ (flower)$/, '$1')
+						.replace(/^遙$/, '夏語遙')
+						.replace(/Megpoid/, 'GUMI')
+						.replace(/\s\([^()]+\)/g, '')
+						.replace(
+							/\s?\b(Synthesizer V|Synthesizer V)( 2)?( Plus| AI)?\b\s?/g,
 							'',
 						)
-						.replace(/\s(ナチュラル|クール)$/gi, '')
-						.replace(/^(AI|V\d+X?)+\s/gi, '')
-						.replace(/^(VY\d+)V\d+\b/, '$1')
-						.replace(/^結月ゆかり.+$/, '結月ゆかり')
-						.replace(/^波音リツキレ$/, '波音リツ')
-						.replace(/^星尘Infinity$/, '星尘')
-						.replace(/^重音テトSV$/, '重音テト')
-						.replace(/^遙$/, '夏語遙')
-						.replace(/^v flower|v4 flower|Ci flower$/, 'flower')
-						.trim();
+						.replace(/^(AI|V\d+X?)\b\s?/g, '')
+						.replace(
+							/\s?\b(AI|V\d+X?|Append|English|Standard|II|2|V|SP|NT|Talk|TALK|VoiSona|SOLID|Arcane)\b.*$/g,
+							'',
+						)
+						.replace(/\s(トークボイス)$/g, '');
 				}
 				return [...new Set(feat)].join(', ');
 			});
@@ -40,18 +45,66 @@ function cleanupArtist(artist: string) {
 	}
 }
 
-Connector.playerSelector = '#app .css-1pm1wrk';
-Connector.trackArtSelector = '.css-1no5jxy';
-Connector.trackSelector = '.css-n3lbvk';
-Connector.artistSelector = '.css-molfmb';
-Connector.playButtonSelector = '.css-1lc7lii button[title="Play"]';
+Connector.playerSelector = '.css-1pm1wrk';
 
-Connector.getDuration = () => {
-	const store = getPlayQueueStore();
-	const current = store.items[store.currentIndex];
-	return current.entry.pvs[0].length;
+Connector.playButtonSelector = '.css-1lc7lii button[title=Play]';
+
+interface Store {
+	currentIndex: number;
+	items: Array<Item>;
+}
+
+interface Item {
+	entry: Entry;
+	pvId: number;
+}
+
+interface Entry {
+	artistString: string;
+	id: number;
+	name: string;
+	pvs: Array<Pv>;
+	urlThumb: string;
+}
+
+interface Pv {
+	id: number;
+	length: number;
+	url: string;
 };
 
-function getPlayQueueStore() {
+Connector.getTrackInfo = () => {
+	const store = getPlayQueueStore();
+	const current = store?.items[store.currentIndex];
+	const currentPv = current?.entry.pvs.filter(
+		(pv) => pv.id === current.pvId,
+	)[0];
+
+	const data = {
+		track: current?.entry.name,
+		artist: current?.entry.artistString,
+		uniqueID: current?.entry.id,
+		duration: currentPv?.length,
+		currentTime: (currentPv?.length || 0) * getPercentage(),
+		trackArt: current?.entry.urlThumb,
+		originUrl: currentPv?.url,
+	};
+
+	return data;
+};
+
+function getPercentage(): number {
+	const progressBarElement = document.querySelector(
+		'.css-1hasgzz',
+	) as HTMLElement;
+	const percentage = progressBarElement?.style.width;
+	return parseFloat(percentage) / 100;
+}
+
+function getPlayQueueStore(): Store | null {
+	if (!localStorage.PlayQueueStore) {
+		return null;
+	}
+
 	return JSON.parse(localStorage.PlayQueueStore);
 }


### PR DESCRIPTION
**Describe the changes you made**
* Gracefully handle uninitialized localstorage (supersedes #6147)
* Fully rely on localstorage data, which was already read for track duration. This also addresses the initial concerns about CSS stability (#4638)
* Implement uniqueID, currentTime, and originUrl
* Refine artist filters after further testing (handle naming patterns that are new since my original writing in 2024 or I otherwise overlooked)

**Additional context**
* In my testing, auto-detected originUrl appeared in the debug log instead of connector-provided originUrl.
* Web Scrobbler correctly detects repeating tracks when the NicoNicoDouga embed is selected (the play-pause button briefly changes state), but not when the YouTube embed is selected. I am not sure how to solve this, besides constantly watching localstorage, which seems unoptimal.

closes #6147