### PR TITLE
Fix Online Radio Box connector

### DIFF
--- a/src/connectors/onlineradiobox.ts
+++ b/src/connectors/onlineradiobox.ts
@@ -1,8 +1,43 @@
 export {};
 
+const topPlayerTrackSelector = '#top_player_track';
+const trackHistorySelector = '.station-onair';
+
 // Need to select also .station to cover popup where #top_player_track is outside of .player.
 Connector.playerSelector = ['.player', 'body > .station'];
 
-Connector.artistTrackSelector = '#top_player_track';
+Connector.artistTrackSelector = topPlayerTrackSelector;
 
 Connector.playButtonSelector = '.player .b-play';
+
+const getArtistTrackFromTitle = Connector.getArtistTrack;
+
+Connector.getArtistTrack = () => {
+	const currentTrackUrl = document
+		.querySelector(`${topPlayerTrackSelector} a`)
+		?.getAttribute('href');
+	const historyTrack = Array.from(
+		document.querySelectorAll<HTMLAnchorElement>(
+			`${trackHistorySelector} .track_history_item a`,
+		),
+	).find((link) => link.getAttribute('href') === currentTrackUrl);
+	const artist = historyTrack?.querySelector('b')?.textContent?.trim();
+
+	if (!historyTrack || !artist) {
+		return getArtistTrackFromTitle();
+	}
+
+	const trackWithoutArtist = historyTrack.cloneNode(true) as HTMLElement;
+	trackWithoutArtist.querySelector('b')?.remove();
+	const track = trackWithoutArtist.textContent?.trim();
+
+	return track ? { artist, track } : getArtistTrackFromTitle();
+};
+
+const trackHistory = document.querySelector(trackHistorySelector);
+if (trackHistory) {
+	new MutationObserver(Connector.onStateChanged).observe(trackHistory, {
+		childList: true,
+		subtree: true,
+	});
+}


### PR DESCRIPTION
**Describe the changes you made**

- Read the artist and track from the matching Online Radio Box history entry when the top player only exposes a programme title.
- Keep the existing combined-title parser as a fallback for stations and popup pages without track history.
- Observe history updates so a new track is emitted after Online Radio Box refreshes its delayed metadata.

**Additional context**

Fixes #6192

### Problem and user impact

Some Online Radio Box stations display a programme title in `#top_player_track` while their actual artist and track are only present in the station history. The connector tried to split the programme title and returned empty metadata, so playback was never scrobbled.

### Root cause and fix

Online Radio Box links both representations with the same track URL. The connector now matches that URL to the history row, reads the `<b>` artist separately, and removes it from the row text to obtain the track. The site updates the history about one second after the top player, so a focused MutationObserver triggers a second state read when that metadata arrives.

### Validation

- Reproduced on the station from the report and verified the live DOM resolves `Root` / `House Najat` while the top player says `Root House Show`.
- `npm test -- --run` (2,162 tests)
- `npm run checkts`
- `npm run lint`
- `npm run build chrome`
- `npm run build firefox`
