### PR TITLE
Fix YouTube Topic channel artist names

### DIFF
--- a/src/connectors/youtube.ts
+++ b/src/connectors/youtube.ts
@@ -518,7 +518,10 @@ function getTrackInfoFromTitle(): ArtistTrackInfo {
 	);
 	if (!artist) {
 		const channelName = Util.getTextFromSelectors(channelNameSelector);
-		artist = channelName?.replace(/ - Topic$/, '') ?? null;
+		const re =
+			// eslint-disable-next-line no-irregular-whitespace
+			/^(?:Mavzu|Тема|الموضوع|ਵਿਸ਼ਾ)\s[–-]\s|(?:(?:\s[-—–]|[:՝])\s(?:Onderwerp|Mövzu|Topik|tema|Tema|téma|Emne|Thema|teema|Topic|gaia|Paksa|Sujet|Isihloko|Efni|Mada|tēma|téma|emne|temat|Tópico|Subiect|aihekanava|Ämne|Chủ đề|Konu|тэма|Тема|Тақырып|Сэдэв|тема|Θέμα|թեմա|נושא|موضوع|عنوان|विषय|বিষয়বস্তু|বিষয়|મુદ્દો|ବିଷୟ|தலைப்பு|అంశం|ವಿಷಯ|വിഷയം|මාතෘකාව|หัวข้อ|ຫົວ​ຂໍ້|ခေါင်းစဉ်|თემა|ርዕስ|ប្រធាន​បទ|主题|主題|トピック|주제)|\s\(tema\))$/;
+		artist = channelName?.replace(re, '') ?? null;
 	}
 
 	return { artist, track };

--- a/src/connectors/youtube.ts
+++ b/src/connectors/youtube.ts
@@ -517,7 +517,8 @@ function getTrackInfoFromTitle(): ArtistTrackInfo {
 		Util.getTextFromSelectors(videoTitleSelector),
 	);
 	if (!artist) {
-		artist = Util.getTextFromSelectors(channelNameSelector);
+		const channelName = Util.getTextFromSelectors(channelNameSelector);
+		artist = channelName?.replace(/ - Topic$/, '') ?? null;
 	}
 
 	return { artist, track };


### PR DESCRIPTION
**Describe the changes you made**

The YouTube connector used the unchanged Topic channel name when a video title did not contain an artist. This change removes an exact trailing ` - Topic` from that fallback artist.

Fixes #5191

**Additional context**

Testing:

- `npm.cmd run test -- --run tests/background/connectors.test.ts tests/content/util.test.ts`: 1,927 tests passed.
- `npm.cmd run lint`: passed with 75 processing warnings.
- `npm.cmd run checkts`: passed.
- `npm.cmd run build firefox`: passed with Vite chunking warnings.
- Firefox manual test: passed.