### PR TITLE
core: trigger onStateChanged when finding observeTarget delayed

### DIFF
--- a/src/core/content/starter.ts
+++ b/src/core/content/starter.ts
@@ -129,6 +129,7 @@ function setupSecondObserver() {
 		if (observeTarget !== null) {
 			playerObserver.disconnect();
 			setupObserver(observeTarget);
+			Connector.onStateChanged();
 		}
 	});
 


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
`onStateChanged` was not triggered when the `observeTarget` was only found after the initial second of delay, one example being footers on websites that are only created when you start playing something. If these don't permanently have some subtree changes, you will not observe that the playback has started.

Now, when an `observeTarget` is found with the full document `MutationObserver`, one `onStateChanged` is triggered.

**Additional context**
<!-- Add any other context or screenshots here. -->
Connector that encountered this issue in review is WQXR: #5623 