### PR TITLE
Add support for Outra Hora

### DIFF
--- a/src/connectors/outrahora.ts
+++ b/src/connectors/outrahora.ts
@@ -1,7 +1,7 @@
 export {};
 
 /**
- * Outra Hora ships two players that both fill the Media Session API:
+ * outrahora rádio ships two players that both fill the Media Session API:
  * the station site at radio.outrahora.com, and an embed bar injected on
  * every page of outrahora.com.
  *

--- a/src/connectors/outrahora.ts
+++ b/src/connectors/outrahora.ts
@@ -1,13 +1,32 @@
 export {};
 
-Connector.playerSelector = '#playerView';
+/**
+ * Outra Hora ships two players that both fill the Media Session API:
+ * the station site at radio.outrahora.com, and an embed bar injected on
+ * every page of outrahora.com.
+ *
+ * The bar keeps its player inside a Shadow DOM and creates the audio
+ * element with `new Audio()`, so it is reachable neither by
+ * `document.querySelector('audio')` nor through the shadow root. Both
+ * the audio listeners and the `paused` check only apply to the station
+ * site; on the bar we fall back to the tab audible API.
+ */
+const isEmbedBar = window.location.hostname !== 'radio.outrahora.com';
 
-Util.bindListeners(
-	['audio'],
-	['playing', 'pause', 'waiting'],
-	Connector.onStateChanged,
-);
+if (isEmbedBar) {
+	Connector.playerSelector = '#outrahora-radio-widget';
 
-Connector.isPlaying = () => !document.querySelector('audio')?.paused;
+	Connector.useTabAudibleApi();
+} else {
+	Connector.playerSelector = '#playerView';
+
+	Util.bindListeners(
+		['audio'],
+		['playing', 'pause', 'waiting'],
+		Connector.onStateChanged,
+	);
+
+	Connector.isPlaying = () => !document.querySelector('audio')?.paused;
+}
 
 Connector.useMediaSessionApi();

--- a/src/connectors/outrahora.ts
+++ b/src/connectors/outrahora.ts
@@ -1,32 +1,12 @@
 export {};
 
-/**
- * Connector for Rádio Outra Hora (https://radio.outrahora.com).
- *
- * The site is a static SPA that exposes a single primary player
- * (`#playerView`) on both the home page and the TV layout. Track info
- * is updated in place by `player.js` / `tv.js` and the extension
- * already fills `navigator.mediaSession` via `media-session.js`, so
- * we delegate metadata extraction to the MediaSession API and only
- * need to point the connector at the player container and artwork
- * element.
- *
- * The TV page (`/tv`) and the embed widget (`embed/outrahora-bar.js`)
- * also use the same `#currentTitle` / `#currentArtist` / `#coverArtwork`
- * / `#audio` selectors in their own DOM, so this connector covers all
- * of them once the URL matches.
- *
- * `#playButton` is never hidden or removed while playing (it just
- * swaps its icon), so playback state is read from the `<audio>`
- * element instead, like other connectors do.
- */
-
 Connector.playerSelector = '#playerView';
 
-Connector.artistSelector = '#currentArtist';
-Connector.trackSelector = '#currentTitle';
-
-Connector.trackArtSelector = '#coverArtwork';
+Util.bindListeners(
+	['audio'],
+	['playing', 'pause', 'waiting'],
+	Connector.onStateChanged,
+);
 
 Connector.isPlaying = () => !document.querySelector('audio')?.paused;
 

--- a/src/connectors/outrahora.ts
+++ b/src/connectors/outrahora.ts
@@ -13,8 +13,12 @@ export {};
  *
  * The TV page (`/tv`) and the embed widget (`embed/outrahora-bar.js`)
  * also use the same `#currentTitle` / `#currentArtist` / `#coverArtwork`
- * / `#playButton` selectors in their own DOM, so this connector covers
- * all of them once the URL matches.
+ * / `#audio` selectors in their own DOM, so this connector covers all
+ * of them once the URL matches.
+ *
+ * `#playButton` is never hidden or removed while playing (it just
+ * swaps its icon), so playback state is read from the `<audio>`
+ * element instead, like other connectors do.
  */
 
 Connector.playerSelector = '#playerView';
@@ -24,6 +28,6 @@ Connector.trackSelector = '#currentTitle';
 
 Connector.trackArtSelector = '#coverArtwork';
 
-Connector.playButtonSelector = '#playButton';
+Connector.isPlaying = () => !document.querySelector('audio')?.paused;
 
 Connector.useMediaSessionApi();

--- a/src/connectors/outrahora.ts
+++ b/src/connectors/outrahora.ts
@@ -1,0 +1,29 @@
+export {};
+
+/**
+ * Connector for Rádio Outra Hora (https://radio.outrahora.com).
+ *
+ * The site is a static SPA that exposes a single primary player
+ * (`#playerView`) on both the home page and the TV layout. Track info
+ * is updated in place by `player.js` / `tv.js` and the extension
+ * already fills `navigator.mediaSession` via `media-session.js`, so
+ * we delegate metadata extraction to the MediaSession API and only
+ * need to point the connector at the player container and artwork
+ * element.
+ *
+ * The TV page (`/tv`) and the embed widget (`embed/outrahora-bar.js`)
+ * also use the same `#currentTitle` / `#currentArtist` / `#coverArtwork`
+ * / `#playButton` selectors in their own DOM, so this connector covers
+ * all of them once the URL matches.
+ */
+
+Connector.playerSelector = '#playerView';
+
+Connector.artistSelector = '#currentArtist';
+Connector.trackSelector = '#currentTitle';
+
+Connector.trackArtSelector = '#coverArtwork';
+
+Connector.playButtonSelector = '#playButton';
+
+Connector.useMediaSessionApi();

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -313,7 +313,7 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'Outra Hora',
-		matches: ['*://radio.outrahora.com/*', '*://radio.outrahora.com'],
+		matches: ['*://radio.outrahora.com/*'],
 		js: 'outrahora.js',
 		id: 'outrahora',
 	},

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -312,7 +312,7 @@ export default <ConnectorMeta[]>[
 		id: 'odnoklassniki',
 	},
 	{
-		label: 'Outra Hora',
+		label: 'outrahora rádio',
 		matches: [
 			'*://radio.outrahora.com/*',
 			'*://outrahora.com/*',

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -313,7 +313,11 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'Outra Hora',
-		matches: ['*://radio.outrahora.com/*'],
+		matches: [
+			'*://radio.outrahora.com/*',
+			'*://outrahora.com/*',
+			'*://*.outrahora.com/*',
+		],
 		js: 'outrahora.js',
 		id: 'outrahora',
 	},

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -312,6 +312,12 @@ export default <ConnectorMeta[]>[
 		id: 'odnoklassniki',
 	},
 	{
+		label: 'Outra Hora',
+		matches: ['*://radio.outrahora.com/*', '*://radio.outrahora.com'],
+		js: 'outrahora.js',
+		id: 'outrahora',
+	},
+	{
 		label: 'Overcast',
 		matches: ['*://overcast.fm/*'],
 		js: 'overcast.js',

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -313,11 +313,7 @@ export default <ConnectorMeta[]>[
 	},
 	{
 		label: 'outrahora rádio',
-		matches: [
-			'*://radio.outrahora.com/*',
-			'*://outrahora.com/*',
-			'*://*.outrahora.com/*',
-		],
+		matches: ['*://*.outrahora.com/*'],
 		js: 'outrahora.js',
 		id: 'outrahora',
 	},


### PR DESCRIPTION
Adds a connector for https://radio.outrahora.com, an independent Brazilian online radio. The site exposes MediaMetadata via \
avigator.mediaSession\, so the connector points at the player container and the artwork element and delegates metadata extraction to the MediaSession API.