### PR TITLE
chore: add AGENTS.md for improved agent workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,17 +19,19 @@ Use `npm run dist chrome|firefox` to build the extension for distribution.
 
 When creating pull requests:
 - **Template**: Always use the template provided in `.github/PULL_REQUEST_TEMPLATE.md`.
-- **Labels**: Choose relevant labels based on the categories defined in `.github/release-drafter.yml`:
-    - `new-feature`: Additions of new functionalities.
-    - `core-fix`: Bug fixes for core extension functionality.
-    - `new-connector`: Addition of support for a new music service connector.
-    - `fixed-connector`: Fixes for issues with existing music service connectors.
-    - `updated`: Dependency updates or other component updates.
-    - `maintenance`: General maintenance, refactoring, or infrastructure improvements.
+- **Labels**: You MUST select exactly one label from each of the two sets defined in `.github/release-drafter.yml`:
 
-    Additionally, every PR **must** include exactly one of the following versioning labels to determine the next release version:
-    - `major-change`: Use for major overhauls or breaking changes.
-    - `minor-change`: Use for new features or new connectors.
-    - `patch-change`: Use for bug fixes or maintenance changes.
+    **Category labels** (choose one):
+    - `new-feature`
+    - `core-fix`
+    - `new-connector`
+    - `fixed-connector`
+    - `updated`
+    - `maintenance`
+
+    **Versioning labels** (choose one):
+    - `major-change`
+    - `minor-change`
+    - `patch-change`
 
 Ensure your commit messages and PR titles follow Conventional Commits (as per `CLAUDE.md`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,5 +33,8 @@ When creating pull requests:
     - `major-change`
     - `minor-change`
     - `patch-change`
+    - `skip-changelog` (for changes that should not appear in the changelog, e.g., chores)
+
+    *Note: If `skip-changelog` is used, a versioning label is not required.*
 
 Ensure your commit messages and PR titles follow Conventional Commits (as per `CLAUDE.md`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Agent Instructions
+
+This document provides guidance for agents working on this project.
+
+## Development Tasks
+
+### Running Tests
+Use `npm run test` to run the test suite using `vitest`.
+
+### Compiling the Extension
+Use `npm run dist chrome|firefox` to build the extension for distribution.
+
+### Linting and Fixing
+- To run all linters: `npm run lint`
+- To fix Prettier issues: `npm run prettierfix`
+- To fix Stylelint issues: `npm run fixstyle`
+
+## Pull Requests
+
+When creating pull requests:
+- **Template**: Always use the template provided in `.github/PULL_REQUEST_TEMPLATE.md`.
+- **Labels**: Choose relevant labels based on the categories defined in `.github/release-drafter.yml`:
+    - `new-feature`: Additions of new functionalities.
+    - `core-fix`: Bug fixes for core extension functionality.
+    - `new-connector`: Addition of support for a new music service connector.
+    - `fixed-connector`: Fixes for issues with existing music service connectors.
+    - `updated`: Dependency updates or other component updates.
+    - `maintenance`: General maintenance, refactoring, or infrastructure improvements.
+
+    Additionally, every PR **must** include exactly one of the following versioning labels to determine the next release version:
+    - `major-change`: Use for major overhauls or breaking changes.
+    - `minor-change`: Use for new features or new connectors.
+    - `patch-change`: Use for bug fixes or maintenance changes.
+
+Ensure your commit messages and PR titles follow Conventional Commits (as per `CLAUDE.md`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,12 +29,14 @@ When creating pull requests:
     - `updated`
     - `maintenance`
 
-    **Versioning labels** (choose one):
+    **Versioning labels**:
     - `major-change`
     - `minor-change`
     - `patch-change`
+
+    **Additional labels**:
     - `skip-changelog` (for changes that should not appear in the changelog, e.g., chores)
 
-    *Note: If `skip-changelog` is used, a versioning label is not required.*
+    *Note: Select exactly one versioning label. You may additionally select `skip-changelog` if appropriate.*
 
 Ensure your commit messages and PR titles follow Conventional Commits (as per `CLAUDE.md`).


### PR DESCRIPTION
## Describe the changes you made
Added AGENTS.md to the root directory to provide standardized instructions for agent-driven tasks. This includes procedures for running tests, building the extension, linting, and PR conventions. 

Label requirements are updated to explicitly require exactly one category label and one versioning label from .github/release-drafter.yml.

## Additional context
This addition aims to streamline agent onboardings and ensure consistent task execution across the project.