### PR TITLE
Change YouTube connector defaults (to prevent false scrobbles)

### DIFF
--- a/src/core/storage/options.ts
+++ b/src/core/storage/options.ts
@@ -134,10 +134,10 @@ const OVERRIDE_CONTENT = {
 
 export interface ConnectorOptions {
 	YouTube: {
-		scrobbleMusicOnly: boolean;
-		scrobbleEntertainmentOnly: boolean;
 		scrobbleMusicRecognisedOnly: boolean;
 		enableGetTrackInfoFromYtMusic: boolean;
+		scrobbleMusicOnly: boolean;
+		scrobbleEntertainmentOnly: boolean;
 	};
 }
 
@@ -146,10 +146,10 @@ export interface ConnectorOptions {
  */
 const DEFAULT_CONNECTOR_OPTIONS: ConnectorOptions = {
 	YouTube: {
-		scrobbleMusicOnly: false,
+		scrobbleMusicRecognisedOnly: true,
+		enableGetTrackInfoFromYtMusic: true,
+		scrobbleMusicOnly: true,
 		scrobbleEntertainmentOnly: false,
-		scrobbleMusicRecognisedOnly: false,
-		enableGetTrackInfoFromYtMusic: false,
 	},
 };
 


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
- reordered the options in source code to match the ui option order
- enabled restrictions to only scrobble what is most definitely music

**Additional context**
<!-- Add any other context or screenshots here. -->
fixes #4290
fixes #5884