### PR TITLE
refactor(controller): simplify controller logic by moving UI rendering out

### DIFF
--- a/src/core/object/controller/controller-ui-connector.ts
+++ b/src/core/object/controller/controller-ui-connector.ts
@@ -1,0 +1,10 @@
+import type { ConnectorMeta } from '@/core/connectors';
+
+export interface ControllerUIConnector {
+	meta: ConnectorMeta;
+	scrobbleInfoLocationSelector: string | null;
+	scrobbleInfoStyle: Partial<CSSStyleDeclaration> &
+		Partial<
+			Record<'box-orient' | '-webkit-line-clamp' | 'text-wrap', string>
+		>;
+}

--- a/src/core/object/controller/controller-ui.ts
+++ b/src/core/object/controller/controller-ui.ts
@@ -1,6 +1,5 @@
 import browser from 'webextension-polyfill';
 import type { ControllerUIConnector } from './controller-ui-connector';
-import * as Options from '@/core/storage/options';
 import * as Util from '@/core/content/util';
 import type Song from '@/core/object/song';
 import type { ControllerModeStr } from './controller';
@@ -9,14 +8,7 @@ export default class ControllerUI {
 	constructor(private connector: ControllerUIConnector) {}
 
 	public async getInfoBoxElement(): Promise<HTMLDivElement | null> {
-		if (
-			!this.connector.scrobbleInfoLocationSelector ||
-			// infobox is disabled in options
-			!(await Options.getOption(
-				Options.USE_INFOBOX,
-				this.connector.meta.id,
-			))
-		) {
+		if (!this.connector.scrobbleInfoLocationSelector) {
 			return null;
 		}
 
@@ -98,5 +90,11 @@ export default class ControllerUI {
 			infoBoxElement.appendChild(img);
 			infoBoxElement.appendChild(info);
 		}
+	}
+
+	public cleanup(): void {
+		document
+			.querySelector<HTMLDivElement>('#scrobbler-infobox-el')
+			?.remove();
 	}
 }

--- a/src/core/object/controller/controller-ui.ts
+++ b/src/core/object/controller/controller-ui.ts
@@ -1,0 +1,102 @@
+import browser from 'webextension-polyfill';
+import type { ControllerUIConnector } from './controller-ui-connector';
+import * as Options from '@/core/storage/options';
+import * as Util from '@/core/content/util';
+import type Song from '@/core/object/song';
+import type { ControllerModeStr } from './controller';
+
+export default class ControllerUI {
+	constructor(private connector: ControllerUIConnector) {}
+
+	public async getInfoBoxElement(): Promise<HTMLDivElement | null> {
+		if (
+			!this.connector.scrobbleInfoLocationSelector ||
+			// infobox is disabled in options
+			!(await Options.getOption(
+				Options.USE_INFOBOX,
+				this.connector.meta.id,
+			))
+		) {
+			return null;
+		}
+
+		const parentEl = document.querySelector(
+			this.connector.scrobbleInfoLocationSelector,
+		);
+		if (!parentEl) {
+			return null;
+		}
+
+		// check if infoBoxEl was already created
+		let infoBoxElement = document.querySelector<HTMLDivElement>(
+			'#scrobbler-infobox-el',
+		);
+
+		// check if element is still in the correct place
+		if (infoBoxElement) {
+			if (infoBoxElement.parentElement !== parentEl) {
+				infoBoxElement.remove();
+			} else {
+				return infoBoxElement;
+			}
+		}
+
+		// if it was not in the correct place or didn't exist, create it
+		infoBoxElement = document.createElement('div');
+		infoBoxElement.setAttribute('id', 'scrobbler-infobox-el');
+
+		// style the infobox
+		for (const prop in this.connector.scrobbleInfoStyle) {
+			infoBoxElement.style[prop] =
+				this.connector.scrobbleInfoStyle[prop] ?? '';
+		}
+
+		parentEl.appendChild(infoBoxElement);
+		return infoBoxElement;
+	}
+
+	public async updateInfoBox(
+		mode: ControllerModeStr,
+		currentSong: Song | null,
+	) {
+		let oldInfoBoxText: string | false = false;
+		const infoBoxElement = await this.getInfoBoxElement();
+		if (!infoBoxElement) {
+			// clean up
+			const infoBoxElement = document.querySelector<HTMLDivElement>(
+				'#scrobbler-infobox-el',
+			);
+			if (infoBoxElement) {
+				infoBoxElement.remove();
+			}
+			return;
+		}
+		const textEl = infoBoxElement.querySelector('span');
+		if (textEl) {
+			oldInfoBoxText = textEl.innerText;
+		}
+
+		const infoBoxText = Util.getInfoBoxText(mode, currentSong);
+
+		// Check if infobox needs to be updated
+		if (!oldInfoBoxText || infoBoxText !== oldInfoBoxText) {
+			const img = document.createElement('img');
+			img.setAttribute(
+				'src',
+				browser.runtime.getURL('./icons/icon_main_48.png'),
+			);
+			img.setAttribute('alt', 'Web Scrobbler state:');
+			img.setAttribute('style', 'height: 1.2em');
+
+			const info = document.createElement('span');
+			info.innerText = infoBoxText;
+
+			// Clear old contents of infoBoxElement
+			while (infoBoxElement.firstChild) {
+				infoBoxElement.removeChild(infoBoxElement.firstChild);
+			}
+			infoBoxElement.appendChild(img);
+			infoBoxElement.appendChild(info);
+		}
+	}
+}

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -25,9 +25,9 @@ import * as BrowserStorage from '@/core/storage/browser-storage';
 import { debugLog } from '@/core/content/util';
 import scrobbleCache from '@/core/storage/scrobble-cache';
 import { ScrobbleStatus } from '@/core/storage/wrapper';
-import browser from 'webextension-polyfill';
 import type BaseConnector from '@/core/content/connector';
 import Blocklist from '@/core/storage/blocklist';
+import ControllerUI from './controller-ui';
 
 /**
  * List of song fields used to check if song is changed. If any of
@@ -91,6 +91,7 @@ export default class Controller {
 	private setNotEditingTimeout = setTimeout(() => {
 		// do nothing
 	}, 0);
+	private controllerUI: ControllerUI;
 	private eventEmitter = new EventEmitter<updateEvent>();
 	private tabId = sendContentMessage({
 		type: 'getTabId',
@@ -134,105 +135,13 @@ export default class Controller {
 	}
 
 	/**
-	 * Function that handles updating the scrobble info box
-	 */
-	private async getInfoBoxElement(): Promise<HTMLDivElement | null> {
-		if (
-			!this.connector.scrobbleInfoLocationSelector ||
-			// infobox is disabled in options
-			!(await Options.getOption(
-				Options.USE_INFOBOX,
-				this.connector.meta.id,
-			))
-		) {
-			return null;
-		}
-
-		const parentEl = document.querySelector(
-			this.connector.scrobbleInfoLocationSelector,
-		);
-		if (!parentEl) {
-			return null;
-		}
-
-		// check if infoBoxEl was already created
-		let infoBoxElement = document.querySelector<HTMLDivElement>(
-			'#scrobbler-infobox-el',
-		);
-
-		// check if element is still in the correct place
-		if (infoBoxElement) {
-			if (infoBoxElement.parentElement !== parentEl) {
-				infoBoxElement.remove();
-			} else {
-				return infoBoxElement;
-			}
-		}
-
-		// if it was not in the correct place or didn't exist, create it
-		infoBoxElement = document.createElement('div');
-		infoBoxElement.setAttribute('id', 'scrobbler-infobox-el');
-
-		// style the infobox
-		for (const prop in this.connector.scrobbleInfoStyle) {
-			infoBoxElement.style[prop] =
-				this.connector.scrobbleInfoStyle[prop] ?? '';
-		}
-
-		parentEl.appendChild(infoBoxElement);
-		return infoBoxElement;
-	}
-
-	private async updateInfoBox() {
-		let oldInfoBoxText: string | false = false;
-		const infoBoxElement = await this.getInfoBoxElement();
-		if (!infoBoxElement) {
-			// clean up
-			const infoBoxElement = document.querySelector<HTMLDivElement>(
-				'#scrobbler-infobox-el',
-			);
-			if (infoBoxElement) {
-				infoBoxElement.remove();
-			}
-			return;
-		}
-		const textEl = infoBoxElement.querySelector('span');
-		if (textEl) {
-			oldInfoBoxText = textEl.innerText;
-		}
-
-		const mode = this.getMode();
-		const infoBoxText = Util.getInfoBoxText(mode, this.currentSong);
-
-		// Check if infobox needs to be updated
-		if (!oldInfoBoxText || infoBoxText !== oldInfoBoxText) {
-			const img = document.createElement('img');
-			img.setAttribute(
-				'src',
-				browser.runtime.getURL('./icons/icon_main_48.png'),
-			);
-			img.setAttribute('alt', 'Web Scrobbler state:');
-			img.setAttribute('style', 'height: 1.2em');
-
-			const info = document.createElement('span');
-			info.innerText = infoBoxText;
-
-			// Clear old contents of infoBoxElement
-			while (infoBoxElement.firstChild) {
-				infoBoxElement.removeChild(infoBoxElement.firstChild);
-			}
-			infoBoxElement.appendChild(img);
-			infoBoxElement.appendChild(info);
-		}
-	}
-
-	/**
 	 * @param tabId - Tab ID
 	 * @param connector - Connector match object
 	 * @param isEnabled - Flag indicates initial stage
 	 */
 	constructor(connector: BaseConnector, isEnabled: boolean) {
 		this.connector = connector;
+		this.controllerUI = new ControllerUI(connector);
 		this.blocklist = new Blocklist(this.connector.meta.id);
 		this.isEnabled = isEnabled;
 		this.mode = isEnabled ? ControllerMode.Base : ControllerMode.Disabled;
@@ -367,7 +276,7 @@ export default class Controller {
 	 * Called if current song is updated.
 	 */
 	public onSongUpdated(): void {
-		this.updateInfoBox();
+		this.controllerUI.updateInfoBox(this.getMode(), this.currentSong);
 		sendContentMessage({
 			type: 'songUpdate',
 			payload: this.currentSong?.getCloneableData() ?? null,
@@ -378,7 +287,7 @@ export default class Controller {
 	 * Called if a controller mode is changed.
 	 */
 	public onModeChanged(): void {
-		this.updateInfoBox();
+		this.controllerUI.updateInfoBox(this.getMode(), this.currentSong);
 		sendContentMessage({
 			type: 'controllerModeChange',
 			payload: {
@@ -452,7 +361,7 @@ export default class Controller {
 			}
 		}
 
-		this.updateInfoBox();
+		this.controllerUI.updateInfoBox(this.getMode(), this.currentSong);
 	}
 
 	/** Public functions */

--- a/src/core/object/controller/controller.ts
+++ b/src/core/object/controller/controller.ts
@@ -98,6 +98,20 @@ export default class Controller {
 		payload: undefined,
 	});
 
+	private async updateUI(): Promise<void> {
+		const isEnabled = await Options.getOption(
+			Options.USE_INFOBOX,
+			this.connector.meta.id,
+		);
+
+		if (!isEnabled) {
+			this.controllerUI.cleanup();
+			return;
+		}
+
+		await this.controllerUI.updateInfoBox(this.getMode(), this.currentSong);
+	}
+
 	/**
 	 * Mutates this.currentSong to sync disallowed reason, and returns whether song should scrobble
 	 *
@@ -276,7 +290,7 @@ export default class Controller {
 	 * Called if current song is updated.
 	 */
 	public onSongUpdated(): void {
-		this.controllerUI.updateInfoBox(this.getMode(), this.currentSong);
+		void this.updateUI();
 		sendContentMessage({
 			type: 'songUpdate',
 			payload: this.currentSong?.getCloneableData() ?? null,
@@ -287,7 +301,7 @@ export default class Controller {
 	 * Called if a controller mode is changed.
 	 */
 	public onModeChanged(): void {
-		this.controllerUI.updateInfoBox(this.getMode(), this.currentSong);
+		void this.updateUI();
 		sendContentMessage({
 			type: 'controllerModeChange',
 			payload: {
@@ -361,7 +375,7 @@ export default class Controller {
 			}
 		}
 
-		this.controllerUI.updateInfoBox(this.getMode(), this.currentSong);
+		void this.updateUI();
 	}
 
 	/** Public functions */


### PR DESCRIPTION
## Describe the changes you made
Moves info-box rendering logic out of the Controller class and into a new ControllerUI class to reduce code complexity and improve separation of concerns.

## Additional context
This refactoring reduces the responsibility of the Controller class, improving its cohesion and alignment with the Single Responsibility Principle.