### PR TITLE
core: fix circularity

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:stylelint": "stylelint \"**/*.scss\"",
     "lint:prettier": "prettier . --check",
     "lint:markdown": "remark .",
-    "lint:circular": "madge --extensions ts,tsx --circular src",
+    "lint:circular": "madge --circular src",
     "prettierfix": "prettier . --write",
     "fixstyle": "stylelint \"**/*.scss\" --fix",
     "translations": "tx pull -m onlytranslated && tsx scripts/translations-prepare.ts"
@@ -103,6 +103,10 @@
       "at-rule-prelude-no-invalid": null,
       "declaration-property-value-no-unknown": null
     }
+  },
+  "madge": {
+    "tsConfig": "./tsconfig.json",
+    "fileExtensions": ["ts", "tsx"]
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -106,7 +106,12 @@
   },
   "madge": {
     "tsConfig": "./tsconfig.json",
-    "fileExtensions": ["ts", "tsx"]
+    "fileExtensions": ["ts", "tsx"],
+    "detectiveOptions": {
+      "ts": {
+        "skipTypeImports": true
+      }
+    }
   },
   "license": "MIT"
 }

--- a/src/core/storage/browser-storage.ts
+++ b/src/core/storage/browser-storage.ts
@@ -160,6 +160,7 @@ const storageTypeMap = {
 	[CONNECTORS_OVERRIDE_OPTIONS]: SYNC,
 	[CUSTOM_PATTERNS]: SYNC,
 	[NOTIFICATIONS]: SYNC,
+	// make sure to update '@/core/util/debug' if you change this
 	[OPTIONS]: SYNC,
 
 	LastFM: LOCAL,

--- a/src/core/storage/wrapper.ts
+++ b/src/core/storage/wrapper.ts
@@ -28,8 +28,8 @@ import type { CloneableSong } from '@/core/object/song';
 import EventEmitter from '@/util/emitter';
 import type connectors from '@/core/connectors';
 import type { RegexEdit } from '@/util/regex';
-import { debugLog } from '../content/util';
 import { ServiceCallResult } from '../object/service-call-result';
+import { debugLog } from '../util/debug';
 
 export interface CustomPatterns {
 	[connectorId: string]: string[];

--- a/src/core/util/debug.ts
+++ b/src/core/util/debug.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-const Options = import('@/core/storage/options');
+import browser from 'webextension-polyfill';
 
 /**
  * Log type for debug messages.
@@ -14,9 +14,9 @@ export type DebugLogType = 'log' | 'error' | 'warn' | 'info';
 class DebugLogQueue {
 	private queue: { text: unknown; logType: DebugLogType }[] = [];
 	private isActive = false;
-	private shouldPrint = Options.then((awaitedOptions) =>
-		awaitedOptions.getOption(awaitedOptions.DEBUG_LOGGING_ENABLED),
-	);
+	private shouldPrint = (browser.storage.sync || browser.storage.local)
+		.get('Options')
+		.then((options) => options['debugLoggingEnabled']);
 
 	/**
 	 * Enqueue a log message to be printed.

--- a/tests/mocks/webextension-polyfill.ts
+++ b/tests/mocks/webextension-polyfill.ts
@@ -11,19 +11,22 @@ class StorageAreaStub {
 	}
 
 	get() {
-		return this.data;
+		return Promise.resolve(this.data);
 	}
 
 	set(data: Record<string, unknown>) {
 		this.data = Object.assign(this.data, data);
+		return Promise.resolve();
 	}
 
 	remove(key: string) {
 		delete this.data[key];
+		return Promise.resolve();
 	}
 
 	clear() {
 		this.data = {};
+		return Promise.resolve();
 	}
 }
 


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
- add `tsConfig` setting for `lint:circular` (`madge`)
- remove the dynamic import of Options from `@/core/util/debug` in favor of reading from `browser.storage.(sync||local).get('Options')` directly

**Additional context**
<!-- Add any other context or screenshots here. -->
the CI for checking for circular dependencies had a lot of ignored files because it wasn't pointed to the `tsConfig` and as such it ignored all `@/` imports, which are the ones that have the circularity

to our analysis tools the dynamic import seemed to fix the issues with circularity, which it doesn't do in reality due to [vite not creating a new chunk just for that dynamic import][vite-chunk].

[vite-chunk]: https://github.com/vitejs/vite/discussions/13903