### PR TITLE
Add support for SoundScout

### DIFF
--- a/src/connectors/soundscout.ts
+++ b/src/connectors/soundscout.ts
@@ -1,0 +1,15 @@
+export {};
+
+Connector.playerSelector = '[data-sidebar-collapsed][data-player-active]';
+
+Connector.artistSelector = '[data-testid="player-bar-track-artist"]';
+
+Connector.trackSelector = '[data-testid="player-bar-track-title"]';
+
+Connector.durationSelector = '[data-testid="player-bar-duration"]';
+
+Connector.isPlaying = () =>
+	Util.getAttrFromSelectors(
+		'[data-testid="btn-player-bar-play"]',
+		'aria-label',
+	) === 'Pause';

--- a/src/core/connectors.ts
+++ b/src/core/connectors.ts
@@ -87,6 +87,12 @@ export default <ConnectorMeta[]>[
 		id: 'soundcloud',
 	},
 	{
+		label: 'SoundScout',
+		matches: ['*://www.soundscout.com/*'],
+		js: 'soundscout.js',
+		id: 'soundscout',
+	},
+	{
 		label: 'Amazon Music',
 		matches: [
 			'*://music.amazon.*/*',


### PR DESCRIPTION
<!-- 
  Thank you for taking the time to contribute to this project!

  Make sure to check out our guide on contributing with guidelines of how to contribute.

  See: https://github.com/web-scrobbler/web-scrobbler/blob/master/.github/CONTRIBUTING.md

--> 

**Describe the changes you made**

Adds support for scrobbling from SoundScout (soundscout.com).

The new connector detects:
- Track title
- Artist
- Track duration
- Play/pause state
- Track changes

SoundScout dynamically adds its player when playback begins, so the connector observes a persistent player layout container to detect when the player and track information become available.

**Additional context**

Tested manually in Firefox with the development build.

Verified:
- Starting playback detects the current track
- Pausing and resuming updates the playback state
- Changing tracks detects the new track
- Track duration is detected correctly
- Now Playing is submitted successfully
- Tracks scrobble successfully

Validation:
- `npm test` — 2088 tests passed
- `npm run lint` — passed
