### PR TITLE
remove deprecated `baseDir` tsconfig setting

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -5,10 +5,10 @@ import { build } from 'vite';
 import * as configs from './vite.configs';
 import { mkdir } from 'fs/promises';
 import { getBrowser, isDev, releaseTarget, releaseType } from './scripts/util';
-import colorLog from 'scripts/log';
+import colorLog from './scripts/log';
 import { exec } from 'child_process';
 import { emptydirSync } from 'fs-extra';
-import createDistributable from 'scripts/create-distributable';
+import createDistributable from './scripts/create-distributable';
 
 /**
  * Try to make a directory, dont error if the directory exists

--- a/scripts/make-manifest.ts
+++ b/scripts/make-manifest.ts
@@ -4,7 +4,7 @@ import {
 	chromeManifest,
 	firefoxManifest,
 	safariManifest,
-} from 'manifest.config';
+} from '../manifest.config';
 import colorLog from './log';
 import { getBrowser, releaseTarget } from './util';
 import type { Manifest } from 'webextension-polyfill';

--- a/scripts/translations-prepare.ts
+++ b/scripts/translations-prepare.ts
@@ -1,6 +1,6 @@
 import { glob } from 'glob';
 import { readFile, writeFile } from 'fs/promises';
-import colorLog from 'scripts/log';
+import colorLog from './log';
 
 async function main() {
 	const translationFiles = await glob('src/_locales/**/messages.json');

--- a/tsconfig.connectors.json
+++ b/tsconfig.connectors.json
@@ -1,13 +1,12 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
     "module": "ES2022",
     "moduleResolution": "Node",
     "outDir": "build/connectorraw",
     "paths": {
-      "@/*": ["src/*"],
-      "#/*": ["tests/*"]
+      "@/*": ["./src/*"],
+      "#/*": ["./tests/*"]
     },
     "resolveJsonModule": true,
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
     "module": "ES2022",
     "moduleResolution": "Bundler",
     "isolatedModules": true,
@@ -9,8 +8,8 @@
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
     "paths": {
-      "@/*": ["src/*"],
-      "#/*": ["tests/*"]
+      "@/*": ["./src/*"],
+      "#/*": ["./tests/*"]
     },
     "resolveJsonModule": true,
     "sourceMap": true,

--- a/vite.configs.ts
+++ b/vite.configs.ts
@@ -4,9 +4,9 @@ import solid from 'vite-plugin-solid';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 import compileConnectors from './scripts/compile-connectors';
 import makeManifest from './scripts/make-manifest';
-import { isDev, isProd, releaseTarget, resolvePath } from 'scripts/util';
-import minifyImages from 'scripts/minify-images';
-import generateIcons from 'scripts/generate-icons';
+import { isDev, isProd, releaseTarget, resolvePath } from './scripts/util';
+import minifyImages from './scripts/minify-images';
+import generateIcons from './scripts/generate-icons';
 import ConditionalCompile from 'vite-plugin-conditional-compiler';
 
 const dist = resolvePath('build');


### PR DESCRIPTION

**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
changed config and imports where necessary

**Additional context**
<!-- Add any other context or screenshots here. -->
upgrading to typescript 7.0 in the future will require we do this, it has been nagging me in my editor for a while now

> Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.

see https://github.com/microsoft/TypeScript/issues/62508#issuecomment-3348649259